### PR TITLE
fix: hotfix — Animals crash, Workshop detection, bullet glyph, two-row nav (v1.1.0.9)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="92">
     <author>TisonK</author>
-    <version>1.1.0.8</version>
+    <version>1.1.0.9</version>
     <modName>FS25_FarmTablet</modName>
     <title>
         <en>Farm Tablet</en>

--- a/src/FarmTabletUI.lua
+++ b/src/FarmTabletUI.lua
@@ -288,7 +288,7 @@ function FarmTabletUI:createAppContentArea()
     local headerHeight = self:py(40)
     local y = self.ui.backgroundY + pad + headerHeight
     
-    local appButtonsHeight = self:py(40)
+    local appButtonsHeight = self:py(66)  -- two rows of nav buttons
     local navBarHeight = self:py(35)
     local bottomPadding = self:py(20)
     
@@ -428,20 +428,30 @@ function FarmTabletUI:createAppNavigationButtons()
     local btnW    = self:px(44)
     local btnH    = self:py(22)
     local spacing = self:px(4)
-    local startY  = navBar.y - btnH - self:py(8)
+    local rowGap  = self:py(4)
     local startX  = navBar.x + self:px(15)
     local maxX    = navBar.x + navBar.width - self:px(70)
+    local row1Y   = navBar.y - btnH - self:py(8)
+    local row2Y   = row1Y - btnH - rowGap
+
+    -- Calculate max buttons per row
+    local maxPerRow = math.max(1, math.floor((maxX - startX) / (btnW + spacing)))
 
     local isActive = self.tabletSystem.currentApp
+    local btnIdx   = 0
 
     for _, app in ipairs(self.tabletSystem.registeredApps) do
         if app.enabled then
-            local x = startX + (#self.ui.appButtons) * (btnW + spacing)
-            if x + btnW > maxX then break end
+            local col  = btnIdx % maxPerRow
+            local row  = math.floor(btnIdx / maxPerRow)
+            if row >= 2 then break end  -- max two rows
+
+            local x = startX + col * (btnW + spacing)
+            local y = (row == 0) and row1Y or row2Y
 
             local isSelected = (app.id == isActive)
             local overlay = self:createBlankOverlay(
-                x, startY, btnW, btnH,
+                x, y, btnW, btnH,
                 isSelected and self.UI_CONSTANTS.BUTTON_HOVER_COLOR
                            or  self.UI_CONSTANTS.BUTTON_NORMAL_COLOR
             )
@@ -450,7 +460,7 @@ function FarmTabletUI:createAppNavigationButtons()
 
             table.insert(self.ui.appButtons, {
                 overlay = overlay,
-                x = x, y = startY, width = btnW, height = btnH,
+                x = x, y = y, width = btnW, height = btnH,
                 appId = app.id
             })
 
@@ -458,12 +468,14 @@ function FarmTabletUI:createAppNavigationButtons()
             table.insert(self.ui.texts, {
                 text  = label,
                 x     = x + btnW / 2,
-                y     = startY + btnH / 2 - 0.004,
+                y     = y + btnH / 2 - 0.004,
                 size  = 0.009,
                 align = RenderText.ALIGN_CENTER,
                 color = isSelected and self.UI_CONSTANTS.TITLE_COLOR
                                    or  self.UI_CONSTANTS.MUTED_COLOR
             })
+
+            btnIdx = btnIdx + 1
         end
     end
 end

--- a/src/apps/AnimalHusbandryApp.lua
+++ b/src/apps/AnimalHusbandryApp.lua
@@ -118,18 +118,16 @@ function FarmTabletUI:getAnimalPens(farmId)
                 ownerId = placeable.farmId
             end
         end)
-        if ownerId ~= farmId then goto continue end
 
-        -- Must have animal spec
-        local aSpec = placeable.spec_husbandryAnimals
-        if not aSpec then goto continue end
-
-        local pen = self:extractPenData(placeable, aSpec)
-        if pen then
-            table.insert(result, pen)
+        if ownerId == farmId then
+            local aSpec = placeable.spec_husbandryAnimals
+            if aSpec then
+                local pen = self:extractPenData(placeable, aSpec)
+                if pen then
+                    table.insert(result, pen)
+                end
+            end
         end
-
-        ::continue::
     end
 
     table.sort(result, function(a, b) return a.typeName < b.typeName end)

--- a/src/apps/UpdatesApp.lua
+++ b/src/apps/UpdatesApp.lua
@@ -3,6 +3,12 @@
 -- =========================================================
 
 local CHANGELOG = {
+    { version = "1.1.0.9", notes = {
+        "Fixed Animals app crash (Lua 5.1 goto not supported in FS25)",
+        "Fixed Workshop app not detecting vehicles (wrong player position reference)",
+        "Fixed bullet character warning in Updates app (unsupported font glyph)",
+        "Nav bar now uses two rows, supporting up to 16 apps",
+    }},
     { version = "1.1.0.8", notes = {
         "Added in-game help section in the pause menu (F1 / Help tab)",
         "Help covers all built-in apps, open key, App Store and console commands",
@@ -62,7 +68,7 @@ function FarmTabletUI:loadUpdatesApp()
 
         for _, note in ipairs(entry.notes) do
             if y <= content.y + padY then break end
-            self:drawText("• " .. note, content.x + padX + self:px(8), y, 0.013,
+            self:drawText("-" .. note, content.x + padX + self:px(8), y, 0.013,
                 RenderText.ALIGN_LEFT, C.MUTED_COLOR)
             y = y - 0.019
         end

--- a/src/apps/WorkshopApp.lua
+++ b/src/apps/WorkshopApp.lua
@@ -165,10 +165,23 @@ function FarmTabletUI:getWorkshopNearbyVehicles(radius)
 
     local farmId = self.tabletSystem:getPlayerFarmId()
     local px, pz = 0, 0
-    local player = g_currentMission.player
-    if player and player.rootNode then
-        local x, y, z = getWorldTranslation(player.rootNode)
-        px, pz = x, z
+    -- g_localPlayer is the correct FS25 reference for the local player character
+    pcall(function()
+        local player = g_localPlayer
+        if player and player.rootNode then
+            local x, _, z = getWorldTranslation(player.rootNode)
+            px, pz = x, z
+        end
+    end)
+    -- Fallback to g_currentMission.player if g_localPlayer unavailable
+    if px == 0 and pz == 0 then
+        pcall(function()
+            local player = g_currentMission and g_currentMission.player
+            if player and player.rootNode then
+                local x, _, z = getWorldTranslation(player.rootNode)
+                px, pz = x, z
+            end
+        end)
     end
 
     for _, v in pairs(g_currentMission.vehicles) do


### PR DESCRIPTION
## Fixes

- **Animals app crash** — used `goto`/`::continue::` (Lua 5.1 labels, unsupported in FS25). File failed to load entirely, causing `loadAnimalHusbandryApp` missing method error on every mouse click. Replaced with nested `if` guards.
- **Workshop not finding vehicles** — `g_currentMission.player` was nil at runtime. FS25 uses `g_localPlayer` for the local player character. Now tries `g_localPlayer` first with `g_currentMission.player` as fallback, both pcall-guarded.
- **Bullet character warning** — `•` (U+2022) is not in FS25's texture font. Replaced all instances in UpdatesApp with `-`.
- **Nav bar overflow** — with 12 apps, single-row nav silently dropped apps past the 8th. Redesigned to two rows (8 per row = 16 capacity). Content area height adjusted to match.

## Test plan

- [ ] Animals app loads without LUA error in log
- [ ] Workshop shows nearby vehicles when player is within 20 m of a tractor
- [ ] Updates app shows no character warning in log
- [ ] All 12 registered apps visible across two nav rows