### PR TITLE
fix: correct FS25 API for all 3 new apps + taller tablet (v1.1.1.0)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="92">
     <author>TisonK</author>
-    <version>1.1.0.9</version>
+    <version>1.1.1.0</version>
     <modName>FS25_FarmTablet</modName>
     <title>
         <en>Farm Tablet</en>

--- a/src/FarmTabletUI.lua
+++ b/src/FarmTabletUI.lua
@@ -153,7 +153,7 @@ function FarmTabletUI:createTabletUI()
     self.ui.contentOverlays = {}
 
     -- Calculate screen position
-    local tabletWidth, tabletHeight = getNormalizedScreenValues(800, 600)
+    local tabletWidth, tabletHeight = getNormalizedScreenValues(800, 680)
     
     self.ui.backgroundX = 0.5 - tabletWidth / 2
     self.ui.backgroundY = 0.5 - tabletHeight / 2

--- a/src/apps/AnimalHusbandryApp.lua
+++ b/src/apps/AnimalHusbandryApp.lua
@@ -100,24 +100,33 @@ end
 -- Returns table of pen data for all animal placeables owned by farmId.
 function FarmTabletUI:getAnimalPens(farmId)
     local result = {}
-    local ps = g_currentMission and g_currentMission.placeableSystem
-    if not ps then return result end
+    if not g_currentMission then return result end
 
-    local ok, placeables = pcall(function() return ps:getPlaceables() end)
-    if not ok or not placeables then return result end
+    -- FS25: placeables live in g_currentMission.placeableSystem
+    -- Try getPlaceables() first, fallback to direct .placeables table
+    local placeables = nil
+    pcall(function()
+        local ps = g_currentMission.placeableSystem
+        if ps then
+            if ps.getPlaceables then
+                placeables = ps:getPlaceables()
+            elseif ps.placeables then
+                placeables = ps.placeables
+            end
+        end
+    end)
+    if not placeables then return result end
 
     for _, placeable in pairs(placeables) do
-        -- Ownership check
-        local ownerId = nil
-        pcall(function()
-            if placeable.getOwnerFarmId then
-                ownerId = placeable:getOwnerFarmId()
-            elseif placeable.ownerFarmId then
-                ownerId = placeable.ownerFarmId
-            elseif placeable.farmId then
-                ownerId = placeable.farmId
-            end
-        end)
+        -- Ownership: FS25 uses .ownerFarmId as a direct property
+        local ownerId = placeable.ownerFarmId or placeable.farmId
+        if ownerId == nil then
+            pcall(function()
+                if placeable.getOwnerFarmId then
+                    ownerId = placeable:getOwnerFarmId()
+                end
+            end)
+        end
 
         if ownerId == farmId then
             local aSpec = placeable.spec_husbandryAnimals

--- a/src/apps/FieldStatusApp.lua
+++ b/src/apps/FieldStatusApp.lua
@@ -106,8 +106,34 @@ function FarmTabletUI:getOwnedFields(farmId)
     local ok, allFields = pcall(function() return fieldManager:getFields() end)
     if not ok or not allFields then return fields end
 
+    -- Build a set of owned farmland IDs from g_farmlandManager
+    local ownedFarmlandIds = {}
+    pcall(function()
+        local fm = g_farmlandManager
+        if fm and fm.farmlands then
+            for _, farmland in pairs(fm.farmlands) do
+                if farmland.ownerId == farmId then
+                    ownedFarmlandIds[farmland.id] = true
+                end
+            end
+        end
+    end)
+
     for _, field in pairs(allFields) do
-        if field.farmland and field.farmland.ownerId == farmId then
+        local owned = false
+        -- Method 1: field has farmlandId property -> look up in owned set
+        if field.farmlandId and ownedFarmlandIds[field.farmlandId] then
+            owned = true
+        end
+        -- Method 2: field.farmland.ownerId (older API)
+        if not owned and field.farmland and field.farmland.ownerId == farmId then
+            owned = true
+        end
+        -- Method 3: field directly stores ownerFarmId
+        if not owned and field.ownerFarmId == farmId then
+            owned = true
+        end
+        if owned then
             table.insert(fields, field)
         end
     end

--- a/src/apps/UpdatesApp.lua
+++ b/src/apps/UpdatesApp.lua
@@ -3,6 +3,12 @@
 -- =========================================================
 
 local CHANGELOG = {
+    { version = "1.1.1.0", notes = {
+        "Fixed Workshop vehicle detection: now uses correct FS25 vehicle API",
+        "Fixed Field Manager: now uses g_farmlandManager for ownership checks",
+        "Fixed Animals: fixed placeable ownership and placeables access for FS25",
+        "Tablet height increased from 600 to 680px — less text overflow",
+    }},
     { version = "1.1.0.9", notes = {
         "Fixed Animals app crash (Lua 5.1 goto not supported in FS25)",
         "Fixed Workshop app not detecting vehicles (wrong player position reference)",

--- a/src/apps/WorkshopApp.lua
+++ b/src/apps/WorkshopApp.lua
@@ -185,15 +185,32 @@ function FarmTabletUI:getWorkshopNearbyVehicles(radius)
     end
 
     for _, v in pairs(g_currentMission.vehicles) do
-        if v.spec_motorized and v.rootNode then
-            local vx, vy, vz = getWorldTranslation(v.rootNode)
-            local dist = MathUtil.vector2Length(vx - px, vz - pz)
-            if dist <= radius then
-                local ownerId = (v.getOwnerFarmId and v:getOwnerFarmId()) or v.farmId
-                if ownerId == nil or ownerId == farmId then
-                    local name = (v.getFullName and v:getFullName())
-                              or v.configFileName or "Vehicle"
-                    table.insert(result, { vehicle = v, name = name, distance = dist })
+        -- Use v:isa(Vehicle) like DiggingApp — filters out non-vehicle entries safely
+        local isVehicle = false
+        pcall(function() isVehicle = v:isa(Vehicle) end)
+        if isVehicle and v.spec_motorized and v.rootNode then
+            local ok, vx, vz = false, 0, 0
+            pcall(function()
+                local x, _, z = getWorldTranslation(v.rootNode)
+                vx, vz = x, z
+                ok = true
+            end)
+            if ok then
+                local dist = MathUtil.vector2Length(vx - px, vz - pz)
+                if dist <= radius then
+                    -- Include own farm vehicles and any unowned vehicle
+                    local ownerId = nil
+                    pcall(function()
+                        ownerId = (v.getOwnerFarmId and v:getOwnerFarmId()) or v.ownerFarmId or v.farmId
+                    end)
+                    if ownerId == nil or ownerId == 0 or ownerId == farmId then
+                        local name = ""
+                        pcall(function()
+                            name = (v.getFullName and v:getFullName()) or v.configFileName or "Vehicle"
+                        end)
+                        if name == "" then name = "Vehicle" end
+                        table.insert(result, { vehicle = v, name = name, distance = dist })
+                    end
                 end
             end
         end


### PR DESCRIPTION
## What was wrong

All three new apps had incorrect FS25 API assumptions based on FS22 patterns or guesses that don't match how FS25 actually exposes game data.

## Fixes

**Workshop** (`WorkshopApp.lua`)
- Added `v:isa(Vehicle)` guard (same pattern DiggingApp uses — filters non-vehicle entries from the vehicles table)
- Wrapped `getWorldTranslation` in pcall with proper multi-return capture
- Relaxed ownership filter: also accepts `ownerFarmId == 0` (unowned/AI vehicles)
- All vehicle property access now pcall-guarded

**Field Manager** (`FieldStatusApp.lua`)
- `field.farmland.ownerId` does not exist in FS25 — ownership lives in `g_farmlandManager`
- Now builds an owned farmland ID set from `g_farmlandManager.farmlands` filtered by `ownerId == farmId`
- Fields matched via `field.farmlandId` against that set
- Two fallback paths kept for robustness

**Animals** (`AnimalHusbandryApp.lua`)
- Ownership: FS25 placeables use `.ownerFarmId` as a direct property, not a method
- Placeables access: tries `ps:getPlaceables()` then `ps.placeables` table directly as fallback

**Tablet height** (`FarmTabletUI.lua`)
- Increased from 600 → 680px — gives ~13% more vertical content space, reduces text overflow on dense apps

## Test plan
- [ ] Workshop lists nearby tractor within 20 m
- [ ] Field Manager shows owned fields (non-empty list)
- [ ] Animals shows pens if any exist on the save
- [ ] No text overflow below the tablet frame on any app
- [ ] No LUA errors in log.txt