### PR TITLE
feat: UI polish v1.1.0.6 — title dividers, section accent bars, progress bar

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="92">
     <author>TisonK</author>
-    <version>1.1.0.5</version>
+    <version>1.1.0.6</version>
     <modName>FS25_FarmTablet</modName>
     <title>
         <en>Farm Tablet</en>

--- a/src/FarmTabletUI.lua
+++ b/src/FarmTabletUI.lua
@@ -258,7 +258,7 @@ function FarmTabletUI:createTabletElements()
 
     -- Title text
     table.insert(self.ui.texts, {
-        text = "Farm Tablet v1.1.0.1",
+        text = "Farm Tablet v1.1.0.6",
         x = navBarX + navPadX,
         y = navBarY + navHeight / 2 - 0.004,
         size = 0.014,
@@ -309,7 +309,13 @@ function FarmTabletUI:createAppContentArea()
     )
     bg:setVisible(true)
 
+    -- Thin accent line along the top edge of the content area
+    local lineH = math.max(self:py(2), 0.002)
+    local topLine = self:createBlankOverlay(x, y + h - lineH, w, lineH, {0.30, 0.58, 0.32, 0.55})
+    topLine:setVisible(true)
+
     table.insert(self.ui.overlays, bg)
+    table.insert(self.ui.overlays, topLine)
     table.insert(self.ui.contentOverlays, bg)
 
     self.ui.appContentArea = {
@@ -334,8 +340,8 @@ function FarmTabletUI:loadDefaultApp()
     
     local padX = self:px(15)
     local padY = self:py(15)
-    local titleY = content.y + content.height - padY - 0.03
-    
+    local titleY = content.y + content.height - padY - self:titleH()
+
     -- Title
     table.insert(self.ui.appTexts, {
         text = "Farm Tablet",
@@ -345,7 +351,8 @@ function FarmTabletUI:loadDefaultApp()
         align = RenderText.ALIGN_LEFT,
         color = {0.4, 0.8, 0.4, 1}
     })
-    
+    self:drawDivider(titleY - self:py(4))
+
     local startY = titleY - 0.035
     local lineHeight = 0.022
     
@@ -548,10 +555,18 @@ function FarmTabletUI:drawRow(label, value, y, labelColor, valueColor)
     end
 end
 
--- Insert a section header (left-aligned, accent color).
+-- Insert a section header (left-aligned, accent color) with a left accent bar.
 function FarmTabletUI:drawSectionHeader(text, y)
     local content = self.ui.appContentArea
     if not content then return end
+    -- Small vertical accent bar, vertically centered on the text line
+    self:createAppOverlay(
+        content.x + self:px(8),
+        y - self:py(2),
+        self:px(3),
+        self:py(13),
+        {0.38, 0.88, 0.44, 0.90}
+    )
     table.insert(self.ui.appTexts, {
         text  = text,
         x     = content.x + self:px(15),
@@ -560,6 +575,38 @@ function FarmTabletUI:drawSectionHeader(text, y)
         align = RenderText.ALIGN_LEFT,
         color = self.UI_CONSTANTS.SECTION_COLOR,
     })
+end
+
+-- Draw a thin horizontal rule across the full width of the content area.
+function FarmTabletUI:drawDivider(y, alpha)
+    local content = self.ui.appContentArea
+    if not content then return end
+    self:createAppOverlay(
+        content.x + self:px(8),
+        y,
+        content.width - self:px(16),
+        math.max(self:py(1), 0.0008),
+        {0.30, 0.60, 0.32, alpha or 0.35}
+    )
+end
+
+-- Draw a proportional fill bar. Returns the Y coordinate just below the bar.
+function FarmTabletUI:drawProgressBar(value, max, y, barColor)
+    local content = self.ui.appContentArea
+    if not content then return y end
+    local padX = self:px(15)
+    local barW  = content.width - padX * 2
+    local barH  = math.max(self:py(5), 0.006)
+    local bgX   = content.x + padX
+    -- Background track
+    self:createAppOverlay(bgX, y, barW, barH, {0.16, 0.16, 0.20, 0.95})
+    -- Fill
+    local ratio = (max and max > 0) and math.min(value / max, 1) or 0
+    if ratio > 0 then
+        self:createAppOverlay(bgX, y, barW * ratio, barH,
+            barColor or self.UI_CONSTANTS.VALUE_COLOR)
+    end
+    return y - barH - self:py(3)
 end
 
 -- Insert a single left-aligned text entry.
@@ -600,6 +647,15 @@ end
 function FarmTabletUI:py(y)
     return y * (self.ui.scaleY or 1)
 end
+
+-- Layout helpers — scale-aware equivalents of common hardcoded offsets.
+-- Calibrated so that at the 1080p reference resolution these equal the
+-- existing hardcoded values, keeping layouts pixel-identical there while
+-- scaling correctly at other resolutions.
+function FarmTabletUI:titleH()     return self:py(19)  end  -- app title baseline offset  (~0.028)
+function FarmTabletUI:lineH()      return self:py(15)  end  -- standard row height        (~0.022)
+function FarmTabletUI:smallLineH() return self:py(13)  end  -- compact row height         (~0.019)
+function FarmTabletUI:sectionGap() return self:py(22)  end  -- inter-section spacing      (~0.032)
 
 function FarmTabletUI:createBlankOverlay(x, y, width, height, color, texturePath)
     local overlay

--- a/src/apps/AppStoreApp.lua
+++ b/src/apps/AppStoreApp.lua
@@ -11,13 +11,14 @@ function FarmTabletUI:loadAppStoreApp()
     local padX = self:px(15)
     local padY = self:py(12)
 
-    local titleY = content.y + content.height - padY - 0.028
+    local titleY = content.y + content.height - padY - self:titleH()
     self:drawText("App Store", content.x + padX, titleY, 0.019, RenderText.ALIGN_LEFT, C.TITLE_COLOR)
 
     local apps = self.tabletSystem.registeredApps
     self:drawText(tostring(#apps) .. " apps installed",
         content.x + content.width - padX, titleY, 0.013, RenderText.ALIGN_RIGHT, C.MUTED_COLOR)
 
+    self:drawDivider(titleY - self:py(4))
     local y = titleY - 0.030
     self:drawSectionHeader("INSTALLED APPS", y)
     y = y - 0.022

--- a/src/apps/BucketTrackerApp.lua
+++ b/src/apps/BucketTrackerApp.lua
@@ -13,9 +13,10 @@ function FarmTabletUI:loadBucketTrackerApp()
     local sys     = self.tabletSystem
     local tracker = sys.bucketTracker
 
-    local titleY = content.y + content.height - padY - 0.028
+    local titleY = content.y + content.height - padY - self:titleH()
     self:drawText("Bucket Load Tracker", content.x + padX, titleY, 0.019,
         RenderText.ALIGN_LEFT, C.TITLE_COLOR)
+    self:drawDivider(titleY - self:py(4))
 
     local y = titleY - 0.030
 
@@ -43,6 +44,7 @@ function FarmTabletUI:loadBucketTrackerApp()
             y = y - 0.022
             self:drawRow("Fill %", string.format("%.0f%%", pct), y, C.LABEL_COLOR, pctColor)
             y = y - 0.022
+            y = self:drawProgressBar(pct, 100, y, pctColor)
             local wt = sys:estimateBucketWeight(fi)
             self:drawRow("Est. Weight", string.format("%d kg", wt), y, C.LABEL_COLOR, C.VALUE_COLOR)
             y = y - 0.022

--- a/src/apps/DashboardApp.lua
+++ b/src/apps/DashboardApp.lua
@@ -18,7 +18,7 @@ function FarmTabletUI:loadDashboardApp()
     local farmId = sys:getPlayerFarmId()
 
     -- Title
-    local titleY = content.y + content.height - padY - 0.028
+    local titleY = content.y + content.height - padY - self:titleH()
     self:drawText("Farm Dashboard", content.x + padX, titleY, 0.019, RenderText.ALIGN_LEFT, C.TITLE_COLOR)
 
     -- Farm name (if available)
@@ -29,7 +29,7 @@ function FarmTabletUI:loadDashboardApp()
             RenderText.ALIGN_RIGHT, C.MUTED_COLOR)
     end
 
-    -- Divider
+    self:drawDivider(titleY - self:py(4))
     local y = titleY - 0.028
 
     -- === Finance ===

--- a/src/apps/DiggingApp.lua
+++ b/src/apps/DiggingApp.lua
@@ -11,8 +11,9 @@ function FarmTabletUI:loadDiggingApp()
     local padX = self:px(15)
     local padY = self:py(12)
 
-    local titleY = content.y + content.height - padY - 0.028
+    local titleY = content.y + content.height - padY - self:titleH()
     self:drawText("Digging & Terrain", content.x + padX, titleY, 0.019, RenderText.ALIGN_LEFT, C.TITLE_COLOR)
+    self:drawDivider(titleY - self:py(4))
 
     local info = self:getDiggingInfo()
     local y = titleY - 0.030

--- a/src/apps/IncomeApp.lua
+++ b/src/apps/IncomeApp.lua
@@ -11,8 +11,9 @@ function FarmTabletUI:loadIncomeApp()
     local padX = self:px(15)
     local padY = self:py(12)
 
-    local titleY = content.y + content.height - padY - 0.028
+    local titleY = content.y + content.height - padY - self:titleH()
     self:drawText("Income Mod", content.x + padX, titleY, 0.019, RenderText.ALIGN_LEFT, C.TITLE_COLOR)
+    self:drawDivider(titleY - self:py(4))
 
     local inst = g_IncomeManager or _G["Income"]
 

--- a/src/apps/NPCFavorApp.lua
+++ b/src/apps/NPCFavorApp.lua
@@ -11,8 +11,9 @@ function FarmTabletUI:loadNPCFavorApp()
     local padX = self:px(15)
     local padY = self:py(12)
 
-    local titleY = content.y + content.height - padY - 0.028
+    local titleY = content.y + content.height - padY - self:titleH()
     self:drawText("NPC Favor", content.x + padX, titleY, 0.019, RenderText.ALIGN_LEFT, C.TITLE_COLOR)
+    self:drawDivider(titleY - self:py(4))
 
     -- Access via g_currentMission (cross-mod safe)
     local npc = g_currentMission and g_currentMission.npcFavorSystem

--- a/src/apps/SeasonalCropStressApp.lua
+++ b/src/apps/SeasonalCropStressApp.lua
@@ -11,8 +11,9 @@ function FarmTabletUI:loadCropStressApp()
     local padX = self:px(15)
     local padY = self:py(12)
 
-    local titleY = content.y + content.height - padY - 0.028
+    local titleY = content.y + content.height - padY - self:titleH()
     self:drawText("Crop Stress", content.x + padX, titleY, 0.019, RenderText.ALIGN_LEFT, C.TITLE_COLOR)
+    self:drawDivider(titleY - self:py(4))
 
     local csm = g_currentMission and g_currentMission.cropStressManager
 

--- a/src/apps/SettingsApp.lua
+++ b/src/apps/SettingsApp.lua
@@ -13,13 +13,14 @@ function FarmTabletUI:loadSettingsApp()
     local padY = self:py(12)
     local s    = self.settings
 
-    local titleY = content.y + content.height - padY - 0.028
+    local titleY = content.y + content.height - padY - self:titleH()
     self:drawText("Settings", content.x + padX, titleY, 0.019, RenderText.ALIGN_LEFT, C.TITLE_COLOR)
 
-    local version = "v1.1.0.1"
+    local version = "v1.1.0.6"
     self:drawText(version, content.x + content.width - padX, titleY, 0.012,
         RenderText.ALIGN_RIGHT, C.MUTED_COLOR)
 
+    self:drawDivider(titleY - self:py(4))
     local y = titleY - 0.032
     self:drawSectionHeader("TABLET", y)
     y = y - 0.024

--- a/src/apps/SoilFertilizerApp.lua
+++ b/src/apps/SoilFertilizerApp.lua
@@ -11,8 +11,9 @@ function FarmTabletUI:loadSoilFertilizerApp()
     local padX = self:px(15)
     local padY = self:py(12)
 
-    local titleY = content.y + content.height - padY - 0.028
+    local titleY = content.y + content.height - padY - self:titleH()
     self:drawText("Soil Fertilizer", content.x + padX, titleY, 0.019, RenderText.ALIGN_LEFT, C.TITLE_COLOR)
+    self:drawDivider(titleY - self:py(4))
 
     local sfm = g_soilFertilizerManager
               or (g_currentMission and g_currentMission.soilFertilizerManager)

--- a/src/apps/TaxApp.lua
+++ b/src/apps/TaxApp.lua
@@ -15,8 +15,9 @@ function FarmTabletUI:loadTaxApp()
     local padX = self:px(15)
     local padY = self:py(12)
 
-    local titleY = content.y + content.height - padY - 0.028
+    local titleY = content.y + content.height - padY - self:titleH()
     self:drawText("Tax Mod", content.x + padX, titleY, 0.019, RenderText.ALIGN_LEFT, C.TITLE_COLOR)
+    self:drawDivider(titleY - self:py(4))
 
     local inst = g_TaxManager
 

--- a/src/apps/UpdatesApp.lua
+++ b/src/apps/UpdatesApp.lua
@@ -3,7 +3,15 @@
 -- =========================================================
 
 local CHANGELOG = {
-    { version = "1.1.0.1", notes = {
+    { version = "1.1.0.6", notes = {
+        "Scale-aware layout helpers: titleH, lineH, smallLineH, sectionGap",
+        "Section headers now render with a left accent bar for visual hierarchy",
+        "New drawDivider — title underline rendered across all apps",
+        "New drawProgressBar — fill level bar in Bucket Tracker app",
+        "Content area top accent line for card-style visual framing",
+        "Fixed hardcoded version strings in Settings and Updates apps",
+    }},
+    { version = "1.1.0.5", notes = {
         "NPC Favor, Seasonal Crop Stress, Soil Fertilizer integrations",
         "Interactive in-tablet Settings app with toggle buttons",
         "Drawing helper system: drawRow, drawButton, drawSectionHeader",
@@ -28,9 +36,10 @@ function FarmTabletUI:loadUpdatesApp()
     local padX = self:px(15)
     local padY = self:py(12)
 
-    local titleY = content.y + content.height - padY - 0.028
+    local titleY = content.y + content.height - padY - self:titleH()
     self:drawText("Updates & Changelog", content.x + padX, titleY, 0.019,
         RenderText.ALIGN_LEFT, C.TITLE_COLOR)
+    self:drawDivider(titleY - self:py(4))
 
     local y = titleY - 0.032
 

--- a/src/apps/WeatherApp.lua
+++ b/src/apps/WeatherApp.lua
@@ -11,8 +11,9 @@ function FarmTabletUI:loadWeatherApp()
     local padX = self:px(15)
     local padY = self:py(12)
 
-    local titleY = content.y + content.height - padY - 0.028
+    local titleY = content.y + content.height - padY - self:titleH()
     self:drawText("Weather", content.x + padX, titleY, 0.019, RenderText.ALIGN_LEFT, C.TITLE_COLOR)
+    self:drawDivider(titleY - self:py(4))
 
     local w = self:getWeatherInfo()
     if not w then


### PR DESCRIPTION
## Summary

- **Layout helpers** — `titleH()`, `lineH()`, `smallLineH()`, `sectionGap()` added to `FarmTabletUI`; scale-aware wrappers around `py()` so spacing adapts correctly at all resolutions while remaining pixel-identical at 1080p
- **Title dividers** — `drawDivider()` draws a thin green rule just below each app's title header; applied to all 11 apps
- **Section accent bars** — `drawSectionHeader()` now renders a small 3px green vertical bar to the left of every section label, giving clear visual hierarchy
- **Progress bar** — new `drawProgressBar()` helper; first used in BucketTrackerApp to render a fill level bar under the Fill % row
- **Content area framing** — subtle top accent line added to the content area background for a card-style look
- **Version string fixes** — hardcoded `v1.1.0.1` corrected to `v1.1.0.6` in SettingsApp; CHANGELOG entry `1.1.0.1` renamed to `1.1.0.5` (correct), `1.1.0.6` entry added to UpdatesApp

## Test plan

- [ ] Open tablet in-game — content area top accent line visible
- [ ] All apps: title underline divider appears just below the app title text
- [ ] All apps: section headers show small green left accent bar
- [ ] BucketTrackerApp: fill % progress bar renders correctly with color (green/orange/red)
- [ ] Switch between apps — no overlay leak, dividers and bars all clean up on switch
- [ ] Dashboard with long content (13+ rows) — no overflow past content area bottom
- [ ] SettingsApp shows `v1.1.0.6`, UpdatesApp changelog shows `1.1.0.6` entry at top
- [ ] Close and reopen tablet — no visual glitches