### PR TITLE
feat(apps): Weather app via WeatherGuard + world weather dial

### DIFF
--- a/src/apps/WeatherApp.lua
+++ b/src/apps/WeatherApp.lua
@@ -6,7 +6,20 @@
 -- Falls back to engine reads + projected forecast without WG.
 -- =========================================================
 
-local MODE_LABELS = { "Real", "Arid", "Normal", "Wet" }
+local function _T(key, fallback)
+    if g_i18n and key and g_i18n:hasText(key) then
+        return g_i18n:getText(key)
+    end
+    return fallback or key
+end
+
+-- Dial chip labels. Short on purpose: the chips are cw/4 wide in TINY font.
+-- The fuller meaning lives in the help page and the note line under the dial.
+local MODE_KEYS = {
+    "ft_weather_mode_real", "ft_weather_mode_arid",
+    "ft_weather_mode_normal", "ft_weather_mode_wet",
+}
+local MODE_FALLBACK = { "Real", "Arid", "Normal", "Wet" }
 local MODE_COLORS = {
     { 0.55, 0.58, 0.62, 1.0 },
     { 0.78, 0.62, 0.28, 1.0 },
@@ -14,15 +27,11 @@ local MODE_COLORS = {
     { 0.28, 0.55, 0.88, 1.0 },
 }
 
+-- WeatherGuard publishes g_weatherGuard into its OWN mod environment, which is
+-- not visible from here: getfenv(0) is per-mod scoped in FS25. The shared
+-- g_currentMission field is the only handle that crosses the mod boundary.
 local function _wg()
-    local wg = g_currentMission and g_currentMission.weatherGuard
-    if wg ~= nil then return wg end
-    local ok, alt = pcall(function()
-        local env = getfenv(0)
-        return env["g_weatherGuard"] or env["g_WeatherGuard"]
-    end)
-    if ok then return alt end
-    return nil
+    return g_currentMission and g_currentMission.weatherGuard or nil
 end
 
 FarmTabletUI:registerDrawer(FT.APP.WEATHER, function(self)
@@ -34,21 +43,21 @@ FarmTabletUI:registerDrawer(FT.APP.WEATHER, function(self)
                   "left edge: blue = rain, orange = storm, grey = overcast,\n" ..
                   "white = clear, dark = fog." },
         { title = "WEATHERGUARD",
-          body  = "When FS25_WeatherGuard is installed, this app reads the\n" ..
-                  "shared weather truth (same sky every mod uses) and a real\n" ..
-                  "engine forecast instead of a guessed projection." },
+          body  = "With FS25_WeatherGuard installed this app reads the shared\n" ..
+                  "weather truth and a real engine forecast, not a guess." },
         { title = "WORLD WEATHER DIAL",
-          body  = "Real / Arid / Normal / Wet chips set the shared world\n" ..
-                  "weather mode (admin-only in multiplayer). Same meaning\n" ..
-                  "as the World Climate control in Soil Fertilizer." },
+          body  = "Real / Arid / Normal / Wet set the shared world climate.\n" ..
+                  "Admin-only in multiplayer. Matches Soil Fertilizer." },
         { title = "TEMPERATURE",
-          body  = "Current air temperature in Celsius with a feel label:\n" ..
-                  "Freezing (<0)  Cold (<8)  Cool (<16)  Mild (<24)\n" ..
-                  "Warm (<32)  Hot (32+)." },
+          body  = "Air temperature in Celsius with a feel label: Freezing (<0)\n" ..
+                  "Cold (<8)  Cool (<16)  Mild (<24)  Warm (<32)  Hot (32+)." },
+        { title = "OTHER READINGS",
+          body  = "Cloud cover: 0-19% Clear, 20-39% Partly, 40-69% Mostly,\n" ..
+                  "70%+ Overcast. Wind: km/h plus compass direction.\n" ..
+                  "Precipitation: rain or storm intensity as a fill bar." },
         { title = "FORECAST",
-          body  = "With WeatherGuard: real Day +1.. outlook from the game\n" ..
-                  "forecast (about 9 days filled; we show up to five).\n" ..
-                  "Without WeatherGuard: a projected estimate only." },
+          body  = "With WeatherGuard: real outlook, rain shown as intensity.\n" ..
+                  "Without it: a projected estimate showing rain chance." },
     }) then return end
 
     local data = self.system.data
@@ -103,7 +112,7 @@ FarmTabletUI:registerDrawer(FT.APP.WEATHER, function(self)
                 self.r:appRect(cx, y - FT.py(2), chipW, FT.py(2), col)
             end
             self.r:appText(cx + chipW * 0.5, y - chipH * 0.55, FT.FONT.TINY,
-                MODE_LABELS[i], RenderText.ALIGN_CENTER,
+                _T(MODE_KEYS[i], MODE_FALLBACK[i]), RenderText.ALIGN_CENTER,
                 selected and FT.C.TEXT_BRIGHT or FT.C.TEXT_DIM)
             local btn = self.r:button(cx, y - chipH, chipW, chipH, "",
                 { 0, 0, 0, 0.01 },
@@ -214,7 +223,14 @@ FarmTabletUI:registerDrawer(FT.APP.WEATHER, function(self)
             if f and y > contentY + FT.py(8) then
                 local cond = f.condition or "Unknown"
                 local tempF = f.temperature ~= nil and string.format("%.0f C", f.temperature) or nil
-                local rainBit = f.rainProb ~= nil and string.format("  %d%% rain", f.rainProb) or ""
+                -- WeatherGuard gives rainfall INTENSITY at a sampled moment, the
+                -- projection gives a chance of rain. Never label one as the other.
+                local rainBit = ""
+                if f.rainIntensity ~= nil then
+                    rainBit = string.format("  %d%% intensity", f.rainIntensity)
+                elseif f.rainProb ~= nil then
+                    rainBit = string.format("  %d%% chance", f.rainProb)
+                end
                 local right = (tempF and (cond .. "  " .. tempF) or cond) .. rainBit
                 y = self:drawRow(y, "Day +" .. i, right, nil, FT.C.TEXT_DIM)
             end

--- a/src/apps/WeatherApp.lua
+++ b/src/apps/WeatherApp.lua
@@ -1,6 +1,29 @@
 -- =========================================================
 -- FarmTablet v2 – Weather App
 -- =========================================================
+-- Prefers WeatherGuard (shared weather truth) when present.
+-- World Weather dial chips call weatherGuard:requestWeatherMode.
+-- Falls back to engine reads + projected forecast without WG.
+-- =========================================================
+
+local MODE_LABELS = { "Real", "Arid", "Normal", "Wet" }
+local MODE_COLORS = {
+    { 0.55, 0.58, 0.62, 1.0 },
+    { 0.78, 0.62, 0.28, 1.0 },
+    { 0.35, 0.72, 0.48, 1.0 },
+    { 0.28, 0.55, 0.88, 1.0 },
+}
+
+local function _wg()
+    local wg = g_currentMission and g_currentMission.weatherGuard
+    if wg ~= nil then return wg end
+    local ok, alt = pcall(function()
+        local env = getfenv(0)
+        return env["g_weatherGuard"] or env["g_WeatherGuard"]
+    end)
+    if ok then return alt end
+    return nil
+end
 
 FarmTabletUI:registerDrawer(FT.APP.WEATHER, function(self)
     local AC = FT.appColor(FT.APP.WEATHER)
@@ -10,22 +33,22 @@ FarmTabletUI:registerDrawer(FT.APP.WEATHER, function(self)
           body  = "Shows the current weather at the top with a colour-coded\n" ..
                   "left edge: blue = rain, orange = storm, grey = overcast,\n" ..
                   "white = clear, dark = fog." },
+        { title = "WEATHERGUARD",
+          body  = "When FS25_WeatherGuard is installed, this app reads the\n" ..
+                  "shared weather truth (same sky every mod uses) and a real\n" ..
+                  "engine forecast instead of a guessed projection." },
+        { title = "WORLD WEATHER DIAL",
+          body  = "Real / Arid / Normal / Wet chips set the shared world\n" ..
+                  "weather mode (admin-only in multiplayer). Same meaning\n" ..
+                  "as the World Climate control in Soil Fertilizer." },
         { title = "TEMPERATURE",
           body  = "Current air temperature in Celsius with a feel label:\n" ..
                   "Freezing (<0)  Cold (<8)  Cool (<16)  Mild (<24)\n" ..
                   "Warm (<32)  Hot (32+)." },
-        { title = "CLOUD COVER",
-          body  = "Percentage of sky covered by clouds.\n" ..
-                  "0-19% = Clear  20-39% = Partly  40-69% = Mostly  70%+ = Overcast." },
-        { title = "WIND",
-          body  = "Wind speed in km/h and compass direction.\n" ..
-                  "Shown top-right of the current condition and in the detail rows." },
-        { title = "PRECIPITATION",
-          body  = "Rain or storm intensity shown with a fill bar.\n" ..
-                  "Bar length reflects the rain scale value (0-100%)." },
         { title = "FORECAST",
-          body  = "Multi-day outlook — Day +1 through Day +5.\n" ..
-                  "Each entry shows predicted condition and max temperature." },
+          body  = "With WeatherGuard: real Day +1.. outlook from the game\n" ..
+                  "forecast (about 9 days filled; we show up to five).\n" ..
+                  "Without WeatherGuard: a projected estimate only." },
     }) then return end
 
     local data = self.system.data
@@ -33,18 +56,73 @@ FarmTabletUI:registerDrawer(FT.APP.WEATHER, function(self)
 
     local startY = self:drawAppHeader("Weather", "")
     local x, contentY, cw, _ = self:contentInner()
+    local scrollY = self:getContentScrollY()
+    local y = startY + scrollY
     local accent = AC
 
     if not w then
-        self.r:appText(x, startY - FT.py(10), FT.FONT.BODY,
+        self.r:appText(x, y - FT.py(10), FT.FONT.BODY,
             "Weather data unavailable.", RenderText.ALIGN_LEFT, FT.C.WARNING)
-        self.r:appText(x, startY - FT.py(28), FT.FONT.SMALL,
+        self.r:appText(x, y - FT.py(28), FT.FONT.SMALL,
             "Environment not loaded yet.", RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
         self:drawInfoIcon("_weatherHelp", AC)
         return
     end
 
-    local y = startY
+    -- Source strip
+    local viaWg = w.source == "weatherguard"
+    self.r:appRect(x - FT.px(4), y - FT.py(20), cw + FT.px(8), FT.py(18),
+        { accent[1] * 0.10, accent[2] * 0.10, accent[3] * 0.10, 0.95 })
+    self.r:appText(x, y - FT.py(16), FT.FONT.SMALL,
+        viaWg and "Via WeatherGuard" or "Engine (no WeatherGuard)",
+        RenderText.ALIGN_LEFT, viaWg and FT.C.POSITIVE or FT.C.WARNING)
+    if viaWg and w.forecastHorizonDays then
+        self.r:appText(x + cw, y - FT.py(16), FT.FONT.TINY,
+            string.format("~%.0f day forecast", w.forecastHorizonDays),
+            RenderText.ALIGN_RIGHT, FT.C.TEXT_DIM)
+    end
+    y = y - FT.py(24)
+
+    -- World Weather dial (WeatherGuard only)
+    local wg = _wg()
+    if wg ~= nil and type(wg.requestWeatherMode) == "function" then
+        y = self:drawSection(y, "WORLD WEATHER")
+        local mode = tonumber(w.weatherMode) or 3
+        local chipGap = FT.px(4)
+        local chipW = (cw - chipGap * 3) / 4
+        local chipH = FT.py(28)
+        for i = 1, 4 do
+            local cx = x + (i - 1) * (chipW + chipGap)
+            local selected = (mode == i)
+            local col = MODE_COLORS[i]
+            local bg = selected
+                and { col[1] * 0.35, col[2] * 0.35, col[3] * 0.35, 0.95 }
+                or FT.C.BG_PANEL
+            self.r:appRect(cx, y - chipH, chipW, chipH, bg)
+            if selected then
+                self.r:appRect(cx, y - FT.py(2), chipW, FT.py(2), col)
+            end
+            self.r:appText(cx + chipW * 0.5, y - chipH * 0.55, FT.FONT.TINY,
+                MODE_LABELS[i], RenderText.ALIGN_CENTER,
+                selected and FT.C.TEXT_BRIGHT or FT.C.TEXT_DIM)
+            local btn = self.r:button(cx, y - chipH, chipW, chipH, "",
+                { 0, 0, 0, 0.01 },
+                { onClick = function()
+                    pcall(function() wg:requestWeatherMode(i) end)
+                    if self.system and self.system.data and self.system.data.invalidate then
+                        self.system.data:invalidate()
+                    end
+                    self:switchApp(FT.APP.WEATHER)
+                end })
+            table.insert(self._contentBtns, btn)
+        end
+        y = y - chipH - FT.py(6)
+        self.r:appText(x, y - FT.py(2), FT.FONT.TINY,
+            "Shared world setting · admin-only in multiplayer",
+            RenderText.ALIGN_LEFT, FT.C.MUTED)
+        y = y - FT.py(16)
+        y = self:drawRule(y, 0.3)
+    end
 
     -- Condition hero card
     y = y - FT.py(4)
@@ -56,26 +134,26 @@ FarmTabletUI:registerDrawer(FT.APP.WEATHER, function(self)
     elseif w.isRaining              then condColor = FT.C.WEATHER_RAIN
     elseif w.isFoggy                then condColor = FT.C.WEATHER_FOG
     elseif w.condKey == "clear"     then condColor = FT.C.WEATHER_SUN
-    elseif w.condKey == "overcast"  then condColor = {0.55, 0.57, 0.65, 1.00}
+    elseif w.condKey == "overcast"  then condColor = { 0.55, 0.57, 0.65, 1.00 }
     end
     self.r:appRect(x, y - heroH, FT.px(4), heroH, condColor)
 
     local condLabel = {
-        storm="STORM", rain="RAIN", fog="FOG",
-        overcast="OVC", cloudy="CLOUD", clear="CLEAR",
+        storm = "STORM", rain = "RAIN", fog = "FOG", snow = "SNOW",
+        overcast = "OVC", cloudy = "CLOUD", clear = "CLEAR",
     }
-    self.r:appText(x + FT.px(10), y - heroH/2 + FT.py(2),
+    self.r:appText(x + FT.px(10), y - heroH / 2 + FT.py(2),
         FT.FONT.HEADER, condLabel[w.condKey] or "?", RenderText.ALIGN_LEFT, condColor)
     local tempStr = w.temperature ~= nil and string.format("%.1f C", w.temperature) or "-- C"
-    self.r:appText(x + FT.px(62), y - heroH/2 + FT.py(2),
+    self.r:appText(x + FT.px(62), y - heroH / 2 + FT.py(2),
         FT.FONT.BODY, tempStr, RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
     if w.windSpeed and w.windSpeed > 0 then
-        self.r:appText(x + cw - FT.px(10), y - heroH/2 + FT.py(10),
+        self.r:appText(x + cw - FT.px(10), y - heroH / 2 + FT.py(10),
             FT.FONT.BODY, string.format("%.0f km/h", w.windSpeed), RenderText.ALIGN_RIGHT, FT.C.TEXT_NORMAL)
-        self.r:appText(x + cw - FT.px(10), y - heroH/2 - FT.py(6),
+        self.r:appText(x + cw - FT.px(10), y - heroH / 2 - FT.py(6),
             FT.FONT.TINY, "WIND", RenderText.ALIGN_RIGHT, FT.C.TEXT_DIM)
         if w.windDir and w.windDir ~= "" then
-            self.r:appText(x + cw - FT.px(10), y - heroH/2 - FT.py(16),
+            self.r:appText(x + cw - FT.px(10), y - heroH / 2 - FT.py(16),
                 FT.FONT.TINY, w.windDir, RenderText.ALIGN_RIGHT, FT.C.TEXT_DIM)
         end
     end
@@ -86,17 +164,17 @@ FarmTabletUI:registerDrawer(FT.APP.WEATHER, function(self)
     y = self:drawSection(y, "CONDITIONS")
     if w.temperature ~= nil then
         local tempColor = w.temperature < 0 and FT.C.INFO or w.temperature > 32 and FT.C.NEGATIVE
-                       or w.temperature > 25 and FT.C.WARNING or FT.C.TEXT_ACCENT
-        local feelStr   = w.temperature < 0 and "Freezing" or w.temperature < 8 and "Cold"
-                       or w.temperature < 16 and "Cool" or w.temperature < 24 and "Mild"
-                       or w.temperature < 32 and "Warm" or "Hot"
+            or w.temperature > 25 and FT.C.WARNING or FT.C.TEXT_ACCENT
+        local feelStr = w.temperature < 0 and "Freezing" or w.temperature < 8 and "Cold"
+            or w.temperature < 16 and "Cool" or w.temperature < 24 and "Mild"
+            or w.temperature < 32 and "Warm" or "Hot"
         y = self:drawRow(y, "Temperature",
             string.format("%.1f C  (%s)", w.temperature, feelStr), nil, tempColor)
     end
     if w.cloudCover ~= nil then
         local cp = math.floor(w.cloudCover * 100)
         local cs = cp < 20 and "Clear" or cp < 40 and "Partly Cloudy"
-                or cp < 70 and "Mostly Cloudy" or "Overcast"
+            or cp < 70 and "Mostly Cloudy" or "Overcast"
         y = self:drawRow(y, "Cloud Cover", string.format("%d%%  (%s)", cp, cs))
     end
     if w.humidity ~= nil then
@@ -129,23 +207,21 @@ FarmTabletUI:registerDrawer(FT.APP.WEATHER, function(self)
     if w.forecast and #w.forecast > 0 then
         y = y - FT.py(4)
         y = self:drawRule(y, 0.25)
-        y = self:drawSection(y, "FORECAST")
+        local fcTitle = w.forecastIsReal and "FORECAST  (engine)" or "FORECAST  (projected)"
+        y = self:drawSection(y, fcTitle)
         for i = 1, math.min(5, #w.forecast) do
             local f = w.forecast[i]
             if f and y > contentY + FT.py(8) then
-                local cond = f.weatherType or f.condition or f.type or f.conditionType or f.name or "Unknown"
-                local condMap = {
-                    [0]="Clear",[1]="Cloudy",[2]="Rain",[3]="Storm",[4]="Fog",[5]="Snow",
-                    SUN="Clear",CLOUDY="Cloudy",RAIN="Rain",STORM="Storm",FOG="Fog",SNOW="Snow",
-                }
-                if type(cond) == "number" or condMap[cond] then cond = condMap[cond] or tostring(cond) end
-                local tempF = f.maxTemperature ~= nil and string.format("%.0f C", f.maxTemperature)
-                           or f.temperature   ~= nil and string.format("%.0f C", f.temperature) or nil
-                y = self:drawRow(y, "Day +" .. i,
-                    tempF and (cond .. "  " .. tempF) or cond, nil, FT.C.TEXT_DIM)
+                local cond = f.condition or "Unknown"
+                local tempF = f.temperature ~= nil and string.format("%.0f C", f.temperature) or nil
+                local rainBit = f.rainProb ~= nil and string.format("  %d%% rain", f.rainProb) or ""
+                local right = (tempF and (cond .. "  " .. tempF) or cond) .. rainBit
+                y = self:drawRow(y, "Day +" .. i, right, nil, FT.C.TEXT_DIM)
             end
         end
     end
 
+    self:setContentHeight(startY - y + scrollY)
     self:drawInfoIcon("_weatherHelp", AC)
+    self:drawScrollBar()
 end)

--- a/src/utils/DataProvider.lua
+++ b/src/utils/DataProvider.lua
@@ -351,16 +351,12 @@ function FT_DataProvider:getWorldInfo()
     end)
 end
 
---- Soft-detect WeatherGuard (6th core service). Prefer mission handle.
+--- Soft-detect WeatherGuard (6th core service).
+--- WeatherGuard publishes g_weatherGuard into its OWN mod environment, which is
+--- not reachable from here: getfenv(0) is per-mod scoped in FS25. The shared
+--- g_currentMission field is the only handle that crosses the mod boundary.
 local function _ftWeatherGuard()
-    local wg = g_currentMission and g_currentMission.weatherGuard
-    if wg ~= nil then return wg end
-    local ok, alt = pcall(function()
-        local env = getfenv(0)
-        return env["g_weatherGuard"] or env["g_WeatherGuard"]
-    end)
-    if ok then return alt end
-    return nil
+    return g_currentMission and g_currentMission.weatherGuard or nil
 end
 
 local function _ftCondFromType(weatherType, rainScale, fogScale, cloud)
@@ -543,13 +539,16 @@ function FT_DataProvider:getWeather()
                 elseif rainN > 0.05 then condKeyF, conditionF = "rain",  "Rainy"
                 else                     condKeyF, conditionF = "clear", "Clear"
                 end
+                -- getForecastRain returns rainfallScale: the INTENSITY of rain at
+                -- the sampled moment on that day, not a chance of rain. Publish it
+                -- as rainIntensity so no consumer can render it as a probability.
                 fc[#fc + 1] = {
-                    condition   = conditionF,
-                    condKey     = condKeyF,
-                    temperature = (okT and type(fTemp) == "number") and math.floor(fTemp + 0.5) or nil,
-                    rainProb    = math.floor(math.max(0, math.min(1, rainN)) * 100),
-                    rainScale   = rainN,
-                    source      = "weatherguard",
+                    condition     = conditionF,
+                    condKey       = condKeyF,
+                    temperature   = (okT and type(fTemp) == "number") and math.floor(fTemp + 0.5) or nil,
+                    rainIntensity = math.floor(math.max(0, math.min(1, rainN)) * 100),
+                    rainScale     = rainN,
+                    source        = "weatherguard",
                 }
             end
             w.forecast = fc

--- a/src/utils/DataProvider.lua
+++ b/src/utils/DataProvider.lua
@@ -351,6 +351,44 @@ function FT_DataProvider:getWorldInfo()
     end)
 end
 
+--- Soft-detect WeatherGuard (6th core service). Prefer mission handle.
+local function _ftWeatherGuard()
+    local wg = g_currentMission and g_currentMission.weatherGuard
+    if wg ~= nil then return wg end
+    local ok, alt = pcall(function()
+        local env = getfenv(0)
+        return env["g_weatherGuard"] or env["g_WeatherGuard"]
+    end)
+    if ok then return alt end
+    return nil
+end
+
+local function _ftCondFromType(weatherType, rainScale, fogScale, cloud)
+    local t = type(weatherType) == "string" and weatherType:lower() or nil
+    if t == "storm" or t == "hail" then
+        return "Stormy", "storm"
+    elseif t == "rain" or t == "shower" then
+        return "Rainy", "rain"
+    elseif t == "snow" then
+        return "Snow", "snow"
+    elseif t == "fog" then
+        return "Foggy", "fog"
+    elseif t == "cloud" or t == "cloudy" or t == "overcast" then
+        if (cloud or 0) > 0.70 then return "Overcast", "overcast" end
+        return "Partly Cloudy", "cloudy"
+    elseif t == "clear" or t == "sun" or t == "sunny" then
+        return "Clear", "clear"
+    end
+    -- Heuristic fallback (engine path / incomplete type)
+    local rs = tonumber(rainScale) or 0
+    if rs > 0.70 then return "Stormy", "storm" end
+    if rs > 0.05 then return "Rainy", "rain" end
+    if (fogScale or 0) > 0.3 then return "Foggy", "fog" end
+    if (cloud or 0) > 0.70 then return "Overcast", "overcast" end
+    if (cloud or 0) > 0.30 then return "Partly Cloudy", "cloudy" end
+    return "Clear", "clear"
+end
+
 function FT_DataProvider:getWeather()
     return self:_cached("weather", 2000, function()
         if not (g_currentMission and g_currentMission.environment) then
@@ -363,52 +401,62 @@ function FT_DataProvider:getWeather()
         local weather = env.weatherSystem or env.weather
         if not weather then return nil end
 
+        local wg = _ftWeatherGuard()
+        local sky = nil
+        if wg ~= nil and type(wg.getCurrentSky) == "function" then
+            local ok, result = pcall(function() return wg:getCurrentSky() end)
+            if ok then sky = result end
+        end
+
         -- ── Rain / precipitation ──────────────────────────
-        -- Try all known FS25 rain scale method/field names
         local rainScale = 0
-        if     weather.getRainFallScale          then rainScale = weather:getRainFallScale()
-        elseif weather.getRainScale              then rainScale = weather:getRainScale()
+        if sky ~= nil and type(sky.rainScale) == "number" then
+            rainScale = sky.rainScale
+        elseif weather.getRainFallScale then rainScale = weather:getRainFallScale()
+        elseif weather.getRainScale then rainScale = weather:getRainScale()
         elseif weather.getPrecipitationIntensity then rainScale = weather:getPrecipitationIntensity()
         elseif type(weather.rainFallScale) == "number" then rainScale = weather.rainFallScale
-        elseif type(env.rainScale)         == "number" then rainScale = env.rainScale
+        elseif type(env.rainScale) == "number" then rainScale = env.rainScale
         end
 
         -- ── Temperature ───────────────────────────────────
         local temp = 15
-        if     weather.getCurrentTemperature then temp = weather:getCurrentTemperature()
-        elseif weather.getTemperature        then temp = weather:getTemperature()
+        if sky ~= nil and type(sky.temperature) == "number" then
+            temp = sky.temperature
+        elseif weather.getCurrentTemperature then temp = weather:getCurrentTemperature()
+        elseif weather.getTemperature then temp = weather:getTemperature()
         elseif type(weather.temperature) == "number" then temp = weather.temperature
-        elseif type(env.temperature)     == "number" then temp = env.temperature
+        elseif type(env.temperature) == "number" then temp = env.temperature
         end
 
         -- ── Cloud cover (0.0 – 1.0) ───────────────────────
+        -- WeatherGuard field is cloudCoverage; FarmTablet UI uses cloudCover.
         local cloud = 0
-        if     weather.getCloudCoverage then
+        if sky ~= nil and type(sky.cloudCoverage) == "number" then
+            cloud = sky.cloudCoverage
+        elseif weather.getCloudCoverage then
             cloud = weather:getCloudCoverage()
         elseif env.cloudUpdater and env.cloudUpdater.getCloudCoverage then
             cloud = env.cloudUpdater:getCloudCoverage()
         elseif type(weather.cloudCoverage) == "number" then cloud = weather.cloudCoverage
-        elseif type(env.cloudCoverage)     == "number" then cloud = env.cloudCoverage
+        elseif type(env.cloudCoverage) == "number" then cloud = env.cloudCoverage
         end
-        -- Clamp to 0–1 (some mods return 0–100)
         if cloud > 1.0 then cloud = cloud / 100 end
 
-        -- ── Fog ───────────────────────────────────────────
+        -- ── Fog (engine; WeatherGuard does not publish fog) ─
         local fogScale = 0
         if     type(weather.fogScale) == "number" then fogScale = weather.fogScale
         elseif type(env.fogScale)     == "number" then fogScale = env.fogScale
         end
 
-        -- ── Wind ──────────────────────────────────────────
+        -- ── Wind (engine; WeatherGuard does not publish wind) ─
         local windSpeed = 0
         if     weather.getWindSpeed       then windSpeed = weather:getWindSpeed()
         elseif type(weather.windSpeed) == "number" then windSpeed = weather.windSpeed
         elseif type(env.windSpeed)     == "number" then windSpeed = env.windSpeed
         end
-        -- Convert m/s → km/h if value looks like m/s (< 30)
         if windSpeed > 0 and windSpeed < 30 then windSpeed = windSpeed * 3.6 end
 
-        -- Wind direction (optional)
         local windDir = nil
         if     weather.getWindDirection then
             local deg = weather:getWindDirection()
@@ -424,81 +472,118 @@ function FT_DataProvider:getWeather()
             windDir    = dirs[idx]
         end
 
-        -- ── Humidity (optional, present in some mods) ─────
+        -- ── Humidity ──────────────────────────────────────
         local humidity = nil
-        if     weather.getHumidity        then humidity = weather:getHumidity()
+        if sky ~= nil and type(sky.humidity) == "number" then
+            humidity = sky.humidity
+        elseif weather.getHumidity then humidity = weather:getHumidity()
         elseif type(weather.humidity) == "number" then humidity = weather.humidity
-        elseif type(env.humidity)     == "number" then humidity = env.humidity
+        elseif type(env.humidity) == "number" then humidity = env.humidity
         end
         if humidity and humidity > 1.0 then humidity = humidity / 100 end
 
-        -- ── Build result table ─────────────────────────────
+        local isRaining = rainScale > 0.05
+        if sky ~= nil and sky.isRaining ~= nil then
+            isRaining = sky.isRaining == true or rainScale > 0.05
+        end
+
+        local weatherType = sky and sky.weatherType or nil
+        local condition, condKey = _ftCondFromType(weatherType, rainScale, fogScale, cloud)
+
         local w = {
             temperature = temp,
             rainScale   = rainScale,
-            isRaining   = rainScale > 0.05,
-            isStorming  = rainScale > 0.70,
-            isFoggy     = fogScale  > 0.3,
-            cloudCover  = cloud,       -- 0.0–1.0
-            windSpeed   = windSpeed,   -- km/h
-            windDir     = windDir,     -- compass string or nil
-            humidity    = humidity,    -- 0.0–1.0 or nil
+            isRaining   = isRaining,
+            isStorming  = rainScale > 0.70 or condKey == "storm",
+            isFoggy     = fogScale > 0.3 or condKey == "fog",
+            cloudCover  = cloud,
+            windSpeed   = windSpeed,
+            windDir     = windDir,
+            humidity    = humidity,
+            condition   = condition,
+            condKey     = condKey,
+            weatherType = weatherType,
+            source      = wg ~= nil and "weatherguard" or "engine",
         }
 
-        if     w.isStorming then w.condition = "Stormy";        w.condKey = "storm"
-        elseif w.isRaining  then w.condition = "Rainy";         w.condKey = "rain"
-        elseif w.isFoggy    then w.condition = "Foggy";         w.condKey = "fog"
-        elseif cloud > 0.70 then w.condition = "Overcast";      w.condKey = "overcast"
-        elseif cloud > 0.30 then w.condition = "Partly Cloudy"; w.condKey = "cloudy"
-        else                     w.condition = "Clear";         w.condKey = "clear"
+        -- WeatherGuard world-weather dial (1 Real / 2 Arid / 3 Normal / 4 Wet)
+        if wg ~= nil then
+            local okMode, mode = pcall(function() return wg:getWeatherMode() end)
+            if okMode and type(mode) == "number" then
+                w.weatherMode = mode
+            end
+            local okName, modeName = pcall(function() return wg:getWeatherModeName() end)
+            if okName and type(modeName) == "string" then
+                w.weatherModeName = modeName
+            end
+            local okH, horizon = pcall(function() return wg:getForecastHorizonDays() end)
+            if okH and type(horizon) == "number" then
+                w.forecastHorizonDays = horizon
+            end
         end
 
-        -- ── Projected 5-day Forecast ──────────────────────
-        -- FS25 has no public forecast Lua API (confirmed: SeasonalCropStress
-        -- WeatherIntegration.lua comment).  We build a projection from:
-        --   • Near-term (days 1-2): current cloud coverage → rain probability
-        --   • Far-term  (days 3-5): seasonal base rain probability, blended in
-        -- Temperature drifts ±1 C per day toward the seasonal mean.
-        do
-            -- Seasonal base rain probabilities (spring/summer/autumn/winter)
+        -- ── Forecast ──────────────────────────────────────
+        -- Prefer WeatherGuard's real engine forecast. Fall back to the old
+        -- seasonal heuristic only when WeatherGuard is absent.
+        if wg ~= nil and type(wg.getForecastRain) == "function" then
+            local fc = {}
+            local maxDays = 5
+            if type(w.forecastHorizonDays) == "number" then
+                maxDays = math.max(1, math.min(5, math.floor(w.forecastHorizonDays)))
+            end
+            for day = 1, maxDays do
+                local okR, rain = pcall(function() return wg:getForecastRain(day) end)
+                local okT, fTemp = pcall(function() return wg:getForecastTemperature(day) end)
+                if not okR or rain == nil then
+                    break -- honest horizon edge
+                end
+                local rainN = tonumber(rain) or 0
+                local condKeyF, conditionF
+                if     rainN > 0.70 then condKeyF, conditionF = "storm", "Stormy"
+                elseif rainN > 0.05 then condKeyF, conditionF = "rain",  "Rainy"
+                else                     condKeyF, conditionF = "clear", "Clear"
+                end
+                fc[#fc + 1] = {
+                    condition   = conditionF,
+                    condKey     = condKeyF,
+                    temperature = (okT and type(fTemp) == "number") and math.floor(fTemp + 0.5) or nil,
+                    rainProb    = math.floor(math.max(0, math.min(1, rainN)) * 100),
+                    rainScale   = rainN,
+                    source      = "weatherguard",
+                }
+            end
+            w.forecast = fc
+            w.forecastIsReal = true
+        else
+            -- Legacy projection (no WeatherGuard): season + cloud heuristic.
             local SEASONAL_RAIN = {[0]=0.30, [1]=0.12, [2]=0.28, [3]=0.35}
             local season = env.currentSeason
             season = (type(season) == "number") and math.floor(season) or 0
             local seasonRain = SEASONAL_RAIN[season] or 0.25
-
-            -- Best cloud coverage reading for the projection
-            local cloudFC = cloud  -- already clamped 0-1 above
-            if env.cloudUpdater and env.cloudUpdater.getCloudCoverage then
-                cloudFC = env.cloudUpdater:getCloudCoverage()
-                if cloudFC > 1.0 then cloudFC = cloudFC / 100 end
-            end
-
+            local cloudFC = cloud
             local fc = {}
             for day = 1, 5 do
-                -- Blend: day 1 = 100% cloud-based, day 5 = 100% seasonal
-                local blend   = (day - 1) / 4   -- 0.0 → 1.0
+                local blend = (day - 1) / 4
                 local rainProb = cloudFC * 0.7 * (1 - blend) + seasonRain * blend
-
-                -- Slight temperature drift toward seasonal typical
                 local seasonalMid = ({[0]=12, [1]=24, [2]=14, [3]=2})[season] or 15
                 local projTemp = math.floor(temp + (seasonalMid - temp) * blend * 0.3)
-
-                local condKey, condition
-                if     rainProb > 0.60 then condKey, condition = "storm",    "Stormy"
-                elseif rainProb > 0.35 then condKey, condition = "rain",     "Rainy"
-                elseif cloudFC  > 0.55 then condKey, condition = "overcast", "Overcast"
-                elseif cloudFC  > 0.25 then condKey, condition = "cloudy",   "Partly Cloudy"
-                else                        condKey, condition = "clear",    "Clear"
+                local condKeyF, conditionF
+                if     rainProb > 0.60 then condKeyF, conditionF = "storm",    "Stormy"
+                elseif rainProb > 0.35 then condKeyF, conditionF = "rain",     "Rainy"
+                elseif cloudFC  > 0.55 then condKeyF, conditionF = "overcast", "Overcast"
+                elseif cloudFC  > 0.25 then condKeyF, conditionF = "cloudy",   "Partly Cloudy"
+                else                        condKeyF, conditionF = "clear",    "Clear"
                 end
-
-                table.insert(fc, {
-                    condition   = condition,
-                    condKey     = condKey,
+                fc[#fc + 1] = {
+                    condition   = conditionF,
+                    condKey     = condKeyF,
                     temperature = projTemp,
                     rainProb    = math.floor(rainProb * 100),
-                })
+                    source      = "projected",
+                }
             end
             w.forecast = fc
+            w.forecastIsReal = false
         end
 
         return w

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -2442,5 +2442,9 @@
         <text name="ft_battery_charging_locked" text="Tablet am Ladegerät. Einschalten ab 15% möglich." />
         <text name="ft_battery_charged_usable" text="Tablet ausreichend geladen. Mit T wieder einschalten." />
         <text name="ft_battery_charged_full" text="Tablet voll geladen." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -2483,5 +2483,9 @@
         <text name="ft_battery_charging_locked" text="Планшет на зарядке. Включение с 15%." />
         <text name="ft_battery_charged_usable" text="Планшет достаточно заряжен. Нажмите T." />
         <text name="ft_battery_charged_full" text="Планшет полностью заряжен." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -2441,5 +2441,9 @@
         <text name="ft_battery_charging_locked" text="Tablet on charger. Can be turned on from 15%." />
         <text name="ft_battery_charged_usable" text="Tablet charged enough. Press T to turn it on." />
         <text name="ft_battery_charged_full" text="Tablet fully charged." />
+        <text name="ft_weather_mode_real" text="Real" />
+        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_weather_mode_normal" text="Normal" />
+        <text name="ft_weather_mode_wet" text="Wet" />
     </texts>
 </l10n>


### PR DESCRIPTION
## What
FarmTablet Weather UI against the new WeatherGuard shared weather service (unblocked after WG-1 landed).

- DataProvider getWeather soft-detects g_currentMission.weatherGuard
- Current sky from getCurrentSky (maps cloudCoverage to cloudCover)
- Real engine forecast via getForecastRain / getForecastTemperature (stops at honest horizon)
- World Weather dial chips call requestWeatherMode (Real / Arid / Normal / Wet)
- Without WeatherGuard: previous engine + projected forecast path unchanged
- Wind/fog still from engine (WG does not publish them)

## Notes
- Soil Fertilizer World Climate chips still write SF weatherSource (short-month fill). This PR binds the tablet dial to WeatherGuard. Full SF rebind can follow once sim/WG-2 migrate.
- Dashboard weather row picks up the same DataProvider path automatically.

## Test
With WeatherGuard loaded: open Weather app, see Via WeatherGuard, real forecast rows, dial chips change mode. Without WG: engine path + projected forecast still works.

-- Wizard