### PR TITLE
i18n: add Simplified Chinese translations

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -14,6 +14,7 @@
         <br>Tablet Agrícola</br>
         <uk>Фермерський планшет</uk>
         <ru>Фермерский планшет</ru>
+        <cn>农场平板</cn>
     </title>
     <description>
         <en>Central tablet interface for farm management with modular apps system.</en>
@@ -26,6 +27,7 @@
         <br>Interface central de tablet para gestão agrícola com sistema modular de aplicativos.</br>
         <uk>Центральний планшетний інтерфейс для управління фермою з модульною системою додатків.</uk>
         <ru>Центральный планшетный интерфейс для управления фермой с модульной системой приложений.</ru>
+        <cn>具有模块化应用系统的农场管理中央平板界面。</cn>
     </description>
     <iconFilename>icon.dds</iconFilename>
     
@@ -47,6 +49,7 @@
             <br>Pressione T para abrir ou fechar o tablet agrícola (tecla configurável nas configurações do menu de pausa).</br>
             <uk>Натисніть T, щоб відкрити або закрити фермерський планшет (клавіша налаштовується в меню паузи).</uk>
             <ru>Нажмите T, чтобы открыть или закрыть фермерский планшет (клавиша настраивается в меню паузы).</ru>
+            <cn>按 T 键打开或关闭农场平板（按键可在暂停菜单设置中配置）。</cn>
         </helpLine>
         <helpLine>
             <en>Dashboard: Monitor your farm balance, income, expenses and daily profit at a glance.</en>
@@ -59,6 +62,7 @@
             <br>Painel: Monitore saldo, receitas, despesas e lucro diário em um único lugar.</br>
             <uk>Панель: Відстежуйте баланс ферми, доходи, витрати та щоденний прибуток.</uk>
             <ru>Панель: Отслеживайте баланс фермы, доходы, расходы и ежедневную прибыль.</ru>
+            <cn>仪表盘：一目了然地监控农场余额、收入、支出和每日利润。</cn>
         </helpLine>
         <helpLine>
             <en>Workshop: Walk near a vehicle and inspect its fuel level, wear condition and operating hours.</en>
@@ -71,6 +75,7 @@
             <br>Oficina: Aproxime-se de um veículo para inspecionar combustível, desgaste e horas de operação.</br>
             <uk>Майстерня: Підійдіть до транспортного засобу та перевірте рівень палива, знос і години роботи.</uk>
             <ru>Мастерская: Подойдите к технике и проверьте уровень топлива, износ и часы работы.</ru>
+            <cn>维修站：靠近车辆检查其燃油量、磨损状况和运行小时数。</cn>
         </helpLine>
         <helpLine>
             <en>Field Manager: See all owned fields with their crop type and current growth stage at a glance.</en>
@@ -83,6 +88,7 @@
             <br>Gerenciador de campos: Veja todos os campos próprios com tipo de cultura e estágio de crescimento.</br>
             <uk>Менеджер полів: Перегляньте всі власні поля з типом культури та поточною стадією росту.</uk>
             <ru>Менеджер полей: Все ваши поля с типом культуры и текущей стадией роста на одном экране.</ru>
+            <cn>农田管理：一目了然地查看所有自有田地的作物类型和当前生长阶段。</cn>
         </helpLine>
         <helpLine>
             <en>Animals: Monitor all animal pens — food, water and cleanliness levels shown with progress bars.</en>
@@ -95,6 +101,7 @@
             <br>Animais: Monitore todos os currais — ração, água e limpeza exibidos com barras de progresso.</br>
             <uk>Тварини: Відстежуйте всі загони — корм, вода та чистота з індикаторами прогресу.</uk>
             <ru>Животные: Мониторинг всех загонов — корм, вода и чистота с индикаторами прогресса.</ru>
+            <cn>动物：监控所有动物围栏——进度条显示饲料、饮水和清洁度。</cn>
         </helpLine>
         <helpLine>
             <en>App Store: Browse available apps. Companion mod apps (Income, Tax, NPC Favor, etc.) appear automatically when those mods are loaded.</en>
@@ -107,6 +114,7 @@
             <br>Loja de aplicativos: Navegue pelas apps disponíveis. Apps de mods complementares aparecem automaticamente quando esses mods estão carregados.</br>
             <uk>Магазин додатків: Переглядайте доступні додатки. Додатки супутніх модів з'являються автоматично при їх завантаженні.</uk>
             <ru>Магазин приложений: Просматривайте доступные приложения. Приложения модов-компаньонов появляются автоматически при загрузке этих модов.</ru>
+            <cn>应用商店：浏览可用应用。伴侣模组的应用（收入、税务、NPC好感等）在加载对应模组时自动出现。</cn>
         </helpLine>
         <helpLine>
             <en>Weather: View today's forecast, temperature, wind and upcoming conditions to plan your work ahead.</en>
@@ -119,6 +127,7 @@
             <br>Tempo: Veja a previsão de hoje, temperatura, vento e condições futuras para planejar seu trabalho.</br>
             <uk>Погода: Переглядайте прогноз погоди, температуру, вітер та умови наступних днів.</uk>
             <ru>Погода: Просматривайте прогноз, температуру, ветер и предстоящие условия для планирования работ.</ru>
+            <cn>天气：查看今日预报、温度、风况和未来天气状况，提前规划农事工作。</cn>
         </helpLine>
         <helpLine>
             <en>Settings for the Farm Tablet can be changed in the pause menu under Settings, or via console commands — type 'tablet' in the developer console for a full list.</en>
@@ -131,6 +140,7 @@
             <br>As configurações do tablet podem ser alteradas no menu de pausa em Configurações ou por comandos do console — digite 'tablet' no console do desenvolvedor.</br>
             <uk>Налаштування планшета можна змінити в меню паузи або через команди консолі — введіть 'tablet' у консолі розробника.</uk>
             <ru>Настройки планшета можно изменить в меню паузы или через команды консоли — введите 'tablet' в консоли разработчика.</ru>
+            <cn>农场平板的设置可在暂停菜单"设置"中修改，或通过控制台命令修改——在开发者控制台输入"tablet"查看完整列表。</cn>
         </helpLine>
     </helpLines>
 
@@ -146,6 +156,7 @@
             <br>Tablet Agrícola</br>
             <uk>Фермерський планшет</uk>
             <ru>Фермерский планшет</ru>
+            <cn>农场平板</cn>
         </text>
 
         <text name="ft_welcome_title">
@@ -159,6 +170,7 @@
             <br>Tablet carregado com sucesso</br>
             <uk>Планшет успішно завантажено</uk>
             <ru>Планшет успешно загружен</ru>
+            <cn>平板加载成功</cn>
         </text>
 
         <text name="ft_welcome_message">
@@ -172,6 +184,7 @@
             <br>Pressione "T" para abrir/fechar</br>
             <uk>Натисніть "T", щоб відкрити/закрити</uk>
             <ru>Нажмите "T", чтобы открыть/закрыть</ru>
+            <cn>按"T"键打开/关闭</cn>
         </text>
         
         <text name="ft_enabled_short">
@@ -185,8 +198,9 @@
             <br>Ativar tablet</br>
             <uk>Увімкнути планшет</uk>
             <ru>Включить планшет</ru>
+            <cn>启用平板</cn>
         </text>
-        
+
         <text name="ft_enabled_long">
             <en>Enable or disable the farm tablet system</en>
             <de>Farm-Tablet-System aktivieren oder deaktivieren</de>
@@ -198,6 +212,7 @@
             <br>Ativar ou desativar o sistema de tablet agrícola</br>
             <uk>Увімкнути або вимкнути систему фермерського планшета</uk>
             <ru>Включить или выключить систему фермерского планшета</ru>
+            <cn>启用或禁用农场平板系统</cn>
         </text>
         
         <text name="ft_keybind_short">
@@ -211,8 +226,9 @@
             <br>Tecla abrir</br>
             <uk>Клавіша відкриття</uk>
             <ru>Клавиша открытия</ru>
+            <cn>打开键</cn>
         </text>
-        
+
         <text name="ft_keybind_long">
             <en>Key to open/close the farm tablet</en>
             <de>Taste zum Öffnen/Schließen des Farm-Tablets</de>
@@ -224,6 +240,7 @@
             <br>Tecla para abrir/fechar o tablet agrícola</br>
             <uk>Клавіша для відкриття/закриття фермерського планшета</uk>
             <ru>Клавиша для открытия/закрытия фермерского планшета</ru>
+            <cn>打开/关闭农场平板的按键</cn>
         </text>
         
         <text name="ft_notifications_short">
@@ -237,8 +254,9 @@
             <br>Notificações</br>
             <uk>Сповіщення</uk>
             <ru>Уведомления</ru>
+            <cn>通知</cn>
         </text>
-        
+
         <text name="ft_notifications_long">
             <en>Show tablet notifications</en>
             <de>Tablet-Benachrichtigungen anzeigen</de>
@@ -250,6 +268,7 @@
             <br>Mostrar notificações do tablet</br>
             <uk>Показувати сповіщення планшета</uk>
             <ru>Показывать уведомления планшета</ru>
+            <cn>显示平板通知</cn>
         </text>
         
         <text name="ft_startupapp_short">
@@ -263,8 +282,9 @@
             <br>Aplicativo inicial</br>
             <uk>Стартова програма</uk>
             <ru>Стартовое приложение</ru>
+            <cn>启动应用</cn>
         </text>
-        
+
         <text name="ft_startupapp_long">
             <en>Default app when opening the tablet</en>
             <de>Standard-App beim Öffnen des Tablets</de>
@@ -276,6 +296,7 @@
             <br>Aplicativo padrão ao abrir o tablet</br>
             <uk>Програма за замовчуванням при відкритті планшета</uk>
             <ru>Приложение по умолчанию при открытии планшета</ru>
+            <cn>打开平板时的默认应用</cn>
         </text>
         
         <text name="ft_startupapp_1">
@@ -289,8 +310,9 @@
             <br>Painel</br>
             <uk>Панель</uk>
             <ru>Панель</ru>
+            <cn>仪表盘</cn>
         </text>
-        
+
         <text name="ft_startupapp_2">
             <en>App Store</en>
             <de>App Store</de>
@@ -302,8 +324,9 @@
             <br>Loja de aplicativos</br>
             <uk>Магазин додатків</uk>
             <ru>Магазин приложений</ru>
+            <cn>应用商店</cn>
         </text>
-        
+
         <text name="ft_startupapp_3">
             <en>Weather</en>
             <de>Wetter</de>
@@ -315,8 +338,9 @@
             <br>Tempo</br>
             <uk>Погода</uk>
             <ru>Погода</ru>
+            <cn>天气</cn>
         </text>
-        
+
         <text name="ft_startupapp_4">
             <en>Digging</en>
             <de>Graben</de>
@@ -328,6 +352,7 @@
             <br>Escavação</br>
             <uk>Копання</uk>
             <ru>Копание</ru>
+            <cn>挖掘</cn>
         </text>
         
         <text name="ft_soundeffects_short">
@@ -341,8 +366,9 @@
             <br>Efeitos sonoros</br>
             <uk>Звукові ефекти</uk>
             <ru>Звуковые эффекты</ru>
+            <cn>音效</cn>
         </text>
-        
+
         <text name="ft_soundeffects_long">
             <en>Play sound effects for tablet interactions</en>
             <de>Soundeffekte für Tablet-Interaktionen abspielen</de>
@@ -354,6 +380,7 @@
             <br>Reproduzir efeitos sonoros para interações com o tablet</br>
             <uk>Відтворювати звукові ефекти для взаємодії з планшетом</uk>
             <ru>Воспроизводить звуковые эффекты для взаимодействия с планшетом</ru>
+            <cn>播放平板操作音效</cn>
         </text>
         
         <text name="ft_debug_short">
@@ -367,8 +394,9 @@
             <br>Modo debug</br>
             <uk>Режим налагодження</uk>
             <ru>Режим отладки</ru>
+            <cn>调试模式</cn>
         </text>
-        
+
         <text name="ft_debug_long">
             <en>Enable debug logging in console</en>
             <de>Debug-Protokollierung in der Konsole aktivieren</de>
@@ -380,6 +408,7 @@
             <br>Ativar registro de depuração no console</br>
             <uk>Увімкнути налагодження в консолі</uk>
             <ru>Включить отладку в консоли</ru>
+            <cn>在控制台启用调试日志</cn>
         </text>
         
         <text name="ft_reset">
@@ -393,6 +422,7 @@
             <br>Restaurar configurações do tablet</br>
             <uk>Скинути налаштування планшета</uk>
             <ru>Сбросить настройки планшета</ru>
+            <cn>重置平板设置</cn>
         </text>
         
         <!-- App names -->
@@ -407,8 +437,9 @@
             <br>Painel</br>
             <uk>Панель</uk>
             <ru>Панель</ru>
+            <cn>仪表盘</cn>
         </text>
-        
+
         <text name="ft_app_store">
             <en>App Store</en>
             <de>App Store</de>
@@ -420,8 +451,9 @@
             <br>Loja de aplicativos</br>
             <uk>Магазин додатків</uk>
             <ru>Магазин приложений</ru>
+            <cn>应用商店</cn>
         </text>
-        
+
         <text name="ft_app_updates">
             <en>Updates</en>
             <de>Updates</de>
@@ -433,8 +465,9 @@
             <br>Atualizações</br>
             <uk>Оновлення</uk>
             <ru>Обновления</ru>
+            <cn>更新</cn>
         </text>
-        
+
         <text name="ft_app_settings">
             <en>Settings</en>
             <de>Einstellungen</de>
@@ -446,8 +479,9 @@
             <br>Configurações</br>
             <uk>Налаштування</uk>
             <ru>Настройки</ru>
+            <cn>设置</cn>
         </text>
-        
+
         <text name="ft_app_workshop">
             <en>Workshop</en>
             <de>Werkstatt</de>
@@ -459,8 +493,9 @@
             <br>Oficina</br>
             <uk>Майстерня</uk>
             <ru>Мастерская</ru>
+            <cn>维修站</cn>
         </text>
-        
+
         <text name="ft_app_field_status">
             <en>Field Manager</en>
             <de>Feldmanager</de>
@@ -472,6 +507,7 @@
             <br>Gerenciador de campos</br>
             <uk>Менеджер полів</uk>
             <ru>Менеджер полей</ru>
+            <cn>农田管理</cn>
         </text>
 
         <text name="ft_app_animals">
@@ -485,6 +521,7 @@
             <br>Animais</br>
             <uk>Тварини</uk>
             <ru>Животные</ru>
+            <cn>动物</cn>
         </text>
 
         <text name="ft_app_weather">
@@ -498,8 +535,9 @@
             <br>Tempo</br>
             <uk>Погода</uk>
             <ru>Погода</ru>
+            <cn>天气</cn>
         </text>
-        
+
         <text name="ft_app_digging">
             <en>Digging</en>
             <de>Graben</de>
@@ -511,8 +549,9 @@
             <br>Escavação</br>
             <uk>Копання</uk>
             <ru>Копание</ru>
+            <cn>挖掘</cn>
         </text>
-        
+
         <text name="ft_app_bucket_tracker">
             <en>Bucket Tracker</en>
             <de>Eimer-Zähler</de>
@@ -524,8 +563,9 @@
             <br>Contador de Baldes</br>
             <uk>Лічильник ковшів</uk>
             <ru>Счетчик ковшей</ru>
+            <cn>铲斗计数器</cn>
         </text>
-        
+
         <text name="ft_app_income_mod">
             <en>Income Mod</en>
             <de>Einkommens-Mod</de>
@@ -537,8 +577,9 @@
             <br>Mod de Renda</br>
             <uk>Мод доходу</uk>
             <ru>Мод дохода</ru>
+            <cn>收入模组</cn>
         </text>
-        
+
         <text name="ft_app_tax_mod">
             <en>Tax Mod</en>
             <de>Steuer-Mod</de>
@@ -550,6 +591,7 @@
             <br>Mod de Impostos</br>
             <uk>Мод податків</uk>
             <ru>Мод налогов</ru>
+            <cn>税务模组</cn>
         </text>
 
         <text name="ft_app_npc_favor">
@@ -563,6 +605,7 @@
             <br>Favor NPC</br>
             <uk>Прихильність NPC</uk>
             <ru>Расположение НПС</ru>
+            <cn>NPC好感</cn>
         </text>
 
         <text name="ft_app_crop_stress">
@@ -576,6 +619,7 @@
             <br>Estresse de culturas</br>
             <uk>Стрес рослин</uk>
             <ru>Стресс растений</ru>
+            <cn>作物胁迫</cn>
         </text>
 
         <text name="ft_app_soil_fertilizer">
@@ -589,6 +633,7 @@
             <br>Fertilizante do solo</br>
             <uk>Добрива ґрунту</uk>
             <ru>Удобрение почвы</ru>
+            <cn>土壤施肥</cn>
         </text>
     </l10n>
 </modDesc>


### PR DESCRIPTION
## Summary
- Adds `<cn>` (Simplified Chinese) entries to all localizable strings in `modDesc.xml`
- Covers mod title, description, 8 help lines, and all 25 l10n keys (settings labels, app names)
- Uses proper agricultural Chinese terminology (e.g. 仪表盘, 农田管理, 作物胁迫)

## Test plan
- [ ] Launch game with Chinese language set — verify tablet title, help text, and settings rows display in Chinese
- [ ] Confirm fallback to English still works for any string if `cn` tag is not picked up by the engine

Closes #13