### PR TITLE
fix(apps): FarmTablet full-app overlap / layout sweep

### DIFF
--- a/src/FarmTabletSystem.lua
+++ b/src/FarmTabletSystem.lua
@@ -23,6 +23,16 @@ local function _ftSystemI18nKey(key)
     return nil
 end
 
+local function _ftSystemPrettyCropName(name)
+    name = tostring(name or "")
+    if name == "" then return name end
+    if name:find("%l") then return name end
+    name = name:gsub("_", " ")
+    return (name:lower():gsub("(%a)([%w']*)", function(first, rest)
+        return first:upper() .. rest
+    end))
+end
+
 local function _ftSystemLocalizedFillName(ft, fallback)
     if ft == nil then return fallback or "Unknown" end
     local name = ft.name or ft.fillTypeName or ft.fruitTypeName
@@ -40,6 +50,15 @@ local function _ftSystemLocalizedFillName(ft, fallback)
         local v = _ftSystemI18nKey("fillType_" .. n) or _ftSystemI18nKey("fruitType_" .. n)
         if v ~= nil then return v end
     end
+    if name ~= nil and g_fillTypeManager ~= nil and g_fillTypeManager.getFillTypeByName ~= nil then
+        local n = tostring(name)
+        local fill = g_fillTypeManager:getFillTypeByName(n)
+            or g_fillTypeManager:getFillTypeByName(string.upper(n))
+            or g_fillTypeManager:getFillTypeByName(string.lower(n))
+        if fill ~= nil and fill.title ~= nil and tostring(fill.title) ~= "" then
+            return tostring(fill.title)
+        end
+    end
     if name ~= nil and string.lower(tostring(name)) == "corn" then
         local lang = _ftSystemLang()
         if lang == "de" or lang == "ger" then return "Mais" end
@@ -51,7 +70,8 @@ local function _ftSystemLocalizedFillName(ft, fallback)
         if lang == "cz" or lang == "cs" then return "Kukuřice" end
         if lang == "pt" or lang == "br" then return "Milho" end
     end
-    local t = ft.title or ft.nameI18N or name or fallback or "Unknown"
+    local pretty = (name ~= nil and name ~= "") and _ftSystemPrettyCropName(name) or nil
+    local t = ft.title or ft.nameI18N or pretty or fallback or "Unknown"
     if FT and FT.l10nAuto then return FT.l10nAuto(t) end
     return t
 end

--- a/src/apps/AkitaTabletIntegrationsApp.lua
+++ b/src/apps/AkitaTabletIntegrationsApp.lua
@@ -156,8 +156,10 @@ FarmTabletUI:registerDrawer(FT.APP.ANIMAL_VET, function(self)
                 or d.workerTreatment and ftAkitaText("ft_vet_worker", "Worker")
                 or tostring(d.treatmentMode or ftAkitaText("ft_vet_self", "Self"))
             self.r:appRect(x - FT.px(4), y - FT.py(50), cw + FT.px(8), FT.py(54), {AC[1]*0.08, AC[2]*0.08, AC[3]*0.08, 0.85})
-            self.r:appText(x + FT.px(6), y - FT.py(10), FT.FONT.BODY, name, RenderText.ALIGN_LEFT, FT.C.TEXT_BRIGHT)
-            self.r:appText(x + cw - FT.px(6), y - FT.py(10), FT.FONT.TINY, status, RenderText.ALIGN_RIGHT, FT.C.TEXT_ACCENT)
+            self.r:appText(x + FT.px(6), y - FT.py(10), FT.FONT.BODY,
+                FT_Renderer.truncate(name, 20), RenderText.ALIGN_LEFT, FT.C.TEXT_BRIGHT)
+            self.r:appText(x + cw - FT.px(6), y - FT.py(10), FT.FONT.TINY,
+                FT_Renderer.truncate(status, 14), RenderText.ALIGN_RIGHT, FT.C.TEXT_ACCENT)
             self.r:appText(x + FT.px(10), y - FT.py(28), FT.FONT.TINY,
                 string.format(ftAkitaText("ft_vet_case_line", "%s - %d animals - about %d min"), illness, tonumber(d.animalCount) or 0, rem),
                 RenderText.ALIGN_LEFT, FT.C.TEXT_NORMAL)
@@ -226,10 +228,13 @@ FarmTabletUI:registerDrawer(FT.APP.FACTORY_WEEK, function(self)
             local worker = tostring(fac.workerText or fac.workersText or "")
             local event = tostring(fac.hudEventText or fac.eventText or "")
             self.r:appRect(x - FT.px(4), y - FT.py(48), cw + FT.px(8), FT.py(52), {AC[1]*0.08, AC[2]*0.08, AC[3]*0.08, 0.85})
-            self.r:appText(x + FT.px(6), y - FT.py(10), FT.FONT.BODY, name, RenderText.ALIGN_LEFT, FT.C.TEXT_BRIGHT)
-            self.r:appText(x + cw - FT.px(6), y - FT.py(10), FT.FONT.TINY, state, RenderText.ALIGN_RIGHT, fac.isOpen and FT.C.POSITIVE or FT.C.WARNING)
+            self.r:appText(x + FT.px(6), y - FT.py(10), FT.FONT.BODY,
+                FT_Renderer.truncate(name, 20), RenderText.ALIGN_LEFT, FT.C.TEXT_BRIGHT)
+            self.r:appText(x + cw - FT.px(6), y - FT.py(10), FT.FONT.TINY, state,
+                RenderText.ALIGN_RIGHT, fac.isOpen and FT.C.POSITIVE or FT.C.WARNING)
             local line = worker ~= "" and worker or (event ~= "" and event or ftAkitaText("ft_fws_no_event", "No event"))
-            self.r:appText(x + FT.px(10), y - FT.py(28), FT.FONT.TINY, line, RenderText.ALIGN_LEFT, event ~= "" and FT.C.WARNING or FT.C.TEXT_NORMAL)
+            self.r:appText(x + FT.px(10), y - FT.py(28), FT.FONT.TINY,
+                FT_Renderer.truncate(line, 40), RenderText.ALIGN_LEFT, event ~= "" and FT.C.WARNING or FT.C.TEXT_NORMAL)
             y = y - FT.py(58)
         end
     end

--- a/src/apps/AnimalHusbandryApp.lua
+++ b/src/apps/AnimalHusbandryApp.lua
@@ -35,8 +35,8 @@ FarmTabletUI:registerDrawer(FT.APP.ANIMALS, function(self)
     end
 
     local scrollY = self:getContentScrollY()
-    local y    = startY + scrollY
-    local minY = contentY + FT.py(8)
+    local y = startY + scrollY
+    local pad = FT.px(8)
 
     local function barColor(pct)
         if pct >= 60 then return FT.C.POSITIVE
@@ -44,52 +44,58 @@ FarmTabletUI:registerDrawer(FT.APP.ANIMALS, function(self)
         else return FT.C.NEGATIVE end
     end
 
+    -- One shared left edge for title, labels, and bars so rows line up.
+    -- Label left + percent right, bar on the next line (same pattern as Soil cards).
+    local function drawMetric(rowY, label, pct)
+        local p = math.max(0, math.min(100, tonumber(pct) or 0))
+        self.r:appText(x + pad, rowY, FT.FONT.TINY, label,
+            RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
+        self.r:appText(x + cw - pad, rowY, FT.FONT.TINY, string.format("%d%%", p),
+            RenderText.ALIGN_RIGHT, FT.C.TEXT_NORMAL)
+        local barY = rowY - FT.py(12)
+        self.r:progressBar(x + pad, barY, cw - pad * 2, p, 100, barColor(p))
+        return barY - FT.py(8)
+    end
+
     for _, pen in ipairs(pens) do
-        local cardH = FT.py(10)
-            + (pen.hasFood        and pen.foodPct  ~= nil and FT.py(24) or 0)
-            + (pen.hasWater       and pen.waterPct ~= nil and FT.py(24) or 0)
-            + (pen.hasCleanliness and pen.cleanPct ~= nil and FT.py(24) or 0)
-            + FT.py(18)
-        cardH = math.max(cardH, FT.py(30))
+        local metrics = {}
+        if pen.hasFood and pen.foodPct ~= nil then
+            metrics[#metrics + 1] = { label = FT.l10nAuto("FOOD"), pct = pen.foodPct }
+        end
+        if pen.hasWater and pen.waterPct ~= nil then
+            metrics[#metrics + 1] = { label = FT.l10nAuto("WATER"), pct = pen.waterPct }
+        end
+        if pen.hasCleanliness and pen.cleanPct ~= nil then
+            metrics[#metrics + 1] = { label = FT.l10nAuto("STRAW/CLEAN"), pct = pen.cleanPct }
+        end
 
-        self.r:appRect(x - FT.px(4), y - cardH, cw + FT.px(8), cardH, FT.C.BG_CARD)
+        local headerH = FT.py(22)
+        local metricH = #metrics * FT.py(20)
+        local cardH = headerH + metricH + FT.py(10)
+        if #metrics == 0 then cardH = FT.py(30) end
+        local cardBottom = y - cardH
 
-        local header = pen.typeName
+        self.r:appRect(x - FT.px(4), cardBottom, cw + FT.px(8), cardH, FT.C.BG_CARD)
+
+        local header = tostring(pen.typeName or FT.l10n("ft_auto_unknown", "Unknown"))
         if pen.numAnimals > 0 then
             header = header .. "  (" .. pen.numAnimals .. " / " .. pen.maxAnimals .. ")"
         else
             header = header .. "  (" .. FT.l10n("ft_common_empty_lower", "empty") .. ")"
         end
-        y = y - FT.py(4)
-        self.r:appText(x + FT.px(8), y, FT.FONT.BODY, header, RenderText.ALIGN_LEFT,
+        self.r:appText(x + pad, y - FT.py(6), FT.FONT.BODY, header, RenderText.ALIGN_LEFT,
             pen.numAnimals > 0 and FT.C.TEXT_BRIGHT or FT.C.TEXT_DIM)
-        y = y - FT.py(18)
 
-        if pen.hasFood and pen.foodPct ~= nil then
-            local pct = math.max(0, math.min(100, pen.foodPct))
-            self.r:appText(x + FT.px(8), y, FT.FONT.TINY,
-                FT.l10nFormat("ft_animals_food_pct", "FOOD  %d%%", pct), RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
-            y = y - FT.py(10)
-            y = self.r:progressBar(x + FT.px(4), y, cw - FT.px(8), pct, 100, barColor(pct))
+        local rowY = y - headerH
+        for _, m in ipairs(metrics) do
+            rowY = drawMetric(rowY, m.label, m.pct)
         end
-        if pen.hasWater and pen.waterPct ~= nil then
-            local pct = math.max(0, math.min(100, pen.waterPct))
-            self.r:appText(x + FT.px(8), y, FT.FONT.TINY,
-                FT.l10nFormat("ft_animals_water_pct", "WATER  %d%%", pct), RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
-            y = y - FT.py(10)
-            y = self.r:progressBar(x + FT.px(4), y, cw - FT.px(8), pct, 100, barColor(pct))
-        end
-        if pen.hasCleanliness and pen.cleanPct ~= nil then
-            local pct = math.max(0, math.min(100, pen.cleanPct))
-            self.r:appText(x + FT.px(8), y, FT.FONT.TINY,
-                FT.l10nFormat("ft_animals_straw_clean_pct", "STRAW/CLEAN  %d%%", pct), RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
-            y = y - FT.py(10)
-            y = self.r:progressBar(x + FT.px(4), y, cw - FT.px(8), pct, 100, barColor(pct))
-        end
-        y = y - FT.py(6)
+
+        -- Pin to pre-sized card bottom, then gap before the next pen.
+        y = cardBottom - FT.py(8)
     end
 
     self:setContentHeight(startY - y + scrollY)
     self:drawInfoIcon("_animalsHelp", AC)
     self:drawScrollBar()
-    end)
+end)

--- a/src/apps/AppStoreApp.lua
+++ b/src/apps/AppStoreApp.lua
@@ -106,12 +106,13 @@ function FarmTabletUI:_drawAppRow(y, app, dispName, x, cw, dimmed, known)
     self.r:appRect(x - FT.px(4), y - FT.py(8), cw + FT.px(8), FT.py(38),
         dimmed and {0.08, 0.09, 0.12, 0.50} or FT.C.BG_CARD)
 
-    -- App name
+    -- App name (keep clear of version / OPEN on the right)
     local nameColor = dimmed
         and {FT.C.TEXT_DIM[1], FT.C.TEXT_DIM[2], FT.C.TEXT_DIM[3], alpha}
         or FT.C.TEXT_BRIGHT
+    local nameMax = dimmed and 22 or 18
     self.r:appText(x + FT.px(10), y + FT.py(12), FT.FONT.BODY,
-        dispName, RenderText.ALIGN_LEFT, nameColor)
+        FT_Renderer.truncate(dispName, nameMax), RenderText.ALIGN_LEFT, nameColor)
 
     -- Description / hint
     local desc
@@ -130,12 +131,10 @@ function FarmTabletUI:_drawAppRow(y, app, dispName, x, cw, dimmed, known)
         desc, RenderText.ALIGN_LEFT,
         {FT.C.TEXT_DIM[1], FT.C.TEXT_DIM[2], FT.C.TEXT_DIM[3], alpha})
 
-    -- Version / developer (right side)
+    -- Version on the top-right; OPEN alone on the lower right (no developer clash).
     if app and not dimmed then
-        self.r:appText(x + cw - FT.px(58), y + FT.py(12), FT.FONT.TINY,
+        self.r:appText(x + cw - FT.px(8), y + FT.py(12), FT.FONT.TINY,
             FT.l10nAuto(app.version or "Built-in"), RenderText.ALIGN_RIGHT, FT.C.BRAND)
-        self.r:appText(x + cw - FT.px(58), y - FT.py(3), FT.FONT.TINY,
-            FT.l10nAuto(app.developer or ""), RenderText.ALIGN_RIGHT, FT.C.TEXT_DIM)
     elseif dimmed then
         self.r:appText(x + cw - FT.px(8), y + FT.py(12), FT.FONT.TINY,
             FT.l10nAuto("not installed"), RenderText.ALIGN_RIGHT,
@@ -145,7 +144,7 @@ function FarmTabletUI:_drawAppRow(y, app, dispName, x, cw, dimmed, known)
     -- OPEN button (only for installed apps)
     if app and not dimmed then
         local appId = app.id
-        local btn = self.r:button(x + cw - FT.px(48), y - FT.py(2), FT.px(44), FT.py(15),
+        local btn = self.r:button(x + cw - FT.px(48), y - FT.py(4), FT.px(44), FT.py(15),
             FT.l10nAuto("OPEN"), FT.C.BTN_PRIMARY, { onClick = function() self:switchApp(appId) end })
         table.insert(self._contentBtns, btn)
     end

--- a/src/apps/ContractsApp.lua
+++ b/src/apps/ContractsApp.lua
@@ -139,7 +139,6 @@ FarmTabletUI:registerDrawer(FT.APP.CONTRACTS, function(self)
     -- ── Contract card helper ──────────────────────────────
     local cardH  = FT.py(58)
     local padX   = FT.px(10)
-    local BADGE_W = FT.px(52)
 
     local function drawCard(mission, cardAccent, statusLabel, statusColor)
         local typeName   = getTypeName(mission)
@@ -168,16 +167,18 @@ FarmTabletUI:registerDrawer(FT.APP.CONTRACTS, function(self)
             FT.px(3), cardH,
             {cardAccent[1], cardAccent[2], cardAccent[3], 0.80})
 
-        -- Status badge (top-right corner)
-        self.r:appRect(x + cw - BADGE_W, y - FT.py(1), BADGE_W, FT.py(12),
+        -- Status badge (top-right); width follows the label so EXPIRING is not clipped.
+        local badgeW = math.max(FT.px(52), FT.px(8) + string.len(tostring(statusLabel or "")) * FT.px(5.2))
+        self.r:appRect(x + cw - badgeW, y - FT.py(1), badgeW, FT.py(12),
             {statusColor[1], statusColor[2], statusColor[3], 0.20})
-        self.r:appText(x + cw - BADGE_W / 2, y + FT.py(4),
+        self.r:appText(x + cw - badgeW / 2, y + FT.py(4),
             FT.FONT.TINY, statusLabel,
             RenderText.ALIGN_CENTER, statusColor)
 
-        -- Row 1: type name
+        -- Row 1: type name (keep clear of the status badge)
+        local typeMax = math.max(8, math.floor((cw - badgeW - padX - FT.px(8)) / FT.px(7)))
         self.r:appText(x + padX, y - FT.py(3),
-            FT.FONT.BODY, typeName,
+            FT.FONT.BODY, FT_Renderer.truncate(typeName, typeMax),
             RenderText.ALIGN_LEFT, {cardAccent[1], cardAccent[2], cardAccent[3], 1.00})
 
         -- Row 2: field / location

--- a/src/apps/DashboardApp.lua
+++ b/src/apps/DashboardApp.lua
@@ -272,7 +272,7 @@ function _dashDrawCustomize(self, settings, AC)
     local scrollY = self:getContentScrollY()
     local y = startY + scrollY - FT.py(2)
 
-    -- DONE button (top-right)
+    -- DONE button (top-right); tip sits on the row below so it cannot collide.
     local doneBW = FT.px(48)
     local doneBH = FT.py(20)
     local doneBtn = self.r:button(x + cw - doneBW, y, doneBW, doneBH,
@@ -283,11 +283,12 @@ function _dashDrawCustomize(self, settings, AC)
         end
     })
     table.insert(self._contentBtns, doneBtn)
+    y = y - doneBH - FT.py(4)
 
-    self.r:appText(x, y + FT.py(4), FT.FONT.TINY,
+    self.r:appText(x, y, FT.FONT.TINY,
         "Tap ON/OFF to show or hide each widget.",
         RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
-    y = y - FT.py(26)
+    y = y - FT.py(18)
 
     -- Widget rows, grouped by section
     local lastSection = ""

--- a/src/apps/FarmStatsApp.lua
+++ b/src/apps/FarmStatsApp.lua
@@ -117,7 +117,8 @@ FarmTabletUI:registerDrawer(FT.APP.FARM_STATS, function(self)
         y = self:drawRow(y, "World data", "unavailable", nil, FT.C.MUTED)
     end
 
-    self:setContentHeight(startY - y + scrollY)
+    -- Reserve room so the info icon does not sit on the Time value.
+    self:setContentHeight(startY - y + scrollY + FT.py(28))
     self:drawScrollBar()
     self:drawInfoIcon("_statsHelp", AC)
 end)

--- a/src/apps/FieldStatusApp.lua
+++ b/src/apps/FieldStatusApp.lua
@@ -86,7 +86,9 @@ FarmTabletUI:registerDrawer(FT.APP.FIELDS, function(self)
             self.r:appText(x + cw * 0.6, y, FT.FONT.SMALL,
                 string.format("%.1f", field.area), RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
         end
-        self.r:appText(x + cw, y, FT.FONT.SMALL, field.stateName, RenderText.ALIGN_RIGHT, field.stateColor or FT.C.MUTED)
+        -- Keep STATE clear of the HA column.
+        local stateDisp = FT_Renderer.truncate(field.stateName or "", 12)
+        self.r:appText(x + cw, y, FT.FONT.SMALL, stateDisp, RenderText.ALIGN_RIGHT, field.stateColor or FT.C.MUTED)
         y = y - rowH
     end
 

--- a/src/apps/FinancialCockpitApp.lua
+++ b/src/apps/FinancialCockpitApp.lua
@@ -858,7 +858,7 @@ local function _drawHeart(self, x, y, w, snap, AC)
     end
     if worstLabel ~= "" then
         self.r:appText(x + w - FT.px(10), y - FT.py(18), FT.FONT.TINY,
-            worstLabel, RenderText.ALIGN_RIGHT, FT.C.TEXT_DIM)
+            FT_Renderer.truncate(worstLabel, 18), RenderText.ALIGN_RIGHT, FT.C.TEXT_DIM)
     end
 
     _pocketBtn(self, x, y - h, w, h, "", {0, 0, 0, 0}, {
@@ -922,8 +922,9 @@ local function _drawHome(self, snap, AC)
         y = self:drawRow(y, _T("ft_fc_forecast_month_end", "Month-end outlook"),
             fc.monthEndProjected, nil, FT.C.TEXT_NORMAL)
     end
+    -- OPEN on its own row so it cannot cover the forecast values above.
     local fcBtnW = FT.px(72)
-    _pocketBtn(self, x + cw - fcBtnW, y + FT.py(2), fcBtnW, FT.py(16),
+    _pocketBtn(self, x + cw - fcBtnW, y - FT.py(2), fcBtnW, FT.py(16),
         _T("ft_fc_open", "OPEN"), FT.C.BTN_NEUTRAL, {
             onClick = function()
                 _view = "forecast"

--- a/src/apps/FinancialCockpitApp.lua
+++ b/src/apps/FinancialCockpitApp.lua
@@ -990,7 +990,7 @@ local function _drawHome(self, snap, AC)
     end
 
     local fBtnW = FT.px(72)
-    _pocketBtn(self, x + cw - fBtnW, y + FT.py(2), fBtnW, FT.py(16),
+    _pocketBtn(self, x + cw - fBtnW, y - FT.py(2), fBtnW, FT.py(16),
         _T("ft_fc_open", "OPEN"), FT.C.BTN_NEUTRAL, {
             onClick = function()
                 _view = "flows"

--- a/src/apps/FinancialCockpitApp.lua
+++ b/src/apps/FinancialCockpitApp.lua
@@ -951,7 +951,7 @@ local function _drawHome(self, snap, AC)
             nil, FT.C.TEXT_NORMAL)
     end
     local hBtnW = FT.px(72)
-    _pocketBtn(self, x + cw - hBtnW, y + FT.py(2), hBtnW, FT.py(16),
+    _pocketBtn(self, x + cw - hBtnW, y - FT.py(2), hBtnW, FT.py(16),
         _T("ft_fc_open", "OPEN"), FT.C.BTN_NEUTRAL, {
             onClick = function()
                 _view = "history"

--- a/src/apps/FleetManagerApp.lua
+++ b/src/apps/FleetManagerApp.lua
@@ -68,8 +68,9 @@ FarmTabletUI:registerDrawer(FT.APP.FLEET, function(self)
             {AC[1], AC[2], AC[3], 0.28})
 
         local nameColor = v.aiActive and FT.C.INFO or FT.C.TEXT_BRIGHT
+        local nameMax = v.aiActive and 20 or 26
         self.r:appText(x + FT.px(8), y - FT.py(11), FT.FONT.BODY,
-            tostring(v.name or "-"), RenderText.ALIGN_LEFT, nameColor)
+            FT_Renderer.truncate(tostring(v.name or "-"), nameMax), RenderText.ALIGN_LEFT, nameColor)
         if v.aiActive then
             self.r:appText(x + cw - FT.px(8), y - FT.py(11), FT.FONT.TINY,
                 ftFleetText("ft_ai_active_short", "HELFER"), RenderText.ALIGN_RIGHT, FT.C.INFO)
@@ -90,7 +91,8 @@ FarmTabletUI:registerDrawer(FT.APP.FLEET, function(self)
                 {fuelColor[1], fuelColor[2], fuelColor[3], 0.90})
         end
         self.r:appText(valueX, fuelY + FT.py(1), FT.FONT.TINY,
-            string.format("%d%%  %d/%d L", fuelPct, tonumber(v.fuelLitres) or 0, tonumber(v.fuelCap) or 0),
+            FT_Renderer.truncate(string.format("%d%%  %d/%d L",
+                fuelPct, tonumber(v.fuelLitres) or 0, tonumber(v.fuelCap) or 0), 16),
             RenderText.ALIGN_LEFT, fuelColor)
 
         local wearPct = tonumber(v.wearPct) or 0

--- a/src/apps/HotspotManagerApp.lua
+++ b/src/apps/HotspotManagerApp.lua
@@ -1,6 +1,6 @@
 -- =========================================================
 -- FarmTablet v2 – Hotspot Manager App
--- View and remove map hotspots/pins.
+-- View map hotspots/pins; multi-select remove; add pin at player.
 -- =========================================================
 
 -- ── Category labels ───────────────────────────────────────
@@ -39,22 +39,92 @@ local function hs_getIngameMap()
         and g_currentMission.hud.ingameMap
 end
 
+local function hs_hotspotKey(hs)
+    if hs == nil then return "?" end
+    local n = hs_getName(hs)
+    local x = tonumber(hs.worldX or hs.xMapPos) or 0
+    local z = tonumber(hs.worldZ or hs.zMapPos) or 0
+    return string.format("%s|%.1f|%.1f|%s", tostring(hs.category or ""), x, z, n)
+end
+
 -- Hotspot removal is a LOCAL client-side operation — it only affects this player's
 -- map view. Other players' maps and the server are not affected. System hotspots
 -- (shops, missions) will reappear on server re-sync; this is intentional.
 local function hs_removeHotspot(hotspot)
     local im = hs_getIngameMap()
-    if not im then return end
-    pcall(function()
-        im:removeMapHotspot(hotspot)
+    if not im then return false end
+    local ok = pcall(function()
+        if im.removeMapHotspot then
+            im:removeMapHotspot(hotspot)
+        elseif g_currentMission and g_currentMission.removeMapHotspot then
+            g_currentMission:removeMapHotspot(hotspot)
+        end
         if hotspot.delete then hotspot:delete() end
     end)
+    return ok == true
+end
+
+--- Add a custom pin at the local player's world position (client map only).
+local function hs_addPinAtPlayer()
+    local px, pz
+    if g_localPlayer and g_localPlayer.rootNode then
+        local ok, x, _, z = pcall(getWorldTranslation, g_localPlayer.rootNode)
+        if ok and x then px, pz = x, z end
+    end
+    if px == nil and g_currentMission and g_currentMission.player and g_currentMission.player.rootNode then
+        local ok, x, _, z = pcall(getWorldTranslation, g_currentMission.player.rootNode)
+        if ok and x then px, pz = x, z end
+    end
+    if px == nil then return false, "No player position" end
+
+    local hotspot = nil
+    local okCreate = pcall(function()
+        if PlaceableHotspot ~= nil and PlaceableHotspot.new then
+            hotspot = PlaceableHotspot.new()
+            if hotspot.setName then hotspot:setName("Farm Tablet pin") end
+            if hotspot.setWorldPosition then hotspot:setWorldPosition(px, pz) end
+            if PlaceableHotspot.TYPE and PlaceableHotspot.TYPE.EXCLAMATION_MARK then
+                hotspot.placeableType = PlaceableHotspot.TYPE.EXCLAMATION_MARK
+            end
+        elseif MapHotspot ~= nil and MapHotspot.new then
+            local cat = MapHotspot.CATEGORY_OTHER or MapHotspot.CATEGORY_DEFAULT
+            hotspot = MapHotspot.new("Farm Tablet pin", cat)
+            if hotspot.setWorldPosition then
+                hotspot:setWorldPosition(px, pz)
+            elseif hotspot.setPosition then
+                hotspot:setPosition(px, pz)
+            end
+            if hotspot.setText then hotspot:setText("Farm Tablet pin") end
+        end
+    end)
+    if not okCreate or hotspot == nil then
+        return false, "Hotspot API unavailable"
+    end
+
+    local okAdd = pcall(function()
+        local im = hs_getIngameMap()
+        if im and im.addMapHotspot then
+            im:addMapHotspot(hotspot)
+        elseif g_currentMission and g_currentMission.addMapHotspot then
+            g_currentMission:addMapHotspot(hotspot)
+        else
+            error("no addMapHotspot")
+        end
+    end)
+    if not okAdd then
+        pcall(function() if hotspot.delete then hotspot:delete() end end)
+        return false, "Could not add pin"
+    end
+    return true, nil
 end
 
 -- ── Module state ──────────────────────────────────────────
 
 local _confirmClear = false
 local _confirmTimer = 0
+local _selected = {}   -- [hotspotKey] = true
+local _statusMsg = nil
+local _statusTimer = 0
 
 -- ── Drawer ────────────────────────────────────────────────
 
@@ -64,10 +134,11 @@ FarmTabletUI:registerDrawer(FT.APP.HOTSPOT_MGR, function(self)
     if self:drawHelpPage("_hotspotHelp", FT.APP.HOTSPOT_MGR, "Hotspot Manager", AC, {
         { title = "WHAT IS THIS?",
           body  = "Shows all active map hotspots / pins.\n" ..
-                  "You can remove individual entries or clear all.\n\n" ..
-                  "Categories shown: Field, Shop, Mission, Vehicle,\n" ..
-                  "Player, etc. Removing system hotspots (Missions,\n" ..
-                  "Shops) may break game features — be careful." },
+                  "Tick the checkbox beside a pin, then REMOVE SELECTED.\n" ..
+                  "ADD PIN HERE drops a custom pin at your feet.\n\n" ..
+                  "Removing system hotspots (Missions, Shops) may break\n" ..
+                  "game features — be careful. System pins can return\n" ..
+                  "after a map re-sync." },
         { title = "CLEAR ALL",
           body  = "Press CLEAR ALL once — it turns red and asks\n" ..
                   "for confirmation. Press it again within 4 seconds\n" ..
@@ -78,85 +149,160 @@ FarmTabletUI:registerDrawer(FT.APP.HOTSPOT_MGR, function(self)
     local hotspots = im and im.hotspots or {}
     local total = #hotspots
 
-    -- Decay confirm timer
+    -- Decay confirm / status timers (approx frames)
     _confirmTimer = math.max(0, _confirmTimer - 1)
     if _confirmTimer == 0 then _confirmClear = false end
+    _statusTimer = math.max(0, _statusTimer - 1)
+    if _statusTimer == 0 then _statusMsg = nil end
+
+    -- Drop stale selection keys
+    local liveKeys = {}
+    for _, hs in ipairs(hotspots) do
+        liveKeys[hs_hotspotKey(hs)] = true
+    end
+    for k, _ in pairs(_selected) do
+        if not liveKeys[k] then _selected[k] = nil end
+    end
+
+    local selectedCount = 0
+    for _, v in pairs(_selected) do
+        if v then selectedCount = selectedCount + 1 end
+    end
 
     local startY = self:drawAppHeader("Hotspot Manager",
         total > 0 and (total .. " total") or "Empty")
     local x, cy, cw, ch = self:contentInner()
     local scrollY = self:getContentScrollY()
     local y = startY + scrollY
-    local BTN_H = FT.py(22)
+    local BTN_H = FT.py(20)
     local GAP   = FT.py(5)
+    local bottomPad = FT.py(28)
 
-    -- ── Clear All ─────────────────────────────────────────
+    -- ── Action row: ADD / REMOVE SELECTED / CLEAR ALL ─────
+    y = y - FT.py(2)
+    local gapX = FT.px(4)
+    local btnW = (cw - gapX * 2) / 3
+
+    local btnAdd = self.r:button(x, y - BTN_H, btnW, BTN_H, "ADD PIN HERE", FT.C.BTN_PRIMARY, {
+        onClick = function()
+            local ok, err = hs_addPinAtPlayer()
+            _statusMsg = ok and "Pin added at your position." or (err or "Add failed")
+            _statusTimer = 180
+        end
+    })
+    table.insert(self._contentBtns, btnAdd)
+
+    local rmLabel = selectedCount > 0
+        and string.format("REMOVE (%d)", selectedCount) or "REMOVE"
+    local rmColor = selectedCount > 0 and FT.C.BTN_DANGER or FT.C.BTN_NEUTRAL
+    local btnRmSel = self.r:button(x + btnW + gapX, y - BTN_H, btnW, BTN_H, rmLabel, rmColor, {
+        onClick = function()
+            if selectedCount == 0 then
+                _statusMsg = "Tick pins to remove first."
+                _statusTimer = 120
+                return
+            end
+            local toRemove = {}
+            for _, hs in ipairs(im.hotspots or {}) do
+                if _selected[hs_hotspotKey(hs)] then
+                    toRemove[#toRemove + 1] = hs
+                end
+            end
+            for _, hs in ipairs(toRemove) do
+                hs_removeHotspot(hs)
+                _selected[hs_hotspotKey(hs)] = nil
+            end
+            _statusMsg = string.format("Removed %d pin(s).", #toRemove)
+            _statusTimer = 180
+        end
+    })
+    table.insert(self._contentBtns, btnRmSel)
+
     if total > 0 then
-        y = y - FT.py(4)
         local clearLabel = _confirmClear
-            and string.format("CONFIRM CLEAR ALL (%d)", total)
-            or  string.format("CLEAR ALL (%d)", total)
+            and "CONFIRM CLEAR" or "CLEAR ALL"
         local clearColor = _confirmClear and FT.C.BTN_DANGER or FT.C.BTN_NEUTRAL
-        local btnClear = self.r:button(x, y - BTN_H, cw, BTN_H, clearLabel, clearColor, {
+        local btnClear = self.r:button(x + (btnW + gapX) * 2, y - BTN_H, btnW, BTN_H,
+            clearLabel, clearColor, {
             onClick = function()
                 if _confirmClear then
                     local toRemove = {}
                     for _, hs in ipairs(im.hotspots) do table.insert(toRemove, hs) end
                     for _, hs in ipairs(toRemove) do hs_removeHotspot(hs) end
+                    _selected = {}
                     _confirmClear = false
                     _confirmTimer = 0
+                    _statusMsg = "All pins cleared."
+                    _statusTimer = 180
                 else
                     _confirmClear = true
-                    _confirmTimer = 240  -- ~4 seconds at 60fps
+                    _confirmTimer = 240
                 end
             end
         })
         table.insert(self._contentBtns, btnClear)
-        y = y - BTN_H - FT.py(8)
+    end
+    y = y - BTN_H - FT.py(6)
+
+    if _statusMsg then
+        self.r:appText(x, y - FT.py(2), FT.FONT.TINY, _statusMsg,
+            RenderText.ALIGN_LEFT, FT.C.TEXT_ACCENT)
+        y = y - FT.py(14)
     end
 
-    -- ── Hotspot list ──────────────────────────────────────
+    -- ── Hotspot list with checkboxes ──────────────────────
     y = self:drawRule(y - FT.py(2), 0.3)
     y = y - FT.py(6)
-    y = self:drawSection(y, "HOTSPOTS")
+    y = self:drawSection(y, "HOTSPOTS  (tick to select)")
     y = y - GAP
 
     if total == 0 then
         self.r:appText(x + cw / 2, y - FT.py(12), FT.FONT.SMALL,
-            "No hotspots on the map", RenderText.ALIGN_CENTER, FT.C.TEXT_DIM)
+            "No hotspots on the map — use ADD PIN HERE.",
+            RenderText.ALIGN_CENTER, FT.C.TEXT_DIM)
         y = y - FT.py(24)
     else
-        local removeW = FT.px(28)
-        local catW    = FT.px(64)
-        local nameW   = cw - catW - removeW - FT.px(6)
+        local checkW = FT.px(22)
+        local catW   = FT.px(58)
+        local nameW  = cw - checkW - catW - FT.px(8)
+        local rowH   = FT.py(20)
 
         for i, hs in ipairs(hotspots) do
-            if y < cy + FT.py(4) then break end
+            if y < cy + bottomPad then break end
 
+            local key       = hs_hotspotKey(hs)
+            local checked   = _selected[key] == true
             local catLabel  = hs_getCategoryLabel(hs.category)
-            local nameLabel = hs_getName(hs)
-            if string.len(nameLabel) > 20 then
-                nameLabel = string.sub(nameLabel, 1, 19) .. "…"
-            end
+            local nameLabel = FT_Renderer.truncate(hs_getName(hs), 22)
 
-            self.r:appText(x, y - FT.py(5), FT.FONT.TINY,
-                catLabel, RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
-            self.r:appText(x + catW, y - FT.py(5), FT.FONT.SMALL,
-                nameLabel, RenderText.ALIGN_LEFT, FT.C.TEXT_NORMAL)
-
-            local capturedHs = hs
-            local btnRm = self.r:button(x + catW + nameW + FT.px(6), y - BTN_H, removeW, BTN_H,
-                "✕", FT.C.BTN_DANGER, {
-                onClick = function() hs_removeHotspot(capturedHs) end
+            -- Checkbox
+            local boxCol = checked and FT.C.BTN_PRIMARY or FT.C.BTN_NEUTRAL
+            -- ASCII marks only (engine font may not draw unicode ticks).
+            local mark   = checked and "x" or "-"
+            local capturedKey = key
+            local btnChk = self.r:button(x, y - rowH + FT.py(2), checkW, rowH - FT.py(2),
+                mark, boxCol, {
+                onClick = function()
+                    if _selected[capturedKey] then
+                        _selected[capturedKey] = nil
+                    else
+                        _selected[capturedKey] = true
+                    end
+                end
             })
-            table.insert(self._contentBtns, btnRm)
+            table.insert(self._contentBtns, btnChk)
 
-            y = y - BTN_H - GAP
+            self.r:appText(x + checkW + FT.px(4), y - FT.py(5), FT.FONT.TINY,
+                catLabel, RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
+            self.r:appText(x + checkW + catW, y - FT.py(5), FT.FONT.SMALL,
+                nameLabel, RenderText.ALIGN_LEFT,
+                checked and FT.C.TEXT_BRIGHT or FT.C.TEXT_NORMAL)
+
+            y = y - rowH - GAP
         end
     end
 
-    local contentStartY = startY
-    self:setContentHeight(contentStartY - y + scrollY)
-
+    self:setContentHeight(startY - y + scrollY + bottomPad)
     self:drawInfoIcon("_hotspotHelp", AC)
+    self:drawScrollBar()
 end)

--- a/src/apps/IncomeApp.lua
+++ b/src/apps/IncomeApp.lua
@@ -362,12 +362,14 @@ FarmTabletUI:registerDrawer(FT.APP.CROP_STRESS, function(self)
     if settings and settings.enabled ~= nil then
         local en   = settings.enabled
         local diff = settings.difficulty or "Normal"
+        -- Banner bottom is at y-22; leave clear air before FIELDS so DISABLED
+        -- never paints over the section header (same clash as Soil Fertilizer).
         self.r:appRect(x - FT.px(4), y - FT.py(22), cw + FT.px(8), FT.py(20),
             {accent[1]*0.10, accent[2]*0.10, accent[3]*0.10, 0.95})
         self.r:appText(x, y - FT.py(18), FT.FONT.SMALL,
             en and ("Active  |  Difficulty: " .. tostring(diff)) or "DISABLED",
             RenderText.ALIGN_LEFT, en and FT.C.POSITIVE or FT.C.WARNING)
-        y = y - FT.py(26)
+        y = y - FT.py(36)
     end
 
     if not moistureData and not stressData then
@@ -427,16 +429,23 @@ FarmTabletUI:registerDrawer(FT.APP.CROP_STRESS, function(self)
         local valStr = moistPct and string.format("%d%% moisture", moistPct) or "--"
         if stressPct > 5 then valStr = valStr .. "  !" .. stressPct .. "%" end
 
-        y = self:drawRow(y, label, valStr, nil, moistPct and moistColor or FT.C.TEXT_DIM)
+        -- Indent value off the right edge so it clears the scrollbar.
+        local xInner, _, wInner = self:contentInner()
+        self.r:appText(xInner + FT.px(14), y, FT.FONT.BODY, label,
+            RenderText.ALIGN_LEFT, FT.C.TEXT_NORMAL)
+        self.r:appText(xInner + wInner - FT.px(14), y, FT.FONT.BODY, valStr,
+            RenderText.ALIGN_RIGHT, moistPct and moistColor or FT.C.TEXT_DIM)
+        y = y - FT.py(FT.SP.ROW)
 
         if moistPct then
             y = y + FT.py(FT.SP.ROW) - FT.py(8)
-            y = self:drawBar(y, moistPct, 100, moistColor)
-            y = y - FT.py(2)
+            local barW = wInner - FT.px(12)
+            self.r:progressBar(xInner, y, barW, moistPct, 100, moistColor)
+            y = y - FT.py(10)
         end
     end
 
-    self:setContentHeight(startY - y + scrollY)
+    self:setContentHeight(startY - y + scrollY + FT.py(28))
     self:drawInfoIcon("_cropStressHelp", AC)
     self:drawScrollBar()
 end)

--- a/src/apps/IncomeApp.lua
+++ b/src/apps/IncomeApp.lua
@@ -251,8 +251,9 @@ FarmTabletUI:registerDrawer(FT.APP.NPC_FAVOR, function(self)
                     local hoursLeft = math.floor((f.timeRemaining or 0) / 3600000)
                     local pctColor  = f.progress >= 66 and FT.C.POSITIVE
                                    or f.progress >= 33 and FT.C.WARNING or FT.C.TEXT_DIM
-                    y = self:drawRow(y,
-                        (f.npcName or "?") .. "  " .. (f.description or f.type or ""),
+                    local left = FT_Renderer.truncate(
+                        (f.npcName or "?") .. "  " .. (f.description or f.type or ""), 28)
+                    y = self:drawRow(y, left,
                         string.format("%d%%  %dh left", math.floor(f.progress or 0), hoursLeft),
                         nil, pctColor)
                 end

--- a/src/apps/IrrigationSuiteApp.lua
+++ b/src/apps/IrrigationSuiteApp.lua
@@ -222,36 +222,42 @@ FarmTabletUI:registerDrawer(FT.APP.IRRIGATION_SUITE, function(self)
     local startY = self:drawAppHeader("Irrigation Suite", "")
     local x, cyBottom, cw, _ = self:contentInner()
     local scrollY = self:getContentScrollY()
-    local y = startY + scrollY
+    local bottomPad = FT.py(28)
 
     local scs = _scs()
     if scs == nil then
-        self.r:appText(x, y - FT.py(12), FT.FONT.BODY,
+        local yMiss = startY + scrollY
+        self.r:appText(x, yMiss - FT.py(12), FT.FONT.BODY,
             "Seasonal Crop Stress not detected.", RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
-        self.r:appText(x, y - FT.py(30), FT.FONT.SMALL,
+        self.r:appText(x, yMiss - FT.py(30), FT.FONT.SMALL,
             "Install FS25_SeasonalCropStress. This app stays hidden when absent.",
             RenderText.ALIGN_LEFT, FT.C.MUTED)
         self:drawInfoIcon("_irrigationSuiteHelp", AC)
         return
     end
 
-    -- Mode strip
+    -- Mode strip is FIXED (like Personnel tabs). Putting it at startY made the
+    -- labels sit above bodyClipTop so Operations / Forecast / Usage were clipped.
     local mode = self.system.irrigationSuiteMode or "operations"
     local btnW = (cw - FT.px(8)) / 3
-    local btnH = FT.py(20)
+    local btnH = FT.py(22)
+    local tabY = startY - btnH
     for i, m in ipairs(MODES) do
         local bx = x + (i - 1) * (btnW + FT.px(4))
         local selected = (mode == m)
-        local col = selected and AC or FT.C.BTN_NEUTRAL
+        local col = selected and { AC[1], AC[2], AC[3], 0.95 } or FT.C.BTN_NEUTRAL
         local captured = m
-        local btn = self.r:button(bx, y, btnW, btnH, MODE_LABEL[m], col, {
+        local btn = self.r:button(bx, tabY, btnW, btnH, MODE_LABEL[m], col, {
             onClick = function()
                 self.system.irrigationSuiteMode = captured
+                self._contentScrollY = 0
+                self._contentScrollTarget = 0
             end
         })
         table.insert(self._contentBtns, btn)
     end
-    y = y - btnH - FT.py(8)
+
+    local y = tabY - FT.py(10) + scrollY
     y = self:drawRule(y, 0.35)
 
     local systems = _pcall(function() return scs:getIrrigationSystems() end) or {}
@@ -302,8 +308,10 @@ FarmTabletUI:registerDrawer(FT.APP.IRRIGATION_SUITE, function(self)
             RenderText.ALIGN_LEFT, FT.C.TEXT_ACCENT)
         y = y - FT.py(14)
         local polyCache = _cacheCoveragePolys(scs, systems)
-        local mapH = FT.py(110)
-        _drawCoverageMap(self, x, y, cw, mapH, polyCache, AC)
+        -- Slightly shorter map so the moisture list stays inside the frame.
+        local mapH = FT.py(96)
+        local mapW = cw - FT.px(6)
+        _drawCoverageMap(self, x, y, mapW, mapH, polyCache, AC)
         y = y - mapH - FT.py(10)
 
         y = self:drawRule(y, 0.3)
@@ -327,16 +335,19 @@ FarmTabletUI:registerDrawer(FT.APP.IRRIGATION_SUITE, function(self)
                     break
                 end
                 local tag = irrigated and "watering" or "idle"
+                -- Keep % and bars clear of the scrollbar / frame edge.
+                local valueX = x + cw - FT.px(10)
+                local barW = cw - FT.px(12)
                 self.r:appText(x, y - FT.py(1), FT.FONT.SMALL,
                     string.format("Field #%s  %s", tostring(fid), tag),
                     RenderText.ALIGN_LEFT, FT.C.TEXT)
-                self.r:appText(x + cw, y - FT.py(1), FT.FONT.SMALL,
+                self.r:appText(valueX, y - FT.py(1), FT.FONT.SMALL,
                     moisture ~= nil and _pct(moisture) or "n/a",
                     RenderText.ALIGN_RIGHT, FT.C.TEXT_DIM)
                 y = y - FT.py(14)
                 if moisture ~= nil then
                     local barY = y
-                    self.r:progressBar(x, barY, cw, moisture, 1.0, AC)
+                    self.r:progressBar(x, barY, barW, moisture, 1.0, AC)
                     y = barY - FT.py(10)
                     self.r:appText(x, y - FT.py(1), FT.FONT.SMALL,
                         string.format("pivot ~%s   sky/other ~%s",
@@ -534,6 +545,7 @@ FarmTabletUI:registerDrawer(FT.APP.IRRIGATION_SUITE, function(self)
         end
     end
 
+    self:setContentHeight((tabY - FT.py(10)) - y + scrollY + bottomPad)
     self:drawInfoIcon("_irrigationSuiteHelp", AC)
-    self:setContentHeight(startY - y + scrollY + FT.py(12))
+    self:drawScrollBar()
 end)

--- a/src/apps/IrrigationSuiteApp.lua
+++ b/src/apps/IrrigationSuiteApp.lua
@@ -275,7 +275,8 @@ FarmTabletUI:registerDrawer(FT.APP.IRRIGATION_SUITE, function(self)
                 local scol = sys.isActive and FT.C.POSITIVE or FT.C.MUTED
                 local coverN = #(sys.coveredFields or {})
                 self.r:appText(x, y - FT.py(2), FT.FONT.BODY,
-                    string.format("#%s  %s", tostring(sys.id or "?"), tostring(sys.type or "system")),
+                    FT_Renderer.truncate(string.format("#%s  %s",
+                        tostring(sys.id or "?"), tostring(sys.type or "system")), 22),
                     RenderText.ALIGN_LEFT, FT.C.TEXT)
                 self.r:appText(x + cw, y - FT.py(2), FT.FONT.SMALL, state,
                     RenderText.ALIGN_RIGHT, scol)
@@ -332,11 +333,11 @@ FarmTabletUI:registerDrawer(FT.APP.IRRIGATION_SUITE, function(self)
                 self.r:appText(x + cw, y - FT.py(1), FT.FONT.SMALL,
                     moisture ~= nil and _pct(moisture) or "n/a",
                     RenderText.ALIGN_RIGHT, FT.C.TEXT_DIM)
-                y = y - FT.py(12)
+                y = y - FT.py(14)
                 if moisture ~= nil then
                     local barY = y
                     self.r:progressBar(x, barY, cw, moisture, 1.0, AC)
-                    y = y - FT.py(10)
+                    y = barY - FT.py(10)
                     self.r:appText(x, y - FT.py(1), FT.FONT.SMALL,
                         string.format("pivot ~%s   sky/other ~%s",
                             _pct(irrShare), _pct(rainShare)),

--- a/src/apps/MarketDynamicsApp.lua
+++ b/src/apps/MarketDynamicsApp.lua
@@ -150,7 +150,8 @@ FarmTabletUI:registerDrawer(FT.APP.MARKET_DYNAMICS, function(self)
         end
     end
 
-    self:setContentHeight(startY - y + scrollY)
+    -- Extra bottom pad so the last mover and the info icon do not clip.
+    self:setContentHeight(startY - y + scrollY + FT.py(28))
     self:drawInfoIcon("_mktHelp", AC)
     self:drawScrollBar()
 end)

--- a/src/apps/PersonnelApp.lua
+++ b/src/apps/PersonnelApp.lua
@@ -264,9 +264,12 @@ local function drawHire(self, snap, bodyTop, AC)
     local hireH  = FT.py(16)
     for _, r in ipairs(recruits) do
         if visBlock(y, blockH) then
-            self.r:appText(x, y, FT.FONT.SMALL, tostring(r.name or "Recruit"),
+            local nameMax = math.max(8, math.floor((cw - hireW - FT.px(80)) / FT.px(6.5)))
+            self.r:appText(x, y, FT.FONT.SMALL,
+                FT_Renderer.truncate(tostring(r.name or "Recruit"), nameMax),
                 RenderText.ALIGN_LEFT, FT.C.TEXT_BRIGHT)
-            self.r:appText(x + FT.px(96), y, FT.FONT.TINY, "[" .. (r.levelName or "Novice") .. "]",
+            self.r:appText(x + FT.px(96), y, FT.FONT.TINY,
+                FT_Renderer.truncate("[" .. (r.levelName or "Novice") .. "]", 12),
                 RenderText.ALIGN_LEFT, levelColor(r.level))
 
             local slot     = r.slot

--- a/src/apps/ProductionBuildingsApp.lua
+++ b/src/apps/ProductionBuildingsApp.lua
@@ -66,11 +66,7 @@ FarmTabletUI:registerDrawer(FT.APP.PRODUCTION, function(self)
         self.r:appRect(x - FT.px(4), y - cardH + FT.py(4), FT.px(3), cardH,
             {AC[1], AC[2], AC[3], 0.55})
 
-        -- ── Building name ─────────────────────────────────
-        self.r:appText(x + FT.px(10), y - FT.py(10), FT.FONT.SMALL,
-            b.name, RenderText.ALIGN_LEFT, FT.C.TEXT_BRIGHT)
-
-        -- Status badge (top-right)
+        -- Status badge (top-right) first so the name can reserve space.
         local isActive   = b.activeCount > 0
         local statusText = isActive
             and string.format(PText("ft_production_active_fmt", "%d/%d active"), b.activeCount, b.totalCount)
@@ -78,6 +74,11 @@ FarmTabletUI:registerDrawer(FT.APP.PRODUCTION, function(self)
         local statusColor = isActive and FT.C.POSITIVE or FT.C.WARNING
         self.r:appText(x + cw - FT.px(6), y - FT.py(10), FT.FONT.TINY,
             statusText, RenderText.ALIGN_RIGHT, statusColor)
+
+        -- ── Building name ─────────────────────────────────
+        local nameMax = math.max(10, math.floor((cw - FT.px(90)) / FT.px(6.5)))
+        self.r:appText(x + FT.px(10), y - FT.py(10), FT.FONT.SMALL,
+            FT_Renderer.truncate(b.name, nameMax), RenderText.ALIGN_LEFT, FT.C.TEXT_BRIGHT)
 
         -- Accent line below name
         self.r:appRect(x + FT.px(10), y - FT.py(18), cw - FT.px(20), FT.py(1),
@@ -96,9 +97,10 @@ FarmTabletUI:registerDrawer(FT.APP.PRODUCTION, function(self)
                 "-", RenderText.ALIGN_LEFT, FT.C.MUTED)
             ioY = ioY - FT.py(13)
         else
+            local fillMax = math.max(8, math.floor(colW / FT.px(6)))
             for _, inp in ipairs(b.inputs) do
                 self.r:appText(x + FT.px(14), ioY, FT.FONT.TINY,
-                    "- " .. inp, RenderText.ALIGN_LEFT, FT.C.TEXT_NORMAL)
+                    "- " .. FT_Renderer.truncate(inp, fillMax), RenderText.ALIGN_LEFT, FT.C.TEXT_NORMAL)
                 ioY = ioY - FT.py(13)
             end
         end
@@ -115,9 +117,10 @@ FarmTabletUI:registerDrawer(FT.APP.PRODUCTION, function(self)
             self.r:appText(outX + FT.px(4), outY, FT.FONT.TINY,
                 "-", RenderText.ALIGN_LEFT, FT.C.MUTED)
         else
+            local fillMax = math.max(8, math.floor(colW / FT.px(6)))
             for _, out2 in ipairs(b.outputs) do
                 self.r:appText(outX + FT.px(4), outY, FT.FONT.TINY,
-                    "- " .. out2, RenderText.ALIGN_LEFT,
+                    "- " .. FT_Renderer.truncate(out2, fillMax), RenderText.ALIGN_LEFT,
                     isActive and FT.C.POSITIVE or FT.C.TEXT_DIM)
                 outY = outY - FT.py(13)
             end

--- a/src/apps/RoleplayPhoneApp.lua
+++ b/src/apps/RoleplayPhoneApp.lua
@@ -96,21 +96,31 @@ local function initForm(self)
     }
 end
 
+-- Left label gutter so row titles never sit under ◄ / -1k steppers.
+local FORM_LABEL_W = nil
+local function _formLabelW()
+    if FORM_LABEL_W == nil then FORM_LABEL_W = FT.px(70) end
+    return FORM_LABEL_W
+end
+
 -- ── Cycler row helper ─────────────────────────────────────
 local function drawCycler(self, y, label, value, onChange)
     local x, _, w, _ = self:contentInner()
-
-    self.r:appText(x + FT.px(4), y - FT.py(9),
-        FT.FONT.TINY, label, RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
-    y = y - FT.py(13)
-
-    self.r:appRect(x - FT.px(4), y - FT.py(2), w + FT.px(8), FT.py(18), FT.C.BG_CARD)
-
-    local arrowW = FT.px(22)
+    local labelW = _formLabelW()
     local rowH   = FT.py(16)
     local appId  = FT.APP.ROLEPLAY_PHONE
 
-    local btnL = self.r:button(x, y, arrowW, rowH, "◄", FT.C.BTN_NEUTRAL, {
+    self.r:appRect(x - FT.px(4), y - FT.py(2), w + FT.px(8), FT.py(18), FT.C.BG_CARD)
+
+    -- Label in a reserved left column (not on top of the arrows).
+    self.r:appText(x + FT.px(4), y + FT.py(4),
+        FT.FONT.TINY, label, RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
+
+    local ctrlX = x + labelW
+    local ctrlW = w - labelW
+    local arrowW = FT.px(22)
+
+    local btnL = self.r:button(ctrlX, y, arrowW, rowH, "◄", FT.C.BTN_NEUTRAL, {
         onClick = function()
             onChange(-1)
             self:switchApp(appId)
@@ -118,14 +128,16 @@ local function drawCycler(self, y, label, value, onChange)
     })
     table.insert(self._contentBtns, btnL)
 
-    local valX = x + arrowW + FT.px(6)
-    local valW = w - arrowW * 2 - FT.px(12)
+    local valX = ctrlX + arrowW + FT.px(4)
+    local valW = ctrlW - arrowW * 2 - FT.px(8)
     local valStr = tostring(value)
-    if #valStr > 26 then valStr = valStr:sub(1, 24) .. "…" end
+    -- Keep long party / description names out of the arrow buttons.
+    local maxChars = math.max(10, math.floor(valW / FT.px(6.5)))
+    if #valStr > maxChars then valStr = valStr:sub(1, math.max(1, maxChars - 1)) .. "…" end
     self.r:appText(valX + valW * 0.5, y + FT.py(4),
-        FT.FONT.BODY, valStr, RenderText.ALIGN_CENTER, FT.C.TEXT_BRIGHT)
+        FT.FONT.SMALL, valStr, RenderText.ALIGN_CENTER, FT.C.TEXT_BRIGHT)
 
-    local btnR = self.r:button(x + w - arrowW, y, arrowW, rowH, "►", FT.C.BTN_NEUTRAL, {
+    local btnR = self.r:button(ctrlX + ctrlW - arrowW, y, arrowW, rowH, "►", FT.C.BTN_NEUTRAL, {
         onClick = function()
             onChange(1)
             self:switchApp(appId)
@@ -133,7 +145,7 @@ local function drawCycler(self, y, label, value, onChange)
     })
     table.insert(self._contentBtns, btnR)
 
-    return y - FT.py(20)
+    return y - FT.py(22)
 end
 
 -- ── Amount row ────────────────────────────────────────────
@@ -141,32 +153,42 @@ local function drawAmountRow(self, y, amount)
     local x, _, w, _ = self:contentInner()
     local data   = self.system.data
     local appId  = FT.APP.ROLEPLAY_PHONE
-
-    self.r:appText(x + FT.px(4), y - FT.py(9),
-        FT.FONT.TINY, "AMOUNT", RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
-    y = y - FT.py(13)
-
-    local stepW  = FT.px(30)
+    local labelW = _formLabelW()
     local rowH   = FT.py(16)
-    local steps  = { -1000, -100, -10, 10, 100, 1000 }
-    local labels = { "-1k", "-100", "-10", "+10", "+100", "+1k" }
 
     self.r:appRect(x - FT.px(4), y - FT.py(2), w + FT.px(8), FT.py(18), FT.C.BG_CARD)
 
+    self.r:appText(x + FT.px(4), y + FT.py(4),
+        FT.FONT.TINY, "AMOUNT", RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
+
+    local ctrlX = x + labelW
+    local ctrlW = w - labelW
+    -- Wide enough for "-100" / "+100" in SMALL font without spilling into the label.
+    local stepW  = FT.px(34)
+    local steps  = { -1000, -100, -10, 10, 100, 1000 }
+    local labels = { "-1k", "-100", "-10", "+10", "+100", "+1k" }
+
     local totalStepW = stepW * 3
-    local midX = x + totalStepW + FT.px(4)
-    local midW = w - totalStepW * 2 - FT.px(8)
+    local midX = ctrlX + totalStepW + FT.px(2)
+    local midW = ctrlW - totalStepW * 2 - FT.px(4)
+    if midW < FT.px(40) then
+        -- Narrow screens: shrink steppers so the money value still fits.
+        stepW = math.max(FT.px(28), math.floor((ctrlW - FT.px(44)) / 6))
+        totalStepW = stepW * 3
+        midX = ctrlX + totalStepW + FT.px(2)
+        midW = ctrlW - totalStepW * 2 - FT.px(4)
+    end
     self.r:appText(midX + midW * 0.5, y + FT.py(4),
-        FT.FONT.BODY, data:formatMoney(amount),
+        FT.FONT.SMALL, data:formatMoney(amount),
         RenderText.ALIGN_CENTER,
         amount > 0 and FT.C.TEXT_BRIGHT or FT.C.TEXT_DIM)
 
     for i, step in ipairs(steps) do
         local bx
         if i <= 3 then
-            bx = x + (i - 1) * stepW
+            bx = ctrlX + (i - 1) * stepW
         else
-            bx = x + w - (7 - i) * stepW
+            bx = ctrlX + ctrlW - (7 - i) * stepW
         end
         local stepVal = step
         local btn = self.r:button(bx, y, stepW - FT.px(2), rowH, labels[i], FT.C.BTN_NEUTRAL, {
@@ -178,7 +200,7 @@ local function drawAmountRow(self, y, amount)
         table.insert(self._contentBtns, btn)
     end
 
-    return y - FT.py(20)
+    return y - FT.py(22)
 end
 
 -- ── Invoice creation form (built-in / fallback mode only) ─
@@ -464,8 +486,11 @@ FarmTabletUI:registerDrawer(FT.APP.ROLEPLAY_PHONE, function(self)
 
             self.r:appRect(x - FT.px(4), y - FT.py(4), w + FT.px(8), cardH, FT.C.BG_CARD)
 
-            -- Line 1: party + badge
+            -- Line 1: party + badge (truncate party so it cannot run into PENDING/PAID)
             local party = (inv.party and inv.party ~= "") and inv.party or "Unknown"
+            local badgeReserve = FT.px(72)
+            local partyMax = math.max(8, math.floor((w - badgeReserve) / FT.px(7)))
+            if #party > partyMax then party = party:sub(1, math.max(1, partyMax - 1)) .. "…" end
             self.r:appText(x + FT.px(4), line1Y,
                 FT.FONT.BODY, party, RenderText.ALIGN_LEFT, FT.C.TEXT_BRIGHT)
             self.r:appText(x + w - FT.px(4), line1Y,
@@ -473,7 +498,9 @@ FarmTabletUI:registerDrawer(FT.APP.ROLEPLAY_PHONE, function(self)
 
             -- Line 2: description + amount
             local desc = inv.description or ""
-            if #desc > 38 then desc = desc:sub(1, 36) .. "…" end
+            local amtReserve = FT.px(70)
+            local descMax = math.max(10, math.floor((w - amtReserve) / FT.px(6)))
+            if #desc > descMax then desc = desc:sub(1, math.max(1, descMax - 1)) .. "…" end
             self.r:appText(x + FT.px(4), line2Y,
                 FT.FONT.SMALL, desc, RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
             self.r:appText(x + w - FT.px(4), line2Y,

--- a/src/apps/RotationPlannerApp.lua
+++ b/src/apps/RotationPlannerApp.lua
@@ -181,10 +181,12 @@ FarmTabletUI:registerDrawer(FT.APP.ROTATION_PLANNER, function(self)
                     { AC[1] * 0.12, AC[2] * 0.12, AC[3] * 0.12, 0.95 })
             end
 
-            local label = string.format("#%s  %s", tostring(field.id), line)
+            local bx = x + cw - btnW
+            local labelMax = math.max(10, math.floor((cw - btnW - FT.px(12)) / FT.px(6.5)))
+            local label = FT_Renderer.truncate(
+                string.format("#%s  %s", tostring(field.id), line), labelMax)
             self.r:appText(x, y - FT.py(2), FT.FONT.SMALL, label, RenderText.ALIGN_LEFT, col)
 
-            local bx = x + cw - btnW
             local by = y - FT.py(2)
             local btn = self.r:button(bx, by, btnW, btnH, isSel and "VIEW" or "SELECT", AC, {
                 onClick = function()

--- a/src/apps/SoilFertilizerApp.lua
+++ b/src/apps/SoilFertilizerApp.lua
@@ -128,15 +128,16 @@ FarmTabletUI:registerDrawer(FT.APP.FIELD_SENTRY, function(self)
             if i % 2 == 0 then
                 self.r:appRect(x - FT.px(4), y - FT.py(4), cw + FT.px(8), rowH, altBg)
             end
-            -- Status dot + field id + reason label.
+            -- Status dot + field id + reason (truncate before the SLEEP/MEADOW buttons).
             self.r:appRect(x + FT.px(2), y + FT.py(5), FT.px(6), FT.py(6), dotCol)
             self.r:appText(x + FT.px(14), y, FT.FONT.SMALL,
                 "#" .. tostring(field.id), RenderText.ALIGN_LEFT, FT.C.TEXT_NORMAL)
-            self.r:appText(x + FT.px(54), y, FT.FONT.SMALL, label, RenderText.ALIGN_LEFT, dotCol)
+            local reasonMax = math.max(6, math.floor((sleepX - x - FT.px(60)) / FT.px(6.5)))
+            local reasonTxt = FT_Renderer.truncate(label, reasonMax)
             if isMeadow then
-                self.r:appText(x + FT.px(54), y - FT.py(11), FT.FONT.TINY,
-                    "meadow", RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
+                reasonTxt = FT_Renderer.truncate(reasonTxt .. " · meadow", reasonMax)
             end
+            self.r:appText(x + FT.px(54), y, FT.FONT.SMALL, reasonTxt, RenderText.ALIGN_LEFT, dotCol)
 
             -- Sleep toggle (manual blacklist).
             local sleepCol = isManual and FT.C.WARNING or FT.C.BTN_NEUTRAL

--- a/src/apps/SoilNutrientApp.lua
+++ b/src/apps/SoilNutrientApp.lua
@@ -12,13 +12,37 @@ local PRESSURE_ACTION_THRESH = 20
 local OM_TARGET = 4.0
 local OM_MAX = 10.0
 
-local function _soilConstants()
-    return SoilConstants or getfenv(0)["SoilConstants"]
-end
-
 local function _manager()
     return (g_currentMission and g_currentMission.soilFertilityManager)
         or getfenv(0)["g_SoilFertilityManager"]
+end
+
+--- SoilConstants is owned by FS25_SoilFertilizer (often not in FT getfenv).
+--- Prefer the live manager / soilSystem attachment, then globals.
+local function _soilConstants()
+    local mgr = _manager()
+    if mgr ~= nil then
+        if mgr.SoilConstants ~= nil then return mgr.SoilConstants end
+        if mgr.soilSystem ~= nil and mgr.soilSystem.SoilConstants ~= nil then
+            return mgr.soilSystem.SoilConstants
+        end
+        if mgr.constants ~= nil then return mgr.constants end
+    end
+    if SoilConstants ~= nil then return SoilConstants end
+    local ok, sc = pcall(function() return getfenv(0)["SoilConstants"] end)
+    if ok and sc ~= nil then return sc end
+    return nil
+end
+
+--- Wider chip than Renderer:badge (fixed 36px clips "URGENT").
+local function _chip(self, x, y, label, color)
+    local text = tostring(label or "")
+    local w = math.max(FT.px(36), FT.px(8) + string.len(text) * FT.px(5.2))
+    local h = FT.py(14)
+    self.r:appRect(x, y - FT.py(1), w, h, color or FT.C.BRAND_DIM)
+    self.r:appText(x + w * 0.5, y + h * 0.5 - FT.py(3), FT.FONT.TINY, text,
+        RenderText.ALIGN_CENTER, FT.C.TEXT_BRIGHT)
+    return w
 end
 
 local function _pcall(fn, ...)
@@ -109,20 +133,21 @@ end
 
 --- Build TREATMENT rows mirroring SoilTreatmentDialog:_populateData.
 --- Disease uses discovery-gated shownDiseasePressure (nil = Unscouted).
+--- When SoilConstants is invisible from FT, still emit action text (no rates).
 local function _buildTreatments(info, SC, settings)
     local rows = {}
-    if info == nil or SC == nil then
-        return { { label = "—", text = "no data", color = FT.C.MUTED } }
+    if info == nil then
+        return { { label = "—", text = "No soil data", color = FT.C.MUTED } }
     end
 
-    local thresh = SC.STATUS_THRESHOLDS or {}
+    local thresh = (SC and SC.STATUS_THRESHOLDS) or {}
     local nT = thresh.nitrogen or { poor = 30, fair = 50 }
     local pT = thresh.phosphorus or { poor = 25, fair = 40 }
     local kT = thresh.potassium or { poor = 20, fair = 40 }
     local fieldArea = info.fieldArea or 1.0
     local rrIdx = (settings and settings.replenishmentRate) or 3
     local rrMult = 1.0
-    if SC.DIFFICULTY and SC.DIFFICULTY.REPLENISHMENT_MULTIPLIERS then
+    if SC and SC.DIFFICULTY and SC.DIFFICULTY.REPLENISHMENT_MULTIPLIERS then
         rrMult = SC.DIFFICULTY.REPLENISHMENT_MULTIPLIERS[rrIdx] or 1.0
     end
     local ct = info.cropTargets
@@ -130,112 +155,91 @@ local function _buildTreatments(info, SC, settings)
     local targetP = (ct and ct.P and ct.P.opt) or (pT.fair or 40)
     local targetK = (ct and ct.K and ct.K.opt) or (kT.fair or 40)
 
+    local function add(label, text, color)
+        rows[#rows + 1] = { label = label, text = text, color = color }
+    end
+
     local ph = math.floor(((info.pH or 7.0) * 10) + 0.5) / 10
     if ph < 6.5 then
-        rows[#rows + 1] = { label = "pH", text = "Apply LIME or LIQUID LIME to raise pH.", color = FT.C.NEGATIVE }
+        add("pH", "Apply LIME or LIQUID LIME to raise pH.", FT.C.NEGATIVE)
     elseif ph > 7.5 then
-        rows[#rows + 1] = { label = "pH", text = "Apply GYPSUM to lower pH / improve structure.", color = FT.C.WARNING }
-    else
-        rows[#rows + 1] = { label = "pH", text = "OK", color = FT.C.POSITIVE }
+        add("pH", "Apply GYPSUM to lower pH / improve structure.", FT.C.WARNING)
     end
 
     local om = info.organicMatter or 3.5
     if om < 3.0 then
-        rows[#rows + 1] = { label = "OM", text = "Plow in MANURE, COMPOST, or chop straw.", color = FT.C.NEGATIVE }
+        add("OM", "Plow in MANURE, COMPOST, or chop straw.", FT.C.NEGATIVE)
     elseif om < 4.0 then
-        rows[#rows + 1] = { label = "OM", text = "Monitor. Maintain organic inputs.", color = FT.C.WARNING }
-    else
-        rows[#rows + 1] = { label = "OM", text = "OK", color = FT.C.POSITIVE }
+        add("OM", "Monitor. Maintain organic inputs.", FT.C.WARNING)
     end
 
     local nVal = info.nitrogen and info.nitrogen.value or 0
     if nVal < (nT.poor or 30) then
-        rows[#rows + 1] = {
-            label = "N",
-            text = _nutrientActionText(SC, nVal, targetN, rrMult, fieldArea,
-                { { "UREA", "N" }, { "UAN32", "N" } }, "Apply UREA or UAN32"),
-            color = FT.C.NEGATIVE,
-        }
+        add("N", _nutrientActionText(SC, nVal, targetN, rrMult, fieldArea,
+            { { "UREA", "N" }, { "UAN32", "N" } }, "Apply UREA or UAN32"), FT.C.NEGATIVE)
     elseif nVal < (nT.fair or 50) then
-        rows[#rows + 1] = {
-            label = "N",
-            text = _nutrientActionText(SC, nVal, targetN, rrMult, fieldArea,
-                { { "AMS", "N" }, { "AN", "N" } }, "Apply AMS or AN"),
-            color = FT.C.WARNING,
-        }
-    else
-        rows[#rows + 1] = { label = "N", text = "OK", color = FT.C.POSITIVE }
+        add("N", _nutrientActionText(SC, nVal, targetN, rrMult, fieldArea,
+            { { "AMS", "N" }, { "AN", "N" } }, "Apply AMS or AN"), FT.C.WARNING)
     end
 
     local pVal = info.phosphorus and info.phosphorus.value or 0
     if pVal < (pT.poor or 25) then
-        rows[#rows + 1] = {
-            label = "P",
-            text = _nutrientActionText(SC, pVal, targetP, rrMult, fieldArea,
-                { { "MAP", "P" }, { "DAP", "P" } }, "Apply MAP or DAP"),
-            color = FT.C.NEGATIVE,
-        }
+        add("P", _nutrientActionText(SC, pVal, targetP, rrMult, fieldArea,
+            { { "MAP", "P" }, { "DAP", "P" } }, "Apply MAP or DAP"), FT.C.NEGATIVE)
     elseif pVal < (pT.fair or 40) then
-        rows[#rows + 1] = {
-            label = "P",
-            text = _nutrientActionText(SC, pVal, targetP, rrMult, fieldArea,
-                { { "LIQUID_MAP", "P" }, { "LIQUID_DAP", "P" } }, "Top-up with Liquid MAP or Liquid DAP"),
-            color = FT.C.WARNING,
-        }
-    else
-        rows[#rows + 1] = { label = "P", text = "OK", color = FT.C.POSITIVE }
+        add("P", _nutrientActionText(SC, pVal, targetP, rrMult, fieldArea,
+            { { "LIQUID_MAP", "P" }, { "LIQUID_DAP", "P" } }, "Top-up with Liquid MAP / DAP"), FT.C.WARNING)
     end
 
     local kVal = info.potassium and info.potassium.value or 0
     if kVal < (kT.poor or 20) then
-        rows[#rows + 1] = {
-            label = "K",
-            text = _nutrientActionText(SC, kVal, targetK, rrMult, fieldArea,
-                { { "POTASH", "K" }, { "LIQUID_POTASH", "K" } }, "Apply POTASH"),
-            color = FT.C.NEGATIVE,
-        }
+        add("K", _nutrientActionText(SC, kVal, targetK, rrMult, fieldArea,
+            { { "POTASH", "K" }, { "LIQUID_POTASH", "K" } }, "Apply POTASH"), FT.C.NEGATIVE)
     elseif kVal < (kT.fair or 40) then
-        rows[#rows + 1] = {
-            label = "K",
-            text = _nutrientActionText(SC, kVal, targetK, rrMult, fieldArea,
-                { { "POTASH", "K" }, { "LIQUID_POTASH", "K" } }, "Top-up with POTASH or Liquid POTASH"),
-            color = FT.C.WARNING,
-        }
-    else
-        rows[#rows + 1] = { label = "K", text = "OK", color = FT.C.POSITIVE }
+        add("K", _nutrientActionText(SC, kVal, targetK, rrMult, fieldArea,
+            { { "POTASH", "K" }, { "LIQUID_POTASH", "K" } }, "Top-up with POTASH"), FT.C.WARNING)
     end
 
     if (info.weedPressure or 0) >= PRESSURE_ACTION_THRESH then
-        rows[#rows + 1] = { label = "Weed", text = "Apply HERBICIDE or use mechanical WEEDER/HOE.", color = FT.C.NEGATIVE }
-    else
-        rows[#rows + 1] = { label = "Weed", text = "OK", color = FT.C.POSITIVE }
+        add("Weed", "Apply HERBICIDE or use WEEDER/HOE.", FT.C.NEGATIVE)
     end
-
     if (info.pestPressure or 0) >= PRESSURE_ACTION_THRESH then
-        rows[#rows + 1] = { label = "Pest", text = "Apply INSECTICIDE immediately.", color = FT.C.NEGATIVE }
-    else
-        rows[#rows + 1] = { label = "Pest", text = "OK", color = FT.C.POSITIVE }
+        add("Pest", "Apply INSECTICIDE immediately.", FT.C.NEGATIVE)
     end
 
     local shownD = info.shownDiseasePressure
     if shownD == nil then
-        rows[#rows + 1] = { label = "Disease", text = "Unscouted", color = FT.C.MUTED }
+        add("Disease", "Unscouted — scout before treating.", FT.C.MUTED)
     elseif shownD >= PRESSURE_ACTION_THRESH then
-        rows[#rows + 1] = { label = "Disease", text = "Apply FUNGICIDE immediately.", color = FT.C.NEGATIVE }
-    else
-        rows[#rows + 1] = { label = "Disease", text = "OK", color = FT.C.POSITIVE }
+        add("Disease", "Apply FUNGICIDE immediately.", FT.C.NEGATIVE)
     end
 
+    if #rows == 0 then
+        add("—", "All clear — no treatment needed.", FT.C.POSITIVE)
+    end
     return rows
 end
 
+--- Label + value on one line; bar on the next. Returns new y (below bar).
 local function _drawMetricBar(self, x, y, cw, label, valueText, ratio, color)
-    self.r:appText(x + FT.px(8), y, FT.FONT.TINY, label, RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
-    self.r:appText(x + cw - FT.px(8), y, FT.FONT.TINY, valueText, RenderText.ALIGN_RIGHT, FT.C.TEXT_NORMAL)
-    y = y - FT.py(11)
-    local barW = cw - FT.px(16)
-    self.r:progressBar(x + FT.px(8), y, barW, math.max(0, math.min(1, ratio or 0)), 1.0, color)
-    return y - FT.py(10)
+    local rowTop = y
+    self.r:appText(x + FT.px(6), rowTop, FT.FONT.TINY, label,
+        RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
+    self.r:appText(x + cw - FT.px(6), rowTop, FT.FONT.TINY, valueText,
+        RenderText.ALIGN_RIGHT, FT.C.TEXT_NORMAL)
+    -- Drop clearly below the label before painting the track (avoids overlap).
+    local barY = rowTop - FT.py(12)
+    local barW = cw - FT.px(12)
+    local fill = math.max(0, math.min(1, tonumber(ratio) or 0))
+    self.r:progressBar(x + FT.px(6), barY, barW, fill, 1.0, color)
+    -- progressBar bottom is barY; height ~5px upward. Advance past it + gap.
+    return barY - FT.py(8)
+end
+
+local function _truncate(str, maxLen)
+    str = tostring(str or "")
+    if #str <= maxLen then return str end
+    return str:sub(1, math.max(1, maxLen - 1)) .. "…"
 end
 
 FarmTabletUI:registerDrawer(FT.APP.SOIL_FERT, function(self)
@@ -355,34 +359,50 @@ FarmTabletUI:registerDrawer(FT.APP.SOIL_FERT, function(self)
     for _, card in ipairs(cache.cards) do
         local info = card.info
         local uCol = _urgencyColor(card.urgency)
-        local cardTop = y
-        local pad = FT.px(6)
+        local pad = FT.px(8)
         local innerX = x + pad
         local innerW = cw - pad * 2
+        local treats = (info ~= nil) and _buildTreatments(info, SC, settings) or {}
 
-        -- Estimate height for background (header + 8 bars + treatment block).
-        local estH = FT.py(300)
-        self.r:appRect(x - FT.px(2), y - estH + FT.py(4), cw + FT.px(4), estH, FT.C.BG_CARD)
-        self.r:appRect(x - FT.px(2), y - estH + FT.py(4), FT.px(3), estH, uCol)
+        -- Size the card from real content so fields never paint over each other.
+        local metricRows = (info ~= nil) and 8 or 0
+        local metricH = metricRows * FT.py(20)
+        local headerH = FT.py(36)
+        local treatH = 0
+        if info ~= nil then
+            treatH = FT.py(16) + math.max(1, #treats) * FT.py(13)
+        else
+            treatH = FT.py(18)
+        end
+        local cardH = headerH + metricH + treatH + FT.py(14)
+        local cardBottom = y - cardH
 
-        -- Header
-        self.r:appText(innerX, y - FT.py(2), FT.FONT.SMALL,
-            string.format("Field #%s  ·  %s", tostring(card.id), tostring(card.crop)),
+        self.r:appRect(x - FT.px(2), cardBottom, cw + FT.px(4), cardH, FT.C.BG_CARD)
+        self.r:appRect(x - FT.px(2), cardBottom, FT.px(3), cardH, uCol)
+
+        -- Header: title left, area right (crop truncated so it cannot collide).
+        local crop = _truncate(card.crop, 14)
+        self.r:appText(innerX, y - FT.py(4), FT.FONT.SMALL,
+            string.format("Field #%s  ·  %s", tostring(card.id), crop),
             RenderText.ALIGN_LEFT, FT.C.TEXT_BRIGHT)
         local haTxt = (card.area and card.area > 0) and string.format("%.1f ha", card.area) or ""
-        self.r:appText(x + cw - FT.px(4), y - FT.py(2), FT.FONT.TINY,
-            haTxt, RenderText.ALIGN_RIGHT, FT.C.TEXT_DIM)
-        y = y - FT.py(14)
-        local badgeW = self.r:badge(innerX, y, _urgencyLabel(card.urgency), uCol)
-        if info and info.needsFertilization then
-            self.r:badge(innerX + badgeW + FT.px(4), y, "FERT", FT.C.WARNING)
+        if haTxt ~= "" then
+            self.r:appText(x + cw - FT.px(6), y - FT.py(4), FT.FONT.TINY,
+                haTxt, RenderText.ALIGN_RIGHT, FT.C.TEXT_DIM)
         end
         y = y - FT.py(16)
+
+        local bx = innerX
+        bx = bx + _chip(self, bx, y, _urgencyLabel(card.urgency), uCol) + FT.px(5)
+        if info and info.needsFertilization then
+            bx = bx + _chip(self, bx, y, "FERT", FT.C.WARNING) + FT.px(5)
+        end
+        y = y - FT.py(18)
 
         if info == nil then
             self.r:appText(innerX, y, FT.FONT.SMALL, "No soil data for this field.",
                 RenderText.ALIGN_LEFT, FT.C.MUTED)
-            y = y - FT.py(18)
+            y = y - FT.py(16)
         else
             local ct = info.cropTargets
             local thresh = (SC and SC.STATUS_THRESHOLDS) or {}
@@ -409,7 +429,8 @@ FarmTabletUI:registerDrawer(FT.APP.SOIL_FERT, function(self)
 
             local ph = info.pH or 7.0
             local phRatio = 1.0 - math.min(1.0, math.abs(ph - phOpt) / 2.0)
-            local phCol = (ph >= 6.0 and ph <= 7.5) and FT.C.POSITIVE or FT.C.WARNING
+            local phCol = (ph >= 6.0 and ph <= 7.5) and FT.C.POSITIVE
+                or ((ph >= 5.5 and ph <= 8.0) and FT.C.WARNING or FT.C.NEGATIVE)
             y = _drawMetricBar(self, innerX, y, innerW, "pH",
                 string.format("%.1f / %.1f", ph, phOpt), phRatio, phCol)
 
@@ -438,25 +459,22 @@ FarmTabletUI:registerDrawer(FT.APP.SOIL_FERT, function(self)
                     shownD / 100, _barColor(shownD / 100, true))
             end
 
-            self.r:appText(innerX, y, FT.FONT.TINY, "TREATMENT", RenderText.ALIGN_LEFT, FT.C.TEXT_ACCENT)
-            y = y - FT.py(12)
-            local treats = _buildTreatments(info, SC, settings)
+            y = y - FT.py(4)
+            self.r:appText(innerX, y, FT.FONT.TINY, "TREATMENT",
+                RenderText.ALIGN_LEFT, FT.C.TEXT_ACCENT)
+            y = y - FT.py(13)
             for _, row in ipairs(treats) do
-                self.r:appText(innerX, y, FT.FONT.TINY, row.label, RenderText.ALIGN_LEFT, row.color or FT.C.TEXT_DIM)
-                local txt = tostring(row.text or "")
-                if #txt > 42 then txt = txt:sub(1, 40) .. "…" end
-                self.r:appText(innerX + FT.px(44), y, FT.FONT.TINY, txt,
+                self.r:appText(innerX, y, FT.FONT.TINY, row.label,
+                    RenderText.ALIGN_LEFT, row.color or FT.C.TEXT_DIM)
+                local txt = _truncate(row.text, 38)
+                self.r:appText(innerX + FT.px(48), y, FT.FONT.TINY, txt,
                     RenderText.ALIGN_LEFT, FT.C.TEXT_NORMAL)
-                y = y - FT.py(11)
+                y = y - FT.py(13)
             end
         end
 
-        -- Tighten leftover estimated card padding.
-        local used = cardTop - y
-        if used < estH - FT.py(8) then
-            -- leave the oversized BG; spacing below card
-        end
-        y = y - FT.py(10)
+        -- Pin cursor to the pre-sized card bottom, then gap before the next card.
+        y = cardBottom - FT.py(10)
     end
 
     self:setContentHeight(startY - y + scrollY)

--- a/src/apps/SoilNutrientApp.lua
+++ b/src/apps/SoilNutrientApp.lua
@@ -173,30 +173,36 @@ local function _buildTreatments(info, SC, settings)
         add("OM", "Monitor. Maintain organic inputs.", FT.C.WARNING)
     end
 
+    -- Match the bars above: treat against crop target (fallback = fair threshold).
     local nVal = info.nitrogen and info.nitrogen.value or 0
-    if nVal < (nT.poor or 30) then
-        add("N", _nutrientActionText(SC, nVal, targetN, rrMult, fieldArea,
+    local nNeed = targetN or (nT.fair or 50)
+    if nVal < nNeed * 0.60 then
+        add("N", _nutrientActionText(SC, nVal, nNeed, rrMult, fieldArea,
             { { "UREA", "N" }, { "UAN32", "N" } }, "Apply UREA or UAN32"), FT.C.NEGATIVE)
-    elseif nVal < (nT.fair or 50) then
-        add("N", _nutrientActionText(SC, nVal, targetN, rrMult, fieldArea,
+    elseif nVal < nNeed then
+        add("N", _nutrientActionText(SC, nVal, nNeed, rrMult, fieldArea,
             { { "AMS", "N" }, { "AN", "N" } }, "Apply AMS or AN"), FT.C.WARNING)
     end
 
     local pVal = info.phosphorus and info.phosphorus.value or 0
-    if pVal < (pT.poor or 25) then
-        add("P", _nutrientActionText(SC, pVal, targetP, rrMult, fieldArea,
+    local pNeed = targetP or (pT.fair or 40)
+    if pVal < pNeed * 0.60 then
+        add("P", _nutrientActionText(SC, pVal, pNeed, rrMult, fieldArea,
             { { "MAP", "P" }, { "DAP", "P" } }, "Apply MAP or DAP"), FT.C.NEGATIVE)
-    elseif pVal < (pT.fair or 40) then
-        add("P", _nutrientActionText(SC, pVal, targetP, rrMult, fieldArea,
+    elseif pVal < pNeed then
+        add("P", _nutrientActionText(SC, pVal, pNeed, rrMult, fieldArea,
             { { "LIQUID_MAP", "P" }, { "LIQUID_DAP", "P" } }, "Top-up with Liquid MAP / DAP"), FT.C.WARNING)
+    elseif pVal > pNeed * 1.15 then
+        add("P", "Above target - skip P product this pass.", FT.C.WARNING)
     end
 
     local kVal = info.potassium and info.potassium.value or 0
-    if kVal < (kT.poor or 20) then
-        add("K", _nutrientActionText(SC, kVal, targetK, rrMult, fieldArea,
+    local kNeed = targetK or (kT.fair or 40)
+    if kVal < kNeed * 0.60 then
+        add("K", _nutrientActionText(SC, kVal, kNeed, rrMult, fieldArea,
             { { "POTASH", "K" }, { "LIQUID_POTASH", "K" } }, "Apply POTASH"), FT.C.NEGATIVE)
-    elseif kVal < (kT.fair or 40) then
-        add("K", _nutrientActionText(SC, kVal, targetK, rrMult, fieldArea,
+    elseif kVal < kNeed then
+        add("K", _nutrientActionText(SC, kVal, kNeed, rrMult, fieldArea,
             { { "POTASH", "K" }, { "LIQUID_POTASH", "K" } }, "Top-up with POTASH"), FT.C.WARNING)
     end
 
@@ -294,15 +300,17 @@ FarmTabletUI:registerDrawer(FT.APP.SOIL_FERT, function(self)
 
     if settings then
         local en = settings.enabled ~= false
+        -- Banner bottom is at y-22; leave clear air before FIELDS so Active
+        -- never paints on top of the section header.
         self.r:appRect(x - FT.px(4), y - FT.py(22), cw + FT.px(8), FT.py(20),
             { AC[1] * 0.10, AC[2] * 0.10, AC[3] * 0.10, 0.95 })
         self.r:appText(x, y - FT.py(18), FT.FONT.SMALL,
             en and "Active" or "DISABLED", RenderText.ALIGN_LEFT, en and FT.C.POSITIVE or FT.C.WARNING)
         if soilSys.PFActive then
-            self.r:appText(x + cw, y - FT.py(18), FT.FONT.TINY,
+            self.r:appText(x + cw - FT.px(8), y - FT.py(18), FT.FONT.TINY,
                 "PF DLC active", RenderText.ALIGN_RIGHT, FT.C.INFO)
         end
-        y = y - FT.py(26)
+        y = y - FT.py(36)
     end
 
     local farmId = self.system.data:getPlayerFarmId()
@@ -460,16 +468,23 @@ FarmTabletUI:registerDrawer(FT.APP.SOIL_FERT, function(self)
             end
 
             y = y - FT.py(4)
-            self.r:appText(innerX, y, FT.FONT.TINY, "TREATMENT",
+            self.r:appText(innerX, y, FT.FONT.TINY, "TREATMENT PLAN",
                 RenderText.ALIGN_LEFT, FT.C.TEXT_ACCENT)
             y = y - FT.py(13)
-            for _, row in ipairs(treats) do
-                self.r:appText(innerX, y, FT.FONT.TINY, row.label,
-                    RenderText.ALIGN_LEFT, row.color or FT.C.TEXT_DIM)
-                local txt = _truncate(row.text, 38)
-                self.r:appText(innerX + FT.px(48), y, FT.FONT.TINY, txt,
-                    RenderText.ALIGN_LEFT, FT.C.TEXT_NORMAL)
+            if #treats == 0 then
+                self.r:appText(innerX, y, FT.FONT.TINY,
+                    "No actions — levels look fine.",
+                    RenderText.ALIGN_LEFT, FT.C.POSITIVE)
                 y = y - FT.py(13)
+            else
+                for _, row in ipairs(treats) do
+                    self.r:appText(innerX, y, FT.FONT.TINY, row.label,
+                        RenderText.ALIGN_LEFT, row.color or FT.C.TEXT_DIM)
+                    local txt = _truncate(row.text, 42)
+                    self.r:appText(innerX + FT.px(52), y, FT.FONT.TINY, txt,
+                        RenderText.ALIGN_LEFT, FT.C.TEXT_NORMAL)
+                    y = y - FT.py(13)
+                end
             end
         end
 
@@ -477,7 +492,7 @@ FarmTabletUI:registerDrawer(FT.APP.SOIL_FERT, function(self)
         y = cardBottom - FT.py(10)
     end
 
-    self:setContentHeight(startY - y + scrollY)
+    self:setContentHeight(startY - y + scrollY + FT.py(28))
     self:drawInfoIcon("_soilHelp", AC)
     self:drawScrollBar()
 end)

--- a/src/apps/SystemSettingsApp.lua
+++ b/src/apps/SystemSettingsApp.lua
@@ -42,7 +42,9 @@ FarmTabletUI:registerDrawer(FT.APP.SYSTEM_SETTINGS, function(self)
                   "own and stay on this machine." },
         { title = "EDITING",
           body  = "This overview is read-only for now. Change values\n" ..
-                  "from each mod's own settings for the moment." },
+                  "from each mod's own settings for the moment.\n" ..
+                  "Making this page editable is proposed and waiting\n" ..
+                  "on Tyson before we build it." },
     }) then return end
 
     local startY = self:drawAppHeader("System Settings", "Settings Hub")

--- a/src/apps/UsedPlusApp.lua
+++ b/src/apps/UsedPlusApp.lua
@@ -65,7 +65,8 @@ FarmTabletUI:registerDrawer(FT.APP.USED_PLUS, function(self)
         self.r:appText(x + w - FT.px(8), y - FT.py(17),
             FT.FONT.BODY, tostring(score) .. (rating ~= "" and ("  " .. rating) or ""),
             RenderText.ALIGN_RIGHT, scoreColor)
-        y = y - FT.py(4)
+        -- Clear gap so CREDIT does not sit inside the next section header.
+        y = y - FT.py(28)
     end
 
     -- ── Active sale listings ───────────────────────────────
@@ -86,7 +87,7 @@ FarmTabletUI:registerDrawer(FT.APP.USED_PLUS, function(self)
                 statusColor = FT.C.WARNING
                 statusLabel = "  OFFER"
             end
-            local nameText = (lst.vehicleName or "Unknown")
+            local nameText = FT_Renderer.truncate(lst.vehicleName or "Unknown", 22)
             self.r:appText(x + FT.px(4), y - FT.py(10),
                 FT.FONT.BODY, nameText, RenderText.ALIGN_LEFT, statusColor)
             if statusLabel ~= "" then

--- a/src/apps/WorkshopApp.lua
+++ b/src/apps/WorkshopApp.lua
@@ -6,6 +6,21 @@
 -- • "REPAIR" button uses FS25 wear/repair APIs
 -- =========================================================
 
+--- serviceShed / myWorkshop_01 → Service Shed / My Workshop 01
+local function _prettyShopName(name)
+    name = tostring(name or "")
+    if name == "" then return "Workshop" end
+    name = name:match("([^/\\]+)$") or name
+    name = name:gsub("%.xml$", "")
+    name = name:gsub("(%l)(%u)", "%1 %2")
+    name = name:gsub("(%u+)(%u%l)", "%1 %2")
+    name = name:gsub("[_%-]+", " ")
+    name = name:gsub("%s+", " "):match("^%s*(.-)%s*$") or name
+    return (name:lower():gsub("(%a)([%w']*)", function(a, b)
+        return a:upper() .. b
+    end))
+end
+
 FarmTabletUI:registerDrawer(FT.APP.WORKSHOP, function(self)
     local AC = FT.appColor(FT.APP.WORKSHOP)
 
@@ -67,30 +82,45 @@ FarmTabletUI:registerDrawer(FT.APP.WORKSHOP, function(self)
         if not found then self.system.workshopSelectedVehicle = nil; sel = nil end
     end
 
-    -- Workshop status banner
+    -- Workshop status banner (sized from content, clear gap before NEARBY).
     local accent = AC
+    local pad = FT.px(8)
+    local bannerH = FT.py(18)
     if #workshops == 0 then
-        self.r:appRect(x - FT.px(4), y - FT.py(18), cw + FT.px(8), FT.py(16),
+        local bannerBottom = y - bannerH
+        self.r:appRect(x - FT.px(4), bannerBottom, cw + FT.px(8), bannerH,
             {accent[1]*0.12, accent[2]*0.12, accent[3]*0.12, 0.95})
-        self.r:appText(x, y - FT.py(13), FT.FONT.SMALL,
-            "No workshop found on this farm  (repairs disabled)", RenderText.ALIGN_LEFT, FT.C.WARNING)
-        y = y - FT.py(24)
+        self.r:appText(x + pad, y - FT.py(5), FT.FONT.SMALL,
+            "No workshop found on this farm  (repairs disabled)",
+            RenderText.ALIGN_LEFT, FT.C.WARNING)
+        -- Extra air so the next section header cannot sit inside this bar.
+        y = bannerBottom - FT.py(14)
     else
         local ws = workshops[1]
         local wsName = "Workshop"
-        if ws.getName then wsName = ws:getName() or wsName
-        elseif ws.configFileName then wsName = ws.configFileName:match("([^/\\]+)%.xml$") or wsName end
-        self.r:appRect(x - FT.px(4), y - FT.py(18), cw + FT.px(8), FT.py(16),
+        if ws.getName then
+            local n = ws:getName()
+            if n ~= nil and tostring(n) ~= "" then wsName = tostring(n) end
+        end
+        if wsName == "Workshop" and ws.configFileName then
+            wsName = ws.configFileName:match("([^/\\]+)%.xml$") or wsName
+        end
+        wsName = _prettyShopName(wsName)
+        local bannerBottom = y - bannerH
+        self.r:appRect(x - FT.px(4), bannerBottom, cw + FT.px(8), bannerH,
             {accent[1]*0.10, accent[2]*0.10, accent[3]*0.10, 0.95})
-        self.r:appText(x, y - FT.py(13), FT.FONT.SMALL, wsName, RenderText.ALIGN_LEFT, FT.C.POSITIVE)
-        self.r:appText(x + cw, y - FT.py(13), FT.FONT.TINY, "REPAIRS AVAILABLE", RenderText.ALIGN_RIGHT, FT.C.TEXT_ACCENT)
-        y = y - FT.py(24)
+        self.r:appText(x + pad, y - FT.py(5), FT.FONT.SMALL, wsName,
+            RenderText.ALIGN_LEFT, FT.C.POSITIVE)
+        self.r:appText(x + cw - pad, y - FT.py(5), FT.FONT.TINY, "REPAIRS AVAILABLE",
+            RenderText.ALIGN_RIGHT, FT.C.TEXT_ACCENT)
+        y = bannerBottom - FT.py(14)
     end
 
     if #nearby == 0 then
-        y = y - FT.py(4)
-        self.r:appText(x, y, FT.FONT.BODY, "No vehicles within 35 m.", RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
-        self.r:appText(x, y - FT.py(18), FT.FONT.SMALL, "Walk closer to a vehicle to inspect it.", RenderText.ALIGN_LEFT, FT.C.MUTED)
+        self.r:appText(x + pad, y, FT.FONT.BODY, "No vehicles within 35 m.",
+            RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
+        self.r:appText(x + pad, y - FT.py(18), FT.FONT.SMALL,
+            "Walk closer to a vehicle to inspect it.", RenderText.ALIGN_LEFT, FT.C.MUTED)
         self:drawInfoIcon("_workshopHelp", AC)
         return
     end
@@ -108,7 +138,8 @@ FarmTabletUI:registerDrawer(FT.APP.WORKSHOP, function(self)
         end
         local nm = v.name
         if #nm > 22 then nm = nm:sub(1, 20) .. ">" end
-        self.r:appText(x, y, FT.FONT.SMALL, nm, RenderText.ALIGN_LEFT,
+        -- Same left pad as shop banner / section header text.
+        self.r:appText(x + pad, y, FT.FONT.SMALL, nm, RenderText.ALIGN_LEFT,
             isSel and FT.C.TEXT_BRIGHT or FT.C.TEXT_NORMAL)
         local wearColor = v.wearPct <= 30 and FT.C.POSITIVE or v.wearPct <= 65 and FT.C.WARNING or FT.C.NEGATIVE
         self.r:appText(x + cw - btnW - FT.px(62), y, FT.FONT.TINY,

--- a/src/utils/DataProvider.lua
+++ b/src/utils/DataProvider.lua
@@ -39,6 +39,18 @@ local function _ftDpI18nKey(key)
     return nil
 end
 
+--- POPPY / OILSEED_RADISH → Poppy / Oilseed Radish (only when still ALLCAPS/internal).
+local function _ftDpPrettyCropName(name)
+    name = tostring(name or "")
+    if name == "" then return name end
+    -- Already a human title (has lowercase) — keep as-is.
+    if name:find("%l") then return name end
+    name = name:gsub("_", " ")
+    return (name:lower():gsub("(%a)([%w']*)", function(first, rest)
+        return first:upper() .. rest
+    end))
+end
+
 local function _ftDpLocalizedFillTypeName(ft, fallback)
     if ft == nil then return fallback or "" end
     local name = ft.name or ft.fillTypeName or ft.fruitTypeName
@@ -58,6 +70,25 @@ local function _ftDpLocalizedFillTypeName(ft, fallback)
         local v = _ftDpI18nKey("fillType_" .. n) or _ftDpI18nKey("fruitType_" .. n)
         if v ~= nil then return v end
     end
+    -- Mod fruits often register a fill type with a real title even when fillType_* i18n is missing.
+    if name ~= nil and g_fillTypeManager ~= nil and g_fillTypeManager.getFillTypeByName ~= nil then
+        local n = tostring(name)
+        local fill = g_fillTypeManager:getFillTypeByName(n)
+            or g_fillTypeManager:getFillTypeByName(string.upper(n))
+            or g_fillTypeManager:getFillTypeByName(string.lower(n))
+        if fill ~= nil then
+            if fill.title ~= nil and tostring(fill.title) ~= "" then
+                return tostring(fill.title)
+            end
+            local fillName = fill.name or fill.fillTypeName
+            if fillName ~= nil then
+                local v = _ftDpI18nKey("fillType_" .. tostring(fillName))
+                    or _ftDpI18nKey("fillType_" .. string.lower(tostring(fillName)))
+                    or _ftDpI18nKey("fillType_" .. string.upper(tostring(fillName)))
+                if v ~= nil then return v end
+            end
+        end
+    end
     if name ~= nil and string.lower(tostring(name)) == "corn" then
         local lang = _ftDpLang()
         if lang == "de" or lang == "ger" or lang == "deutsch" then return "Mais" end
@@ -69,7 +100,11 @@ local function _ftDpLocalizedFillTypeName(ft, fallback)
         if lang == "cz" or lang == "cs" then return "Kukuřice" end
         if lang == "pt" or lang == "br" then return "Milho" end
     end
-    local t = ft.title or ft.nameI18N or fallback or name or ""
+    -- Prefer the real fruit/fill name over a generic "Unknown" fallback.
+    -- (Bug: fallback was listed before name, so mod crops without i18n keys
+    --  showed as Unknown in Field Manager even when fruitType.name was POPPY.)
+    local pretty = (name ~= nil and name ~= "") and _ftDpPrettyCropName(name) or nil
+    local t = ft.title or ft.nameI18N or pretty or fallback or ""
     if FT and FT.l10nAuto then return FT.l10nAuto(t) end
     return t
 end

--- a/src/utils/Renderer.lua
+++ b/src/utils/Renderer.lua
@@ -188,13 +188,23 @@ end
 
 --- Draws a small filled badge/chip with a centred label.
 --- Returns the badge width so callers can advance their X cursor.
+--- Width follows the label so "URGENT" / "12 READY" are not clipped.
 function FT_Renderer:badge(x, y, label, color)
-    local w = FT.px(36)
-    local h = FT.py(13)
+    local text = tostring(label or "")
+    local w = math.max(FT.px(36), FT.px(8) + string.len(text) * FT.px(5.2))
+    local h = FT.py(14)
     self:appRect(x, y - FT.py(1), w, h, color or FT.C.BRAND_DIM)
-    self:appText(x + w/2, y + h/2 - FT.py(2), FT.FONT.TINY, label,
+    self:appText(x + w/2, y + h/2 - FT.py(3), FT.FONT.TINY, text,
         RenderText.ALIGN_CENTER, FT.C.TEXT_BRIGHT)
     return w
+end
+
+--- Truncate a string to maxLen characters with an ellipsis.
+function FT_Renderer.truncate(str, maxLen)
+    str = tostring(str or "")
+    maxLen = tonumber(maxLen) or 20
+    if #str <= maxLen then return str end
+    return str:sub(1, math.max(1, maxLen - 1)) .. "…"
 end
 
 -- ── Lifecycle ─────────────────────────────────────────────


### PR DESCRIPTION
﻿## Summary
Full FarmTablet playtest overlap sweep (Wizard), plus second-pass follow-up from his full tablet screenshot run.

**Shared**
- Renderer:badge width follows the label.
- FT_Renderer.truncate helper for consistent ellipsis.

**Bundled prior polish (supersedes open #106-#110 if this merges first)**
- Soil field cards (#106), Field Manager mod crop names (#107), Invoices form (#108), Animals pens (#109), Workshop NEARBY (#110).

**Playtest follow-up (tip 4f26098)**
- Hotspot Manager: tick boxes, REMOVE (n), ADD PIN HERE, CLEAR ALL confirm.
- Irrigation Suite: Operations / Forecast / Usage labels were clipped above bodyClipTop; fixed. Content inset + bottom pad.
- Soil Fertilizer: Active/FIELDS gap; TREATMENT PLAN always shows actions keyed to bar targets.
- Crop Stress: DISABLED/FIELDS gap; moisture clear of scrollbar.
- Farm Stats / Market Dynamics: bottom pad vs info icon.
- System Settings: still read-only; editable page ASKED of Tyson (not in this PR).

## Test plan
- [ ] Hotspot: tick, REMOVE, ADD PIN HERE, CLEAR ALL
- [ ] Irrigation: tab titles visible; moisture % not clipped
- [ ] Soil: Active clear of FIELDS; TREATMENT PLAN under each field
- [ ] Crop Stress: DISABLED clear of FIELDS
- [ ] Farm Stats / Market Dynamics last rows clear of info icon
- [ ] If merging, close #106-#110 as superseded
