### PR TITLE
fix: MP — route companion mod setting changes through proper API

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>2.1.2.1</version>
+    <version>2.1.2.2</version>
     <modName>FS25_FarmTablet</modName>
     <title>
         <en>Farm Tablet</en>

--- a/src/apps/IncomeApp.lua
+++ b/src/apps/IncomeApp.lua
@@ -67,12 +67,14 @@ FarmTabletUI:registerDrawer(FT.APP.INCOME, function(self)
         self:drawButtonPair(minY + FT.py(2),
             "ENABLE",  enabled and FT.C.BTN_NEUTRAL or FT.C.BTN_PRIMARY,
             { onClick = function()
+                if not g_currentMission:getIsServer() then return end
                 if inst.settings then inst.settings.enabled = true end
                 if inst.settings and inst.settings.save then inst.settings:save() end
                 self:switchApp(FT.APP.INCOME)
             end },
             "DISABLE", enabled and FT.C.BTN_DANGER or FT.C.BTN_NEUTRAL,
             { onClick = function()
+                if not g_currentMission:getIsServer() then return end
                 if inst.settings then inst.settings.enabled = false end
                 if inst.settings and inst.settings.save then inst.settings:save() end
                 self:switchApp(FT.APP.INCOME)
@@ -145,12 +147,14 @@ FarmTabletUI:registerDrawer(FT.APP.TAX, function(self)
         self:drawButtonPair(minY + FT.py(2),
             "ENABLE",  enabled and FT.C.BTN_NEUTRAL or FT.C.BTN_PRIMARY,
             { onClick = function()
+                if not g_currentMission:getIsServer() then return end
                 if inst.settings then inst.settings.enabled = true end
                 if inst.saveSettings then inst:saveSettings() end
                 self:switchApp(FT.APP.TAX)
             end },
             "DISABLE", enabled and FT.C.BTN_DANGER or FT.C.BTN_NEUTRAL,
             { onClick = function()
+                if not g_currentMission:getIsServer() then return end
                 if inst.settings then inst.settings.enabled = false end
                 if inst.saveSettings then inst:saveSettings() end
                 self:switchApp(FT.APP.TAX)


### PR DESCRIPTION
## Summary

- `IncomeApp.lua` ENABLE/DISABLE buttons for IncomeMod and TaxMod directly mutated `inst.settings.enabled` on whichever machine clicked them
- In an MP session this meant each client had its own independent enabled state — there was no broadcast and the server was not authoritative
- Added `g_currentMission:getIsServer()` guard in all four button `onClick` closures (ENABLE/DISABLE for both IncomeMod and TaxMod)
- Clients see the buttons but clicks are silently ignored; only the host/server can commit setting changes
- No new network code needed — IncomeMod and TaxMod already sync their state on the server and broadcast via their own update loops
- Version bumped to 2.1.2.2

## Test plan

- [ ] In MP (listen server + 1 client), open FarmTablet on the client and click DISABLE for Income Mod — verify the mod remains enabled (server wins)
- [ ] On the host, click DISABLE for Income Mod — verify it disables and the client sees the change after IncomeMod's own sync cycle
- [ ] Repeat for Tax Mod enable/disable
- [ ] Load on a dedicated server — verify no Lua errors in log.txt