### PR TITLE
i18n: merge warriordeere's improved German translation (#120)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,10 @@
 > Status: FILLED from the ecosystem audit/baseline, kept current.
 > Convention: `[ ]` open · `[~]` in progress · `[x]` done · `[!]` blocked. Newest at the top of each section.
 
+## Bugs
+- [x] 2026-07-30: `src/apps/ProStaffApp.lua:111` failed to COMPILE - `...` referenced from inside an anonymous function ("cannot use '...' outside of a vararg function"). Lua 5.1 does not let a nested closure see the enclosing function's vararg. The whole file was rejected, so the ProStaff app was dead in every session. `safeGet` now passes the varargs straight to `pcall` (no inner closure) and guards a missing method.
+- [ ] **ROOT CAUSE, still open: `build.py` has NO Lua 5.1 syntax gate**, which is the only reason the above reached the game. SoilFertilizer catches this class of error before it can ship (its pre-commit hook runs `luaparse` pinned to 5.1 over every source file, plus a lint pass). Port that gate here: either a `tools/test/` harness of our own, or a syntax step in `build.py` that fails the build. A compile error in one app file takes the file down silently, so this is worth more than any individual fix.
+
 ## From the ecosystem audit (Arissani)
 - [ ] Focus state (Point 1): goHome / openTablet / unlock should pass nil, not the previous appId. Three one-line fixes in FarmTabletUI.lua.
 - [x] Confirmed: MarketDynamicsApp and RandomWorldEventsApp are real apps, not stubs (autoDetect registers them when handles present).

--- a/src/apps/ProStaffApp.lua
+++ b/src/apps/ProStaffApp.lua
@@ -105,12 +105,17 @@ FarmTabletUI:registerDrawer(FT.APP.PROSTAFF, function(self)
     y = self:drawRule(y, 0.3)
     y = self:drawSection(y, "ACTIVE BENEFITS")
 
+    -- pcall takes the arguments directly, so there is no inner closure and therefore
+    -- no vararg to capture. The previous version referenced `...` from inside an
+    -- anonymous function, which Lua 5.1 rejects at COMPILE time ("cannot use '...'
+    -- outside of a vararg function") - the whole file failed to load and this app was
+    -- dead in every session. Also guards a missing method instead of erroring into pcall.
     local function safeGet(funcName, ...)
-        local result = nil
-        pcall(function()
-            result = psm[funcName](psm, ...)
-        end)
-        return result
+        local fn = psm and psm[funcName]
+        if type(fn) ~= "function" then return nil end
+        local ok, result = pcall(fn, psm, ...)
+        if ok then return result end
+        return nil
     end
 
     local function pctLabel(mult, inverse)

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1,159 +1,159 @@
 <?xml version='1.0' encoding='utf-8'?>
 <l10n>
     <texts>
-        <text name="ft_ui_section" text="Bauernhof-Tablet" />
+        <text name="ft_ui_section" text="Farm Tablet" />
         <text name="ft_ui_welcome_title" text="Farm Tablet v2" />
-        <text name="ft_ui_welcome_message" text="Drücken Sie zum Öffnen %s" />
+        <text name="ft_ui_welcome_message" text="Tablet öffnen mit %s" />
         <text name="ft_ui_enabled_short" text="Tablet aktivieren" />
-        <text name="ft_ui_enabled_long" text="Aktivieren oder deaktivieren Sie das Farm-Tablet-System" />
-        <text name="ft_ui_keybind_short" text="Taste zum Öffnen" />
+        <text name="ft_ui_enabled_long" text="Aktivieren oder Deaktivieren des Farm Tablet" />
+        <text name="ft_ui_keybind_short" text="Tablet Öffnen" />
         <text name="ft_ui_keybind_long" text="Taste zum Öffnen/Schließen des Farm-Tablets" />
         <text name="ft_ui_notifications_short" text="Benachrichtigungen" />
         <text name="ft_ui_notifications_long" text="Tablet-Benachrichtigungen beim Laden des Spiels anzeigen" />
         <text name="ft_ui_startupapp_short" text="Startup-App" />
-        <text name="ft_ui_startupapp_long" text="Standard-App beim Öffnen des Tablets" />
-        <text name="ft_ui_startupapp_1" text="Übersicht" />
-        <text name="ft_ui_startupapp_2" text="App Store" />
+        <text name="ft_ui_startupapp_long" text="Standard-App, die beim Öffnen des Tablets angezeigt wird" />
+        <text name="ft_ui_startupapp_1" text="Dashboard" />
+        <text name="ft_ui_startupapp_2" text="AppStore" />
         <text name="ft_ui_startupapp_3" text="Wetter" />
-        <text name="ft_ui_startupapp_4" text="Graben" />
+        <text name="ft_ui_startupapp_4" text="Vermessung" />
         <text name="ft_ui_soundeffects_short" text="Soundeffekte" />
-        <text name="ft_ui_soundeffects_long" text="Spielen Sie Soundeffekte für Tablet-Interaktionen ab" />
+        <text name="ft_ui_soundeffects_long" text="Soundeffekte bei Tablet-Interaktionen abspielen" />
         <text name="ft_ui_debug_short" text="Debug-Modus" />
-        <text name="ft_ui_debug_long" text="Aktivieren Sie die Debug-Protokollierung in der Konsole" />
-        <text name="ft_ui_reset" text="Setzen Sie die Tablet-Einstellungen zurück" />
-        <text name="ft_ui_app_dashboard" text="Übersicht" />
+        <text name="ft_ui_debug_long" text="Aktiviert den Debug-Log in der Konsole" />
+        <text name="ft_ui_reset" text="Tablet-Einstellungen zurücksetzen" />
+        <text name="ft_ui_app_dashboard" text="Dashboard" />
         <text name="ft_ui_app_store" text="App Store" />
-        <text name="ft_ui_app_updates" text="Aktualisierungen" />
+        <text name="ft_ui_app_updates" text="Updates" />
         <text name="ft_ui_app_settings" text="Einstellungen" />
-        <text name="ft_ui_app_system_settings" text="System Settings" />
+        <text name="ft_ui_app_system_settings" text="Globale Einstellungen" />
         <text name="ft_ui_app_workshop" text="Werkstatt" />
-        <text name="ft_ui_app_field_status" text="Feldmanager" />
-        <text name="ft_ui_app_field_sentry" text="Feldwächter" />
-        <text name="ft_ui_app_rotation_planner" text="Rotation Planner" />
-        <text name="ft_ui_app_irrigation_suite" text="Irrigation Suite" />
-        <text name="ft_ui_app_financial_cockpit" text="Finanz-Cockpit" />
-        <text name="ft_fc_health" text="BETRIEBSGESUNDHEIT" />
-        <text name="ft_fc_band_green" text="Gesund" />
-        <text name="ft_fc_band_amber" text="Beobachten" />
-        <text name="ft_fc_band_red" text="Kritisch" />
-        <text name="ft_fc_band_partial" text="Teilweise / Geschätzt" />
+        <text name="ft_ui_app_field_status" text="Feldübersicht" />
+        <text name="ft_ui_app_field_sentry" text="Feldmonitor" />
+        <text name="ft_ui_app_rotation_planner" text="Fruchtfolge" />
+        <text name="ft_ui_app_irrigation_suite" text="Bewässerung" />
+        <text name="ft_ui_app_financial_cockpit" text="Finanzen" />
+        <text name="ft_fc_health" text="Bilanz" />
+        <text name="ft_fc_band_green" text="Ausgewogen" />
+        <text name="ft_fc_band_amber" text="Besorgniserregend" />
+        <text name="ft_fc_band_red" text="Handlungsbedarf" />
+        <text name="ft_fc_band_partial" text="Schätzung" />
         <text name="ft_fc_band_neutral" text="Neutral" />
-        <text name="ft_fc_partial" text="TEILWEISE" />
+        <text name="ft_fc_partial" text="Teilweise" />
         <text name="ft_fc_not_tracked" text="Noch nicht erfasst" />
         <text name="ft_fc_syncing" text="Synchronisiert" />
-        <text name="ft_fc_unavailable" text="Unavailable" />
-        <text name="ft_fc_open" text="OPEN" />
-        <text name="ft_fc_months" text="months" />
-        <text name="ft_fc_month" text="Month" />
-        <text name="ft_fc_year" text="Year" />
+        <text name="ft_fc_unavailable" text="Nicht Verfügbar" />
+        <text name="ft_fc_open" text="Öffnen" />
+        <text name="ft_fc_months" text="Monate" />
+        <text name="ft_fc_month" text="Monat" />
+        <text name="ft_fc_year" text="Jahr" />
         <text name="ft_fc_balance" text="Kontostand" />
         <text name="ft_fc_loan" text="Kredit" />
         <text name="ft_fc_net_worth" text="Nettovermögen" />
-        <text name="ft_fc_clock" text="Economic clock" />
-        <text name="ft_fc_period" text="Period" />
-        <text name="ft_fc_days_per_period" text="Days / period" />
-        <text name="ft_fc_section_instruments" text="INSTRUMENTS" />
-        <text name="ft_fc_section_rhythm" text="RHYTHM" />
-        <text name="ft_fc_section_forecast" text="FORECAST" />
-        <text name="ft_fc_section_history" text="HISTORY" />
-        <text name="ft_fc_section_flows" text="FLOWS AND SIGNALS" />
-        <text name="ft_fc_section_vitals" text="VITALS" />
-        <text name="ft_fc_forecast_label" text="Projection" />
-        <text name="ft_fc_forecast_month_end" text="Month-end outlook" />
-        <text name="ft_fc_forecast_remaining" text="Period remaining" />
-        <text name="ft_fc_forecast_next_pay" text="Next income pulse" />
-        <text name="ft_fc_forecast_tax" text="Tax accumulated (annual)" />
-        <text name="ft_fc_forecast_wages" text="Wage burn (known)" />
-        <text name="ft_fc_forecast_fuel" text="Fuel spend" />
-        <text name="ft_fc_forecast_limited" text="Limited to readable flows" />
-        <text name="ft_fc_forecast_disclaimer" text="Projection only. Missing flows are not invented." />
-        <text name="ft_fc_history" text="Monthly record" />
+        <text name="ft_fc_clock" text="Uhr" />
+        <text name="ft_fc_period" text="Zeitraum" />
+        <text name="ft_fc_days_per_period" text="Tage pro ausgewähltem Zeitraum" />
+        <text name="ft_fc_section_instruments" text="Werkzeuge" />
+        <text name="ft_fc_section_rhythm" text="Rhytmus" />
+        <text name="ft_fc_section_forecast" text="Finanz-Prognose" />
+        <text name="ft_fc_section_history" text="Rückblick" />
+        <text name="ft_fc_section_flows" text="Finanzströme" />
+        <text name="ft_fc_section_vitals" text="Werte" />
+        <text name="ft_fc_forecast_label" text="Prognose" />
+        <text name="ft_fc_forecast_month_end" text="Monatsaussicht" />
+        <text name="ft_fc_forecast_remaining" text="Verbleibender Zeitraum" />
+        <text name="ft_fc_forecast_next_pay" text="Vorraussichtliche Zahlung" />
+        <text name="ft_fc_forecast_tax" text="Aufgelaufene Jahressteuer" />
+        <text name="ft_fc_forecast_wages" text="Lohnzahlungen" />
+        <text name="ft_fc_forecast_fuel" text="Verbrauchter Kraftstoff" />
+        <text name="ft_fc_forecast_limited" text="Beschränkt auf lesbare Daten." />
+        <text name="ft_fc_forecast_disclaimer" text="Prognose. Fehlende Werte werden nicht einbezogen." />
+        <text name="ft_fc_history" text="Monatsübersicht" />
         <text name="ft_fc_history_host_only" text="Nur Host in v1" />
-        <text name="ft_fc_history_host_only_detail" text="Monthly history is recorded on the host. Live cash and leverage still stand." />
+        <text name="ft_fc_history_host_only_detail" text="Die Monatsübersicht wird nur durch den Host gespeichert. Kontostand und Kredite sind davon unberührt." />
         <text name="ft_fc_history_dedicated" text="Auf diesem Server nicht verfügbar" />
-        <text name="ft_fc_history_no_ledger" text="No StateLedger (live vitals only)" />
-        <text name="ft_fc_history_wait_detail" text="A compact row is written each closed in-game month." />
-        <text name="ft_fc_no_history_yet" text="No history yet" />
-        <text name="ft_fc_recent_months" text="RECENT MONTHS" />
-        <text name="ft_fc_yearly_rollup" text="YEARLY ROLLUP" />
-        <text name="ft_fc_vital_cash" text="Cash position" />
-        <text name="ft_fc_vital_cash_detail" text="Available farm balance." />
-        <text name="ft_fc_vital_leverage" text="Leverage" />
-        <text name="ft_fc_vital_leverage_detail" text="Loan share of balance plus loan." />
-        <text name="ft_fc_vital_runway" text="Cash runway" />
-        <text name="ft_fc_vital_runway_partial" text="Needs a fuller cost picture before runway is confident." />
-        <text name="ft_fc_vital_runway_detail" text="Balance divided by known operating burn." />
-        <text name="ft_fc_vital_direction" text="Profit direction" />
-        <text name="ft_fc_vital_direction_wait" text="Needs at least two monthly samples." />
-        <text name="ft_fc_vital_direction_detail" text="Change in net worth across the last two closed months." />
-        <text name="ft_fc_vital_margin" text="Margin" />
-        <text name="ft_fc_vital_margin_wait" text="Needs a recorded month with flow totals." />
-        <text name="ft_fc_vital_margin_partial" text="Flow gaps remain; margin is estimated only." />
-        <text name="ft_fc_vital_trajectory" text="Net-worth trajectory" />
-        <text name="ft_fc_vital_trajectory_wait" text="Needs at least two monthly samples." />
-        <text name="ft_fc_vital_trajectory_detail" text="Net worth change over the recent recorded window." />
-        <text name="ft_fc_worst_rule" text="Heart color = worst vital that has data. Neutrals and partials do not count as healthy." />
-        <text name="ft_fc_pocket_vital" text="Health vital" />
-        <text name="ft_fc_pocket_history" text="Financial history" />
-        <text name="ft_fc_pocket_forecast" text="Forecast" />
-        <text name="ft_fc_pocket_flows" text="Flows and signals" />
-        <text name="ft_fc_flow_income" text="Income" />
-        <text name="ft_fc_flow_income_mode" text="Pay mode" />
-        <text name="ft_fc_flow_tax" text="Tax paid (total)" />
-        <text name="ft_fc_flow_wages" text="Wages (month)" />
-        <text name="ft_fc_flow_fuel" text="Fuel spend" />
-        <text name="ft_fc_flow_dairy_income" text="Dairy contract income" />
-        <text name="ft_fc_flow_rwe" text="World-event money" />
-        <text name="ft_fc_signal_coop" text="Co-Op level" />
-        <text name="ft_fc_signal_coop_note" text="Level only. Quantified savings wait on ProStaff benefit getters." />
-        <text name="ft_fc_signal_dairy" text="Dairy barns" />
-        <text name="ft_fc_signal_market" text="Market events" />
-        <text name="ft_fc_signal_rwe" text="World event" />
-        <text name="ft_fc_dollar_flows" text="DOLLAR FLOWS" />
-        <text name="ft_fc_signals" text="SIGNALS" />
-        <text name="ft_fc_honesty" text="Honesty" />
-        <text name="ft_fc_help_health_title" text="FARM HEALTH" />
-        <text name="ft_fc_help_health_body" text="One heart color from the worst vital that has data.&#10;Green / amber / red. Neutrals and partials never count as healthy.&#10;Tap the heart to open the vital that set the color." />
-        <text name="ft_fc_help_history_title" text="HISTORY" />
-        <text name="ft_fc_help_history_body" text="This page records a compact monthly row itself.&#10;Host / single-player only in v1. Gaps stay gaps." />
-        <text name="ft_fc_help_forecast_title" text="FORECAST" />
-        <text name="ft_fc_help_forecast_body" text="Labeled as a projection. PARTIAL when a flow is missing.&#10;Missing flows show not yet tracked, never a guess." />
-        <text name="ft_fc_help_readonly_title" text="READ-ONLY" />
-        <text name="ft_fc_help_readonly_body" text="The cockpit never moves money and never re-implements&#10;Income, Tax, Wages, or other owning apps." />
+        <text name="ft_fc_history_no_ledger" text="Kein StateLedger (nur aktuelle Werte)" />
+        <text name="ft_fc_history_wait_detail" text="Für jeden abgeschlossenen Ingame-Monat werden Informationen zusammengefasst." />
+        <text name="ft_fc_no_history_yet" text="Kein Rückblick verfügbar." />
+        <text name="ft_fc_recent_months" text="Vergangene Monate" />
+        <text name="ft_fc_yearly_rollup" text="Jahresübersicht" />
+        <text name="ft_fc_vital_cash" text="Kontostand" />
+        <text name="ft_fc_vital_cash_detail" text="Aktueller Kontostand deines Hofs." />
+        <text name="ft_fc_vital_leverage" text="Kredit" />
+        <text name="ft_fc_vital_leverage_detail" text="Anteil des Kredit am Kontostand inklusive des Kredit." />
+        <text name="ft_fc_vital_runway" text="Rücklagen" />
+        <text name="ft_fc_vital_runway_partial" text="Ein vollständiger Kostenüberblick ist notwendig, bevor eine genaue Höhe der finanziellen Rücklagen berechnet werden kann." />
+        <text name="ft_fc_vital_runway_detail" text="Kontostand geteilt durch laufende Betriebsausgaben." />
+        <text name="ft_fc_vital_direction" text="Gewinnentwicklung" />
+        <text name="ft_fc_vital_direction_wait" text="Es werden mindestens 2 Monate für eine sichere Aussage benötigt." />
+        <text name="ft_fc_vital_direction_detail" text="Veränderung des Vermögens über die vergangenen 2 Monate." />
+        <text name="ft_fc_vital_margin" text="Gewinnspanne" />
+        <text name="ft_fc_vital_margin_wait" text="Benötigt eine Monatsaufzeichnungen mit allen Finanzwerten." />
+        <text name="ft_fc_vital_margin_partial" text="Es gibt Lücken in den Aufzeichnungen, die Gewinnspanne ist nur eine Schätzung." />
+        <text name="ft_fc_vital_trajectory" text="Vermögensentwicklung" />
+        <text name="ft_fc_vital_trajectory_wait" text="Benötigt mindestens 2 Monatsaufzeichnungen." />
+        <text name="ft_fc_vital_trajectory_detail" text="Veränderung des Nettovermögens über den zuletzt erfassten Zeitraum." />
+        <text name="ft_fc_worst_rule" text="Die Herzfarbe zeigt die schlechtesten Werte im Datensatz an. Neutrale und unvollständige Werte werden nicht positiv berücksichtigt." />
+        <text name="ft_fc_pocket_vital" text="Werte" />
+        <text name="ft_fc_pocket_history" text="Finanzrückblick" />
+        <text name="ft_fc_pocket_forecast" text="Prognose" />
+        <text name="ft_fc_pocket_flows" text="Finanzströme" />
+        <text name="ft_fc_flow_income" text="Einkommen" />
+        <text name="ft_fc_flow_income_mode" text="Modus des Einkommen" />
+        <text name="ft_fc_flow_tax" text="Gezahlte Steuern (gesamt)" />
+        <text name="ft_fc_flow_wages" text="Monatliche Lohnkosten" />
+        <text name="ft_fc_flow_fuel" text="Verbrauchter Kraftstoff" />
+        <text name="ft_fc_flow_dairy_income" text="Einnahmen aus Lieferverträgen (Milch)" />
+        <text name="ft_fc_flow_rwe" text="Globale Einnahmen" />
+        <text name="ft_fc_signal_coop" text="Kooperationsstufe" />
+        <text name="ft_fc_signal_coop_note" text="Basisstufe. Die Nutzung der gemessenen Einsparungen ist ein Exklusiv-Vorteil von ProStaff-Mitgliedern." />
+        <text name="ft_fc_signal_dairy" text="Milchviehanlagen" />
+        <text name="ft_fc_signal_market" text="Handelsereignisse" />
+        <text name="ft_fc_signal_rwe" text="Globale Ereignisse" />
+        <text name="ft_fc_dollar_flows" text="Kaptialstrom" />
+        <text name="ft_fc_signals" text="Signale" />
+        <text name="ft_fc_honesty" text="Ehrlichkeit" />
+        <text name="ft_fc_help_health_title" text="Bilanz" />
+        <text name="ft_fc_help_health_body" text="Herzfarbe des schlechtesten Wert im Datensatz.&#10;Grün, Gelb, Rot. Neutrale und unvollständige Werte werden nicht positiv berücksichtigt.&#10;Drücke auf ein Herz um den Wert zu sehen, der die Farbe hervorgerufen hat." />
+        <text name="ft_fc_help_history_title" text="Rückblick" />
+        <text name="ft_fc_help_history_body" text="Diese Seite zeichnet eine kompakte Monatsübersicht auf.&#10;Nur Host- und Einzelspieler in v1. Lücken verbleiben als solche." />
+        <text name="ft_fc_help_forecast_title" text="Prognose" />
+        <text name="ft_fc_help_forecast_body" text="Erstellt eine Vorhersage über die Entwicklung der Finanzen. Unvollständig, wenn Werte fehlen.&#10;Fehlende Werte und Daten werden als 'nicht erfasst' gekennzeichnet." />
+        <text name="ft_fc_help_readonly_title" text="Keine Veränderungen" />
+        <text name="ft_fc_help_readonly_body" text="Die Finanzen-App verschiebt kein Geld und beeinflusst niemals&#10;Einkommen, Steuern, Gehälter oder andere Apps." />
         <text name="ft_ui_app_animals" text="Tiere" />
         <text name="ft_ui_app_weather" text="Wetter" />
-        <text name="ft_ui_app_digging" text="Graben" />
-        <text name="ft_ui_app_bucket_tracker" text="Schaufelzähler" />
-        <text name="ft_ui_app_income_mod" text="Einkommensmod" />
-        <text name="ft_ui_app_tax_mod" text="Steuermod" />
-        <text name="ft_ui_app_npc_favor" text="NPC-Gefallen" />
-        <text name="ft_ui_app_crop_stress" text="Pflanzenstress" />
-        <text name="ft_ui_app_soil_fertilizer" text="Bodendünger" />
-        <text name="ft_ui_app_market_dynamics" text="Marktdynamik" />
-        <text name="ft_ui_app_worker_costs" text="Arbeiterkosten" />
-        <text name="ft_ui_app_personnel" text="Personal" />
+        <text name="ft_ui_app_digging" text="Vermessung" />
+        <text name="ft_ui_app_bucket_tracker" text="Ladungsübersicht" />
+        <text name="ft_ui_app_income_mod" text="Finanzen" />
+        <text name="ft_ui_app_tax_mod" text="Eichelhäher" />
+        <text name="ft_ui_app_npc_favor" text="Nachbarschaftshilfe" />
+        <text name="ft_ui_app_crop_stress" text="Bestandspflege" />
+        <text name="ft_ui_app_soil_fertilizer" text="Düngung" />
+        <text name="ft_ui_app_market_dynamics" text="Börse" />
+        <text name="ft_ui_app_worker_costs" text="Lohnabrechnung" />
+        <text name="ft_ui_app_personnel" text="Mitarbeiter" />
         <text name="ft_ui_app_prostaff" text="ProStaff Co-Op" />
-        <text name="ft_ui_app_random_world_events" text="Zufallsereignisse" />
-        <text name="ft_ui_app_used_plus" text="UsedPlus" />
-        <text name="ft_ui_app_roleplay_phone" text="Rechnungen / Telefon" />
+        <text name="ft_ui_app_random_world_events" text="Ereignisse" />
+        <text name="ft_ui_app_used_plus" text="Gebraucht+" />
+        <text name="ft_ui_app_roleplay_phone" text="Rechnungen" />
         <text name="ft_ui_app_storage" text="Lager" />
-        <text name="ft_ui_app_time_controls" text="Zeitsteuerung" />
-        <text name="ft_ui_app_hotspot_manager" text="Hotspot-Manager" />
+        <text name="ft_ui_app_time_controls" text="Zeitmaschine" />
+        <text name="ft_ui_app_hotspot_manager" text="Ortsverwaltung" />
         <text name="ft_ui_app_notes" text="Notizen" />
-        <text name="ft_ui_app_farm_admin" text="Hof-Admin" />
-        <text name="ft_ui_app_contracts" text="Aufträge" />
-        <text name="ft_ui_app_fleet_manager" text="Flottenmanager" />
-        <text name="ft_ui_app_production_buildings" text="Produktion" />
-        <text name="ft_ui_app_farm_stats" text="Hofstatistik" />
-        <text name="ft_ui_app_field_jobs" text="Feldarbeiten" />
-        <text name="ft_ui_app_animal_auto_care" text="Tier-AutoCare" />
+        <text name="ft_ui_app_farm_admin" text="Administrator-Dashboard" />
+        <text name="ft_ui_app_contracts" text="Dienstleistungen" />
+        <text name="ft_ui_app_fleet_manager" text="Fuhrpark" />
+        <text name="ft_ui_app_production_buildings" text="Produktionsverwaltung" />
+        <text name="ft_ui_app_farm_stats" text="Statistik" />
+        <text name="ft_ui_app_field_jobs" text="Aufgaben" />
+        <text name="ft_ui_app_animal_auto_care" text="Automatische Tierpflege" />
         <text name="ft_ui_app_animal_vet_system" text="Tierarzt" />
         <text name="ft_ui_app_factory_week_schedule" text="Fabrik-Wochenplan" />
-        <text name="ft_ui_app_realistic_dealer" text="RealisticDealer" />
-        <text name="ft_desc_app_animal_auto_care" text="Status von AnimalAutoCare und sichere Pflege-Aktion" />
-        <text name="ft_desc_app_animal_vet_system" text="AnimalVetSystem: Krankheiten und Behandlungen" />
-        <text name="ft_desc_app_factory_week_schedule" text="FactoryWeekSchedule: Arbeiter, Ereignisse und Feuerstatus" />
-        <text name="ft_desc_app_realistic_dealer" text="RealisticDealer: Finanzierungen, Raten und Rücknahmen" />
+        <text name="ft_ui_app_realistic_dealer" text="Realistischer Händler" />
+        <text name="ft_desc_app_animal_auto_care" text="Übersicht der automatischen Tierpflege." />
+        <text name="ft_desc_app_animal_vet_system" text="Bestandsbuch: Auflistung aufgetretener Krankheiten und Behandlungen durch den Tierarzt." />
+        <text name="ft_desc_app_factory_week_schedule" text="Personal, Ereignisse und BMA." />
+        <text name="ft_desc_app_realistic_dealer" text="Finanzierungen, Leasing-Raten und Rücknahmen." />
         <text name="ft_common_on" text="An" />
         <text name="ft_common_off" text="Aus" />
         <text name="ft_common_connected" text="Verbunden" />
@@ -172,26 +172,26 @@
         <text name="ft_aac_food" text="Futter" />
         <text name="ft_aac_water" text="Wasser" />
         <text name="ft_aac_straw" text="Stroh" />
-        <text name="ft_aac_purchase_cost" text="Kosten Kauf" />
-        <text name="ft_aac_care_cost" text="Kosten Pflege" />
-        <text name="ft_aac_care_now" text="Jetzt versorgen" />
+        <text name="ft_aac_purchase_cost" text="Kosten (Kauf)" />
+        <text name="ft_aac_care_cost" text="Kosten (Pflege)" />
+        <text name="ft_aac_care_now" text="Behandeln" />
         <text name="ft_aac_last_action" text="LETZTE AKTION" />
-        <text name="ft_aac_no_action" text="Noch keine Aktion vorhanden." />
+        <text name="ft_aac_no_action" text="Noch keine Behandlung eingetragen." />
         <text name="ft_vet_active_cases" text="%d aktive Fälle" />
         <text name="ft_vet_not_detected" text="AnimalVetSystem wurde nicht erkannt." />
-        <text name="ft_vet_active_illnesses" text="Aktive Krankheiten" />
+        <text name="ft_vet_active_illnesses" text="Aufgetretene Krankheiten" />
         <text name="ft_vet_veterinarian" text="Tierarzt" />
-        <text name="ft_vet_no_sick_pens" text="Keine kranken Ställe gemeldet." />
+        <text name="ft_vet_no_sick_pens" text="Keine Krankheiten in deinen Ställen bekannt." />
         <text name="ft_vet_cases" text="FÄLLE" />
         <text name="ft_vet_pen" text="Stall" />
         <text name="ft_vet_illness" text="Krankheit" />
-        <text name="ft_vet_worker" text="Pfleger" />
-        <text name="ft_vet_self" text="Selbst" />
+        <text name="ft_vet_worker" text="Mitarbeiter" />
+        <text name="ft_vet_self" text="Du" />
         <text name="ft_vet_case_line" text="%s - %d Tiere - ca. %d min" />
         <text name="ft_fws_open_count" text="%d/%d offen" />
         <text name="ft_fws_not_detected" text="FactoryWeekSchedule wurde nicht erkannt." />
-        <text name="ft_fws_factories_open" text="Fabriken offen" />
-        <text name="ft_fws_fire_system" text="Feuer-System" />
+        <text name="ft_fws_factories_open" text="Fabriken laufen" />
+        <text name="ft_fws_fire_system" text="BMA" />
         <text name="ft_fws_factories" text="FABRIKEN" />
         <text name="ft_fws_no_factories" text="Noch keine Fabriken im FactoryWeekSchedule-HUD-Cache." />
         <text name="ft_fws_factory" text="Fabrik" />
@@ -215,7 +215,7 @@
         <text name="ft_rd_installment_line" text="Raten: %d/%d" />
         <text name="ft_rd_notices_line" text="Mahnungen: %d" />
         <text name="ft_rd_server_note" text="Fahrzeug-Rücknahmen laufen weiterhin serverseitig über RealisticDealer." />
-        <text name="ft_network_default_provider" text="Realistic Farming Mobile" />
+        <text name="ft_network_default_provider" text="ReFaR Mobile" />
         <text name="ft_network_title" text="Netzwerk" />
         <text name="ft_network_choose_provider" text="Netzanbieter wählen" />
         <text name="ft_network_choose_hint" text="Anbieter wählen und aktivieren." />
@@ -225,80 +225,80 @@
         <text name="ft_network_no_signal_short" text="Kein Netz" />
         <text name="ft_network_weak_short" text="Schwach" />
         <text name="ft_network_recovered" text="%s: Empfang wiederhergestellt." />
-        <text name="ft_network_outage_msg" text="%s: Netzstörung, ca. 2 Ingame-Stunden." />
-        <text name="ft_network_no_signal_msg" text="%s: Kein Empfang an dieser Stelle." />
+        <text name="ft_network_outage_msg" text="%s: Netzwerkstörung, ca. 2 Ingame-Stunden." />
+        <text name="ft_network_no_signal_msg" text="%s: Kein Empfang." />
         <text name="ft_network_weak_msg" text="%s: Schwacher Empfang." />
         <text name="ft_battery_empty" text="Tablet-Akku leer" />
         <text name="ft_battery_charging" text="Tablet lädt ..." />
-        <text name="ft_battery_charge_hint" text="Zum Weiterbenutzen kurz laden." />
+        <text name="ft_battery_charge_hint" text="Akku erschöpft. Zum Weiterbenutzen kurz laden." />
         <text name="ft_battery_charge" text="LADEN" />
         <text name="ft_help_cat_start" text="Erste Schritte" />
-        <text name="ft_help_cat_apps" text="Farm-Apps" />
-        <text name="ft_help_cat_mods" text="Companion-Mods" />
+        <text name="ft_help_cat_apps" text="Agrar-Apps" />
+        <text name="ft_help_cat_mods" text="Kompatible Mods" />
         <text name="ft_help_cat_settings" text="Einstellungen und Konsole" />
         <text name="ft_help_p1_title" text="Öffnen und Navigieren" />
         <text name="ft_help_p1_open_title" text="Öffnen des Tablets" />
-        <text name="ft_help_p1_open_text" text="Drücken Sie jederzeit T (konfigurierBalken), um das Farm Tablet zu öffnen oder zu schließen. Sie können den Schlüssel in der App „Einstellungen“ oder durch Eingabe von „TabletKeybind“ gefolgt von einem Schlüsselbuchstaben in der Entwicklerkonsole ändern." />
+        <text name="ft_help_p1_open_text" text="Drücke jederzeit T, um das Farm Tablet zu öffnen oder zu schließen. Du kannst in der App „Einstellungen“ oder mithilfe des Konsolen-Befehls „TabletKeybind [zuzuweisende Taste]“ die Tastenbelegung anpassen." />
         <text name="ft_help_p1_nav_title" text="Startbildschirm &amp; Apps" />
-        <text name="ft_help_p1_nav_text" text="Das Farm-Tablet funktioniert wie ein Smartphone. Zum Entsperren wischen, danach auf dem Startbildschirm ein App-Symbol antippen, um es zu oeffnen. Tippe oben auf HOME, um zum Raster zurueckzukehren. Das Dock am unteren Rund enthaelt deine Favoriten, mit dem Mausrad wechselst du die Seiten. Die App-Store-App zeigt alle vorhandenen Apps." />
+        <text name="ft_help_p1_nav_text" text="Das Farm-Tablet funktioniert wie ein Smartphone. Zum Entsperren wischen, danach auf dem Startbildschirm ein App-Symbol antippen, um sie zu öffnen. Drücke oben auf das HOME-Symbol, um zum Hauptbildschirm zurückzukehren. Die Leiste am unteren Rund enthält deine Favoriten, mit dem Mausrad kannst du die Seiten wechseln. Im AppStore sind alle vorhandenen Apps aufgelistet." />
         <text name="ft_help_p2_title" text="Verschieben und Größenänderung" />
         <text name="ft_help_p2_move_title" text="Bearbeitungsmodus" />
-        <text name="ft_help_p2_move_text" text="Öffnen Sie die App „Einstellungen“ und klicken Sie auf „BEARBEITUNGSMODUS EINGEBEN“. Im Bearbeitungsmodus können Sie den Tablet-Körper ziehen, um ihn ein einer beliebigen Stelle auf dem Bildschirm neu zu positionieren, einen beliebigen Eckgriff ziehen, um das gesamte Tablet zu skalieren, oder den linken oder rechten Rund ziehen, um nur die Breite anzupassen. Klicken Sie mit der rechten Maustaste auf eine beliebige Stelle, um den Bearbeitungsmodus zu verlassen. Ihre Position und Ihr Maßstab werden automatisch gespeichert." />
-        <text name="ft_help_p2_key_title" text="Ändern des Öffnungsschlüssels" />
-        <text name="ft_help_p2_key_text" text="Der Standardschlüssel ist T. Um ihn zu ändern, öffnen Sie die App „Einstellungen“ und suchen Sie die Einstellung „Tastenkombination“ oder geben Sie „TabletKeybind“ gefolgt von einem Schlüsselnamen in der Entwicklerkonsole ein – „TabletKeybind H“ setzt den Schlüssel beispielsweise auf „H“. Einzelbuchstaben, F-Tasten und allgemeine Tasten wie TAB und ESC werden alle unterstützt." />
+        <text name="ft_help_p2_move_text" text="Öffne die App „Einstellungen“ und drücke auf „Bearbeitungsmodus“. Im Bearbeitungsmodus kannst du das Tablet an eine beliebige Stelle verschieben. Um die Größe zu verändern kannst du an einer beliebigen Ecke ziehen. Um nur die Breite anzupassen, kannst du am linken oder rechten Rund ziehen. Rechtsklick auf eine beliebige Stelle, um den Bearbeitungsmodus zu verlassen. Position und Maßstab werden automatisch gespeichert." />
+        <text name="ft_help_p2_key_title" text="Tastenbelegung zum Öffnen anpassen." />
+        <text name="ft_help_p2_key_text" text="Die Standardbelegung ist T. Du kannst das in der App „Einstellungen“ unter „Tastenkombination“ ändern. Alternativ kannst du auch mithilfe des Konsolen-Befehls „TabletKeybind [zuzuweisende Taste]“ die Tastenbelegung anpassen. Es werden Einzelne Buchstaben, Funktions-Tasten (bspw. F1) und alle anderen Tasten wie TAB oder ESC unterstützt." />
         <text name="ft_help_a1_title" text="Dashboard und Wetter" />
-        <text name="ft_help_a1_dash_title" text="Armaturenbrett" />
-        <text name="ft_help_a1_dash_text" text="Das Dashboard ist Ihre Farmzusammenfassung auf einen Blick. Oben wird Ihr aktuelles Guthaben auf einer großen Heldenkarte angezeigt, darunter Einnahmen, Ausgaben und Nettogewinn für die Sitzung. Farm Stats listet auf, wie viele Felder Sie besitzen und wie viele Fahrzeuge Sie insgesamt haben. Im Abschnitt „Welt“ werden die aktuelle Jahreszeit, der aktuelle Tag und die aktuelle Tageszeit sowie ein Live-Wetter-Schnappschuss angezeigt. Tippen Sie auf das kleine Infosymbol in der unteren rechten Ecke des Dashboards, um eine detaillierte Erklärung jedes Werts zu erhalten." />
+        <text name="ft_help_a1_dash_title" text="Dashboard" />
+        <text name="ft_help_a1_dash_text" text="Im Dashboard findest du eine Zusammenfassung über deinen Hof. Oben findest du deinen aktuellen Kontostand, darunter Einnahmen und Ausgaben sowie den Gewinn der aktuellen Spiel-Sitzung. Die Statistiken zeigen dir, wie viele Felder und Fahrzeuge du besitzt. Im Abschnitt „Umgebung“ werden die aktuelle Jahreszeit, der Tag und die Tageszeit sowie das aktuelle Wetter angezeigt. Tippee auf das kleine Infosymbol in der unteren rechten Ecke des Dashboards, um eine detaillierte Erklärung für jeden Wert zu erhalten." />
         <text name="ft_help_a1_weather_title" text="Wetter-App" />
-        <text name="ft_help_a1_weather_text" text="Die Wetter-App zeigt eine detaillierte mehrtägige Vorhersage mit Temperatur, Niederschlagswahrscheinlichkeit und Wind. Die Bedingungen sind farblich gekennzeichnet: Blau für Regen, Orange für Stürme, Weiß für klaren Himmel. Verwenden Sie dies zusammen mit dem Crop Stress-Mod, um zu entscheiden, wann die Bewässerung geplant werden soll." />
+        <text name="ft_help_a1_weather_text" text="Die Wetter-App zeigt dir eine detaillierte mehrtägige Vorhersage mit Temperatur, Niederschlagswahrscheinlichkeit und Windstärke. Die Bedingungen sind farblich gekennzeichnet: Blau für Regen, Orange für Stürme und Weiß für klaren Himmel. Verwendest du außérdem den Crop Stress-Mod, kannst du so entscheiden, wie du deine Bewässerung einsetzt." />
         <text name="ft_help_a2_title" text="Felder &amp; Tiere" />
-        <text name="ft_help_a2_fields_title" text="Feldmanager" />
-        <text name="ft_help_a2_fields_text" text="Field Manager listet alle Felder auf, die Sie besitzen. In jeder Zeile werden die Pflanzenart, die aktuelle Wachstumsphase als Abzeichen (Aussaat, Wachsend, Bereit) und ein farbcodierter Statuspunkt angezeigt. Grün bedeutet, dass das Feld keine Aufmerksamkeit benötigt. Gelb bedeutet, dass etwas benötigt wird – Dünger, Pflügen oder Walzen. Rot bedeutet, dass die Ernte zur Ernte bereit ist oder dringende Maßnahmen erforderlich sind." />
+        <text name="ft_help_a2_fields_title" text="Felder" />
+        <text name="ft_help_a2_fields_text" text="Hier werden alle Felder aufgelistet, die du besitzt. Du findest hier die Kultur, die aktuelle Wachstumsphase (Aussaat, Wachstum, Erntereif) und eine entspechende farbige Kennzeichnung. Ist das Feld Grün markiert, benötigt das Feld keine Aufmerksamkeit benötigt. Bei einer Gelben Markierung solltest du genauer hinschauen: das Feld benötigt Dünger oder eine Bodenbearbeitung wie durch Pflügen oder Walzen. Rot zeigt dir entweder an, dass deine Kultur zur Ernte bereit ist oder dringende Maßnahmen erforderlich sind." />
         <text name="ft_help_a2_animals_title" text="Tiere" />
-        <text name="ft_help_a2_animals_text" text="Die Tiers-App zeigt jeden Stall, den Sie besitzen, mit drei Fortschrittsbalken an: Futterstand, Wasserstund und Sauberkeit. Grüne Balken erfordern keine Maßnahmen. Gelbe Balken sollten bald aufgefüllt werden. Rote Balken sind kritisch und beeinträchtigen die Produktivität, wenn sie unbeaufsichtigt bleiben." />
-        <text name="ft_help_a3_title" text="Werkstatt- und Bucket-Tracker" />
+        <text name="ft_help_a2_animals_text" text="Die Tier-App zeigt jeden Stall, den du besitzt, mit jeweils drei Balken an: Futter, Wasser und Sauberkeit. Grüne erfordert keine Maßnahmen. Ein Gelber Balken sollte bald aufgefüllt werden. Rote Balken sind kritisch und beeinträchtigen die Produktivität, wenn sie unbeaufsichtigt bleiben." />
+        <text name="ft_help_a3_title" text="Werkstatt und Ladungsübersicht" />
         <text name="ft_help_a3_workshop_title" text="Werkstatt" />
-        <text name="ft_help_a3_workshop_text" text="Gehen Sie weniger als 35 Meter ein ein beliebiges Fahrzeug herein und es wird automatisch in der Workshop-App angezeigt. Jeder Eintrag zeigt den Kraftstoffstand, den Verschleißprozentsatz und die Gesamtbetriebsstunden an. Klicken Sie bei einem beliebigen Fahrzeug auf „AUSWÄHLEN“, um es anzupinnen – angeheftete Fahrzeuge bleiben in der App sichtBalken, auch wenn Sie weggehen, sodass Sie die auf dem Feld arbeitenden Maschinen ganz einfach überwachen können." />
-        <text name="ft_help_a3_bucket_title" text="Eimer-Tracker" />
-        <text name="ft_help_a3_bucket_text" text="Bucket Tracker wird automatisch aktiviert, wenn Sie einen Radlader, Bagger oder Materialumschlaggerät fahren. Es zählt jeden Entladezyklus und führt ein fortlaufendes Protokoll über die Materialart und das geschätzte Gewicht pro Ladung. Verwenden Sie es, um die Produktivität bei Erdarbeiten, Gülleausbringung oder Schüttguttransportarbeiten zu verfolgen." />
-        <text name="ft_help_m1_title" text="Einkommens- und Steuermodifikationen" />
-        <text name="ft_help_m1_income_title" text="FS25 Einkommensmod" />
-        <text name="ft_help_m1_income_text" text="Wenn FS25_IncomeMod aktiv ist, erscheint die Einkommen-App auf dem Startbildschirm. Sie zeigt Zahlungsmodus und Betrag und erlaubt das Ein- oder Ausschalten des Mods, ohne das Tablet zu verlassen. Aenderungen wirken sofort." />
-        <text name="ft_help_m1_tax_title" text="FS25 Steuermod" />
-        <text name="ft_help_m1_tax_text" text="Wenn FS25_TaxMod aktiv ist, zeigt die Steuer-App Ihren aktuellen Steuersatz, den Renditeprozentsatz und die in dieser Sitzung insgesamt gezahlten Steuern an. Sie können den Mod über das Tablet ein- oder ausschalten und sehen auf einen Blick, wie viel Mindestguthaben Sie benötigen." />
-        <text name="ft_help_m2_title" text="Pflanzenstress und Bodendünger" />
-        <text name="ft_help_m2_cropstress_title" text="FS25 Saisonaler Pflanzenstress" />
-        <text name="ft_help_m2_cropstress_text" text="Wenn FS25_SeasonalCropStress aktiv ist, listet die Crop Stress-App jedes Feld mit seinem aktuellen Bodenfeuchtigkeitsprozentsatz und dem akkumulierten Trockenstress auf. Ein farbcodierter Balken zeigt den Gesundheitszustund auf einen Blick an: Grün ist in Ordnung, Gelb ist eine Warnung, Rot bedeutet, dass sich bereits Stress aufbaut und der Ertragsverlust begonnen hat. Installieren Sie diesen Mod und öffnen Sie einen eigenen Hilfebereich für eine vollständige Anleitung zur Bewässerung." />
-        <text name="ft_help_m2_soil_title" text="FS25 Bodendünger" />
-        <text name="ft_help_m2_soil_text" text="Wenn FS25_SoilFertilizer aktiv ist, zeigt die Soil Fertilizer-App Stickstoff, Phosphor, Kalium, pH-Wert und organische Substanz pro Feld an. Wählen Sie ein beliebiges Feld aus der Liste aus, um dessen vollständiges Bodenprofil anzuzeigen und festzustellen, ob es gedüngt werden muss. Der Nährstoffgehalt ist farblich gekennzeichnet: Grün ist gut, Gelb ist mittelmäßig, Rot erfordert Aufmerksamkeit." />
-        <text name="ft_help_m3_title" text="App Store" />
-        <text name="ft_help_m3_appstore_title" text="Erkennen installierter Apps" />
-        <text name="ft_help_m3_appstore_text" text="Die App Store-App listet alle auf dem Tablet registrierten Apps auf, einschließlich Companion-Mod-Apps. Apps, die einen Mod erfordern, der derzeit nicht aktiv ist, werden abgeblendet angezeigt, sodass Sie wissen, dass sie verfügBalken sind, sobald Sie den passenden Mod aktivieren. Es ist keine Konfiguration erforderlich – Begleit-Apps werden automatisch angezeigt, wenn ihr Mod geladen wird." />
+        <text name="ft_help_a3_workshop_text" text="Nähere dich einem beliebiges Fahrzeug auf mindestens 35 m und es wird automatisch in der Werkstatt-App angezeigt. Zu jedem Fahrzeug werden der Kraftstoffstand, der Verschleiß und die Gesamtbetriebsstunden angezeigt. Drücke bei einem beliebigen Fahrzeug auf „ANPINNEN“, um es anzupinnen – angeheftete Fahrzeuge bleiben in der App sichtbar, auch dann, wenn du dich von ihnen entfernst. So kannst du auf dem Feld arbeitenden Maschinen ganz einfach überwachen." />
+        <text name="ft_help_a3_bucket_title" text="Ladungsübersicht" />
+        <text name="ft_help_a3_bucket_text" text="Die Ladungsübersicht wird automatisch aktiviert, wenn du einen Radlader, Bagger oder ein anderes Gerät benutzt mit dem du Material bewegen kannst. Es zählt jeden Entladezyklus und führt ein fortlaufendes Protokoll über die Materialart und das geschätzte Gewicht pro Ladung. Das ist nützlich, um die Produktivität bei Erdarbeiten, der Gülleausbringung oder beim Transport von Schüttgütern zu verfolgen." />
+        <text name="ft_help_m1_title" text="Steuern und Gebühren" />
+        <text name="ft_help_m1_income_title" text="FS25_IncomeMod Integration" />
+        <text name="ft_help_m1_income_text" text="Wenn FS25_IncomeMod aktiv ist, erscheint die Finanzen-App auf dem Startbildschirm. Sie zeigt Zahlungsmodus und Betrag und erlaubt das Ein- oder Ausschalten des Mods, ohne das Tablet zu verlassen. Änderungen wirken sofort." />
+        <text name="ft_help_m1_tax_title" text="FS25_TaxMod Integration" />
+        <text name="ft_help_m1_tax_text" text="Wenn FS25_TaxMod aktiv ist, zeigt die Eichelhäher-App dir deinen aktuellen Steuersatz, den Renditeprozentsatz und die in dieser Sitzung insgesamt gezahlten Steuern an. Du kannst den Mod über das Tablet ein- oder ausschalten und siehst auf einen Blick, wie viel Geld du benötigst." />
+        <text name="ft_help_m2_title" text="Bestandspflege und Düngung" />
+        <text name="ft_help_m2_cropstress_title" text="FS25_SeasonalCropStress Integration" />
+        <text name="ft_help_m2_cropstress_text" text="Wenn FS25_SeasonalCropStress aktiv ist, listet die Bestandspflege-App jedes Feld mit seinem aktuellen Bodenfeuchtigkeitsprozentsatz und dem aufgelaufenen Trockenstress auf. Ein farbiger Balken zeigt den Gesundheitszustund auf einen Blick an: Grün ist in Ordnung, Gelb ist als Warnung zu verstehen und Rot bedeutet, dass sich bereits Stress aufgebaut hat und es zu einer Reduzierung des Ertrags bei der Ernte kommt. Du findest im Hilfebereich der Mod eine genaue Anleitung zur Bewässerung." />
+        <text name="ft_help_m2_soil_title" text="FS25_SoilFertilizer Integration" />
+        <text name="ft_help_m2_soil_text" text="Wenn FS25_SoilFertilizer aktiv ist, zeigt die Düngung-App Stickstoff, Phosphor, Kalium, pH-Wert und organische Substanz für jedes Feld an. Wählen ein beliebiges Feld aus der Liste aus, um dessen vollständiges Bodenprofil anzuzeigen und festzustellen, ob es gedüngt werden muss. Der Nährstoffgehalt ist farblich gekennzeichnet: Grün ist gut, Gelb ist mittelmäßig, Rot erfordert entsprechende Maßnahmen." />
+        <text name="ft_help_m3_title" text="AppStore" />
+        <text name="ft_help_m3_appstore_title" text="Installierte Apps" />
+        <text name="ft_help_m3_appstore_text" text="Im AppStore sind alle auf dem Tablet verfügbaren Apps aufgelistet, einschließlich Kompatibler und Integrierter Mod-Apps. Apps, die eine Mod erfordern, welche derzeit nicht aktiv ist, werden ausgegraut angezeigt. Es ist keine Konfiguration erforderlich - Zusatz-Apps werden automatisch angezeigt, wenn die Mod geladen wird." />
         <text name="ft_help_s1_title" text="Tablet-Einstellungen" />
-        <text name="ft_help_s1_settings_title" text="Was Sie ändern können" />
-        <text name="ft_help_s1_settings_text" text="Oeffne die Einstellungen-App, um das Tablet zu verwalten: Position und Groesse (oder Bearbeitungsmodus), Hintergrundfarbe, eigenes Startbild, den Sperrbildschirm, die Start-App, Toene und Benachrichtigungen. Alles wird automatisch gespeichert." />
+        <text name="ft_help_s1_settings_title" text="Was du ändern kannst" />
+        <text name="ft_help_s1_settings_text" text="Öffne die Einstellungen-App, um das Tablet zu verwalten: Position und Größe (Bearbeitungsmodus), Hintergrundfarbe, ein Benutzerdefiniertes Startbild, den Sperrbildschirm, die Start-App, Töne und Benachrichtigungen. Alles wird automatisch gespeichert." />
         <text name="ft_help_s1_sound_title" text="Soundeffekte" />
-        <text name="ft_help_s1_sound_text" text="Soundeffekte sind standardmäßig aktiviert. Der App-Auswahlklick wird abgespielt, wenn Sie die App wechseln. Der Paging-Sound ertönt, wenn das Hilfefenster im Spiel geöffnet oder geschlossen wird. Beide können unabhängig voneinander in der Einstellungen-App umgeschaltet werden." />
+        <text name="ft_help_s1_sound_text" text="Soundeffekte sind standardmäßig aktiviert. Das App-Auswahlgeräusch wird abgespielt, wenn du die App wechselst. Der Paging-Sound ertönt, wenn das Hilfefenster im Spiel geöffnet oder geschlossen wird. Beide können unabhängig voneinander in der Einstellungen-App umgeschaltet werden." />
         <text name="ft_help_s2_title" text="Konsolenbefehle" />
         <text name="ft_help_s2_console_title" text="Verfügbare Befehle" />
-        <text name="ft_help_s2_console_text" text="Oeffne die Entwicklerkonsole mit der Tilde-Taste und tippe tablet, um alle Befehle zu sehen. Beispiel: TabletKeybind H aendert die Oeffnen-Taste, TabletSetStartupApp weather setzt die Start-App, und TabletResetSettings stellt die Standardwerte wieder her." />
+        <text name="ft_help_s2_console_text" text="Öffne die Entwicklerkonsole mit der Tilde-Taste und schreibe tablet, um alle Befehle zu sehen. Beispiel: TabletKeybind H ändert die Taste zum Öffnen des Tablets, TabletSetStartupApp setzt die Start-App, und TabletResetSettings stellt die Standardwerte wieder her." />
         <text name="ft_common_rare" text="Selten" />
         <text name="ft_common_normal" text="Normal" />
         <text name="ft_common_frequent" text="Häufig" />
-        <text name="ft_common_close" text="SCHLIESSEN" />
+        <text name="ft_common_close" text="SCHLIEẞEN" />
         <text name="ft_network_fee_format" text="Grundgebühr: %s €/Tag" />
         <text name="ft_network_fee_deducted" text="Grundgebühr abgezogen: %d €" />
         <text name="ft_network_provider_changed" text="Anbieter gewechselt: %s." />
         <text name="ft_network_outages_changed" text="Störungen: %s." />
-        <text name="ft_network_outage_label" text="Netzstörung" />
+        <text name="ft_network_outage_label" text="Netzwerkstörung" />
         <text name="ft_network_no_signal_label" text="Kein Empfang" />
         <text name="ft_network_weak_signal_label" text="Schwacher Empfang" />
         <text name="ft_network_medium_short" text="Mittel" />
         <text name="ft_network_good_short" text="Gut" />
         <text name="ft_network_excellent_short" text="Sehr gut" />
-        <text name="ft_network_outage_recovered" text="Netzstörung behoben. Daten werden aktualisiert." />
-        <text name="ft_network_outage_detected" text="Netzstörung erkannt. Dauer ca. %d Ingame-Stunden." />
-        <text name="ft_network_no_reception_here" text="Kein Empfang an diesem Standort." />
+        <text name="ft_network_outage_recovered" text="Netzwerkstörung behoben. Daten werden aktualisiert." />
+        <text name="ft_network_outage_detected" text="Netzwerktstörung. Dauer ca. %d Ingame-Stunden." />
+        <text name="ft_network_no_reception_here" text="Kein Empfang." />
         <text name="ft_network_weak_reception" text="Schwacher Empfang." />
         <text name="ft_network_data_frozen" text="%s - Daten eingefroren" />
         <text name="ft_repair_service_title" text="Tablet-Service" />
@@ -306,8 +306,8 @@
         <text name="ft_repair_done_msg" text="Tablet wieder einsatzbereit." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in Reparatur. Wir melden uns." />
         <text name="ft_repair_title" text="DISPLAYSCHADEN" />
-        <text name="ft_repair_subtitle" text="Displayschaden durch Sturz" />
-        <text name="ft_repair_in_progress" text="Tablet in Reparatur" />
+        <text name="ft_repair_subtitle" text="Displayschaden durch einen Sturz." />
+        <text name="ft_repair_in_progress" text="Dein Tablet befindet sich in Reparatur." />
         <text name="ft_repair_notify_done" text="Wir melden uns, sobald es fertig ist." />
         <text name="ft_repair_stock_available" text="Display vorrätig - Dauer: ca. 1 Spielstunde" />
         <text name="ft_repair_stock_ordered" text="Display bestellt - Dauer: ca. 1 Spieltag" />
@@ -317,47 +317,47 @@
         <text name="ft_settings_base_fee" text="Grundgebühr" />
         <text name="ft_settings_fee_per_day" text="%d €/Tag" />
         <text name="ft_settings_reception" text="Empfang" />
-        <text name="ft_settings_network_outages" text="Netzstörungen" />
+        <text name="ft_settings_network_outages" text="Netzwerkstörungen" />
         <text name="ft_settings_duration" text="Dauer" />
         <text name="ft_settings_ingame_hours" text="%d Ingame-Stunden" />
         <text name="ft_settings_change_provider_button" text="Anbieter: %s" />
         <text name="ft_settings_provider_hint" text="Zum Wechseln klicken | in modSettings gespeichert" />
         <text name="ft_settings_outages_button" text="Störung: %s" />
-        <text name="ft_settings_frequency_hint" text="Aus / Selten / Normal / Häufig" />
+        <text name="ft_settings_frequency_hint" text="Häufigkeit von Netzwerkstörungen" />
         <text name="ft_settings_duration_button" text="Dauer: %d Std." />
-        <text name="ft_settings_outage_duration_hint" text="Dauer einer Netzstörung: 1 / 2 / 3 / 4 Stunden" />
+        <text name="ft_settings_outage_duration_hint" text="Dauer einer Netzstörung in Stunden" />
         <text name="ft_settings_display_damage" text="Displayschaden" />
         <text name="ft_settings_display_damage_button" text="Display: %s" />
-        <text name="ft_settings_display_damage_hint" text="Aus / Selten / Normal / Häufig | Standard: Aus" />
+        <text name="ft_settings_display_damage_hint" text="Häufigkeit von Displayschäden (Standard: Aus)" />
         <text name="ft_settings_reopen_provider_select" text="Anbieter-Auswahl öffnen" />
-        <text name="ft_settings_reopen_provider_hint" text="Öffnet das grosse Anbieter-Auswahlfenster" />
-        <text name="ft_lockscreen_slide_to_unlock" text="Zum Entsperren schieben" />
+        <text name="ft_settings_reopen_provider_hint" text="Öffnet die Anbieter-Auswahl" />
+        <text name="ft_lockscreen_slide_to_unlock" text="Wischen, zum Entsperren" />
         <text name="ft_fields_count" text="%d Felder" />
         <text name="ft_fields_none" text="Du besitzt noch keine Felder." />
-        <text name="ft_fields_none_hint" text="Kaufe Land, um mit dem Farmen zu beginnen." />
-        <text name="ft_fields_badge_ready" text="BEREIT" />
-        <text name="ft_fields_badge_grow" text="WÄCHST" />
-        <text name="ft_fields_badge_empty" text="LEER" />
-        <text name="ft_fields_col_crop" text="FRUCHT" />
+        <text name="ft_fields_none_hint" text="Kaufe Land und beginne deine Felder zu bestellen." />
+        <text name="ft_fields_badge_ready" text="ERNTEREIF" />
+        <text name="ft_fields_badge_grow" text="WACHSTUM" />
+        <text name="ft_fields_badge_empty" text="BRACHLAND" />
+        <text name="ft_fields_col_crop" text="KULTUR" />
         <text name="ft_fields_col_state" text="STATUS" />
         <text name="ft_fields_help_summary_title" text="ÜBERSICHT" />
-        <text name="ft_fields_help_summary_body" text="Oben werden die Summen angezeigt: BEREIT für Felder, die geerntet werden können, WÄCHST für wachsende Kulturen und LEER für Felder ohne aktive Frucht." />
-        <text name="ft_fields_help_columns_title" text="SPALTEN: # / FRUCHT / HA / STATUS" />
-        <text name="ft_fields_help_columns_body" text="# = Feld-ID. FRUCHT = Fruchtart. HA = Feldfläche in Hektar. STATUS = aktueller Feldzustand." />
-        <text name="ft_fields_help_state_colors_title" text="STATUS-FARBEN" />
-        <text name="ft_fields_help_state_colors_body" text="Grün  = bereit zur Ernte. Blau   = wächst normal. Gelb   = benötigt Aufmerksamkeit, z.B. düngen, pflügen oder walzen. Grau   = leer / unbestelltes Feld." />
+        <text name="ft_fields_help_summary_body" text="Oben werden die Summen angezeigt: ERNTEREIF für Felder, die geerntet werden können, WACHSTUM für wachsende Kulturen und BRACHLAND für Felder ohne aktive Frucht." />
+        <text name="ft_fields_help_columns_title" text="SPALTEN: # / KULTUR / HEKTAR / STATUS" />
+        <text name="ft_fields_help_columns_body" text="# = Feld-ID. KULTUR = Fruchtart. HEKTAR = Feldfläche in Hektar. STATUS = aktueller Feldzustand." />
+        <text name="ft_fields_help_state_colors_title" text="FARBEN" />
+        <text name="ft_fields_help_state_colors_body" text="Grün = bereit zur Ernte. Blau = wächst normal. Gelb = benötigt Aufmerksamkeit, z.B. Düngen, Pflügen oder Walzen. Grau = abgeerntet oder brachliegende Fläche." />
         <text name="ft_fields_help_scrolling_title" text="SCROLLEN" />
         <text name="ft_fields_help_scrolling_body" text="Wenn du mehr Felder besitzt, als auf den Bildschirm passen, kann die Liste mit dem Mausrad gescrollt werden." />
-        <text name="ft_field_state_harvest" text="Bereit" />
+        <text name="ft_field_state_harvest" text="Erntereif" />
         <text name="ft_field_state_withered" text="Verdorrt" />
         <text name="ft_field_state_seeded" text="Gesät" />
         <text name="ft_field_state_germinated" text="Gekeimt" />
         <text name="ft_field_state_ripening" text="Reift" />
         <text name="ft_field_state_growing" text="Wächst" />
-        <text name="ft_field_state_empty" text="Leer" />
-        <text name="ft_field_crop_empty" text="Leer" />
+        <text name="ft_field_state_empty" text="Brachland" />
+        <text name="ft_field_crop_empty" text="Brachland" />
         <text name="ft_field_crop_unknown" text="Unbekannt" />
-        <text name="ft_field_state_harvested" text="Geerntet" />
+        <text name="ft_field_state_harvested" text="Abgeerntet" />
         <text name="ft_auto_02d_02d" text="%02d:%02d" />
         <text name="ft_auto_0_19_clear_20_39_partly_40_69_mostly_70_overcast" text="0-19% = Klar  20-39% = Teilweise  40-69% = Meist  70%+ = Bedeckt." />
         <text name="ft_auto_0f" text="%.0f%%" />
@@ -368,14 +368,14 @@
         <text name="ft_auto_0f_km_h" text="%.0f km/h" />
         <text name="ft_auto_0f_width_0f" text="%.0f%%  (Breite: %.0f%%)" />
         <text name="ft_auto_0ft" text="%.0ft" />
-        <text name="ft_auto_100k" text="+$100K" />
-        <text name="ft_auto_10k" text="+$10K" />
+        <text name="ft_auto_100k" text="+100.000 €" />
+        <text name="ft_auto_10k" text="+10.000 €" />
         <text name="ft_auto_12_pm" text="12 Uhr" />
         <text name="ft_auto_14_days" text="14 Tage" />
-        <text name="ft_auto_1_active_job" text="1 aktiv job" />
-        <text name="ft_auto_1_building" text="1 building" />
-        <text name="ft_auto_1_real_time_60_fast_forward" text="1× = real-time  ·  60× = fast-forward&#10;" />
-        <text name="ft_auto_1_silo" text="1 silo" />
+        <text name="ft_auto_1_active_job" text="1 aktiver Auftrag" />
+        <text name="ft_auto_1_building" text="1 Gebäude" />
+        <text name="ft_auto_1_real_time_60_fast_forward" text="1× = Echtzeit  ·  60× = Schnelles Vorspulen&#10;" />
+        <text name="ft_auto_1_silo" text="1 Silo" />
         <text name="ft_auto_1_vehicle" text="1 Fahrzeug" />
         <text name="ft_auto_1f" text="%.1f" />
         <text name="ft_auto_1f_2" text="%.1f%%" />
@@ -383,11 +383,11 @@
         <text name="ft_auto_1f_c_s" text="%.1f C  (%s)" />
         <text name="ft_auto_1f_ha" text="%.1f ha" />
         <text name="ft_auto_1f_km_h" text="%.1f km/h" />
-        <text name="ft_auto_1fh_d_jobs_fatigue_d" text="%.1fh  -  %d jobs  -  fatigue %d%%" />
-        <text name="ft_auto_1k" text="+$1K" />
-        <text name="ft_auto_1k_2" text="+1k" />
-        <text name="ft_auto_1k_3" text="-1k" />
-        <text name="ft_auto_1m" text="+$1M" />
+        <text name="ft_auto_1fh_d_jobs_fatigue_d" text="%.1fh  -  %d Aufträge  -  Müdigkeit %d%%" />
+        <text name="ft_auto_1k" text="+1.000 €" />
+        <text name="ft_auto_1k_2" text="+1.000" />
+        <text name="ft_auto_1k_3" text="-1.000" />
+        <text name="ft_auto_1m" text="+1.000.000 €" />
         <text name="ft_auto_2f_m" text="%.2f m" />
         <text name="ft_auto_30_days" text="30 Tage" />
         <text name="ft_auto_3g" text="3G" />
@@ -397,333 +397,333 @@
         <text name="ft_auto_6_pm" text="18 Uhr" />
         <text name="ft_auto_7_days" text="7 Tage" />
         <text name="ft_auto_90_days" text="90 Tage" />
-        <text name="ft_auto_a_20_return_means_you_effectively_pay_80_of_the" text="A 20% return means you effectively pay 80% of the&#10;" />
-        <text name="ft_auto_a_level_and_a_one_off_signing_cost_hire_to_add" text="ein Stufe und ein one-off Einstellungskosten. EINSTELLEN zu add&#10;" />
-        <text name="ft_auto_a_personnel_command_center_for_fs25_workercosts" text="A personnel command center for FS25_WorkerCosts.&#10;" />
-        <text name="ft_auto_a_rotating_recruitment_pool_each_candidate_has" text="A rotating recruitment pool. Each candidate has&#10;" />
+        <text name="ft_auto_a_20_return_means_you_effectively_pay_80_of_the" text="Eine Rückgabe von 20% bedeutet, du hast effektiv 80% von [X] bezahlt&#10;" />
+        <text name="ft_auto_a_level_and_a_one_off_signing_cost_hire_to_add" text="Einmalige Vermittlungsgebühr&#10;" />
+        <text name="ft_auto_a_personnel_command_center_for_fs25_workercosts" text="Verwaltung für FS25_WorkerCosts.&#10;" />
+        <text name="ft_auto_a_rotating_recruitment_pool_each_candidate_has" text="Eine stetig wechselnde Auswahl an Arbeitskräften. Jede Arbeitskraft hat&#10;" />
         <text name="ft_auto_aac" text="AAC" />
-        <text name="ft_auto_above_ground" text="Über Boden" />
-        <text name="ft_auto_above_ground_how_far_above_or_below_the_terrain" text="Über dem Boden: how far above (oder below) terrain&#10;" />
+        <text name="ft_auto_above_ground" text="Über dem Boden" />
+        <text name="ft_auto_above_ground_how_far_above_or_below_the_terrain" text="Über dem Boden: wie weit Ober- oder Unterhalb des Terrains&#10;" />
         <text name="ft_auto_abs" text="abs:" />
-        <text name="ft_auto_accent" text="ACCENT" />
-        <text name="ft_auto_accept_contracts_from_npcs_on_the_map" text="Accept Aufträge von NPCs on map." />
-        <text name="ft_auto_accept_contracts_from_npcs_on_the_map_or_via_the" text="Accept Aufträge von NPCs on map oder viein the&#10;" />
-        <text name="ft_auto_across_all_active_selling_stations_on_the_map" text="across all aktiv selling stations on map.&#10;" />
-        <text name="ft_auto_actions" text="ACTIONS" />
+        <text name="ft_auto_accent" text="Aktzent" />
+        <text name="ft_auto_accept_contracts_from_npcs_on_the_map" text="Aufträge von NPCs auf der Karte annehmen." />
+        <text name="ft_auto_accept_contracts_from_npcs_on_the_map_or_via_the" text="Aufträge von NPCs auf der Karte oder über den [X] annehmen&#10;" />
+        <text name="ft_auto_across_all_active_selling_stations_on_the_map" text="über alle aktive Stationen auf der Karte hinweg.&#10;" />
+        <text name="ft_auto_actions" text="AKTIONEN" />
         <text name="ft_auto_activate" text="AKTIVIEREN" />
-        <text name="ft_auto_activates_visual_editing_of_the_tablet" text="Aktivierens visual editing of the tablet.&#10;" />
-        <text name="ft_auto_active" text=" ACTIVE" />
-        <text name="ft_auto_active_2" text=" aktiv" />
-        <text name="ft_auto_active_3" text="ACTIVE" />
+        <text name="ft_auto_activates_visual_editing_of_the_tablet" text="Sichtbares Bearbeiten des Tablets aktivieren.&#10;" />
+        <text name="ft_auto_active" text="AKTIV" />
+        <text name="ft_auto_active_2" text="AKTIV" />
+        <text name="ft_auto_active_3" text="AKTIV" />
         <text name="ft_auto_active_4" text="Aktiv" />
         <text name="ft_auto_active_5" text="aktiv" />
-        <text name="ft_auto_active_at_least_one_production_chain_is_enabled_and" text="Aktiv: at least one Produktionskette is aktiviert and&#10;" />
-        <text name="ft_auto_active_contracts" text="ACTIVE AUFTRÄGE" />
-        <text name="ft_auto_active_contracts_2" text="Aktiv Aufträge" />
-        <text name="ft_auto_active_contracts_completion_reward_time_remaining" text="Aktive Aufträge – Fortschritt, Belohnung, Restzeit" />
-        <text name="ft_auto_active_difficulty" text="Aktiv  |  Schwierigkeit: " />
-        <text name="ft_auto_active_event" text="ACTIVE EVENT" />
-        <text name="ft_auto_active_events" text="ACTIVE EVENTS  (" />
-        <text name="ft_auto_active_events_and_their_intensity_are_listed_here" text="Aktive Ereignisse und their Intensität are hier aufgelistet." />
-        <text name="ft_auto_active_favors" text="ACTIVE FAVORS" />
-        <text name="ft_auto_active_favors_2" text="Aktive Gefallen" />
+        <text name="ft_auto_active_at_least_one_production_chain_is_enabled_and" text="Aktiv: es ist mindestens eine Produktionskette aktiviert&#10;" />
+        <text name="ft_auto_active_contracts" text="AKTIVE AUFTRÄGE" />
+        <text name="ft_auto_active_contracts_2" text="Aktive Aufträge" />
+        <text name="ft_auto_active_contracts_completion_reward_time_remaining" text="Aktive Aufträge – Fortschritt, Belohnung, Verbleibende Zeit" />
+        <text name="ft_auto_active_difficulty" text="Schwierigkeitsgrad: " />
+        <text name="ft_auto_active_event" text="Aktives Ereignis" />
+        <text name="ft_auto_active_events" text="Aktive Ereignisse  (" />
+        <text name="ft_auto_active_events_and_their_intensity_are_listed_here" text="Aktive Ereignisse und deren Intensität sind hier aufgelistet." />
+        <text name="ft_auto_active_favors" text="Ausstehende Gefallen" />
+        <text name="ft_auto_active_favors_2" text="Ausstehende Gefallen" />
         <text name="ft_auto_active_fields" text="Aktive Felder" />
         <text name="ft_auto_active_fields_vehicles" text="AKTIVE FELDER / FAHRZEUGE" />
         <text name="ft_auto_active_financing" text="Aktive Finanzierung" />
-        <text name="ft_auto_active_illnesses" text="Aktive Krankheiten" />
-        <text name="ft_auto_active_loans_and_leases_arranged_through_usedplus" text="Aktiv Kredite und Leasingverträge arranged through UsedPlus.&#10;" />
-        <text name="ft_auto_active_mods_show_in_full_colour_with_an_open_button" text="Aktiv mods show in full Farbe mit ein ÖFFNEN button.&#10;" />
+        <text name="ft_auto_active_illnesses" text="Aufgetretene Krankheiten" />
+        <text name="ft_auto_active_loans_and_leases_arranged_through_usedplus" text="Durch Gebraucht+ entstandene Kredite und Leasingverträge.&#10;" />
+        <text name="ft_auto_active_mods_show_in_full_colour_with_an_open_button" text="Aktivierte Mods werden vollständig und mit einem Öffnen-Button angezeigt.&#10;" />
         <text name="ft_auto_active_s" text="Aktiv: %s." />
-        <text name="ft_auto_active_sale_listings" text="ACTIVE SALE LISTINGS" />
-        <text name="ft_auto_active_simulated_normally" text="ACTIVE = simulated normally.&#10;" />
-        <text name="ft_auto_active_stalled" text="ACTIVE / STALLED" />
-        <text name="ft_auto_active_vehicle" text="ACTIVE VEHICLE" />
-        <text name="ft_auto_active_workers" text="Aktive Arbeiter" />
-        <text name="ft_auto_active_world_events_market_price_modifiers" text="aktiv world Ereigniss, Marktpreis-Modifikatoren,&#10;" />
+        <text name="ft_auto_active_sale_listings" text="Aktive Verkäufe" />
+        <text name="ft_auto_active_simulated_normally" text="Normale Simulation&#10;" />
+        <text name="ft_auto_active_stalled" text="Verzögert" />
+        <text name="ft_auto_active_vehicle" text="Aktive Fahrzeuge" />
+        <text name="ft_auto_active_workers" text="Aktive Mitarbeiter" />
+        <text name="ft_auto_active_world_events_market_price_modifiers" text="Aktive Globale Ereignisse, Einfluss auf den Marktpreis (Börse),&#10;" />
         <text name="ft_auto_add_todo" text="+ AUFGABE HINZUFÜGEN" />
-        <text name="ft_auto_added_background_color_picker_in_settings" text="Added Hintergrund Farbe picker in Einstellungen" />
+        <text name="ft_auto_added_background_color_picker_in_settings" text="Hintergrund-Farbwähler in den Einstellungen hinzugefügt" />
         <text name="ft_auto_added_dedicated_server_support" text="Dedicated-Server-Unterstützung hinzugefügt" />
         <text name="ft_auto_added_help_section_to_pause_menu" text="Hilfebereich zum Pausemenü hinzugefügt" />
-        <text name="ft_auto_added_info_icon_per_app_bottom_right_corner" text="Info-Symbol pro App hinzugefügt (unten rechts)" />
+        <text name="ft_auto_added_info_icon_per_app_bottom_right_corner" text="Info-Symbol für jede App (unten rechts) hinzugefügt" />
         <text name="ft_auto_added_multiplayer_support" text="Multiplayer-Unterstützung hinzugefügt" />
-        <text name="ft_auto_added_npc_favor_integration" text="Added NPC Favoder integration" />
-        <text name="ft_auto_added_seasonal_crop_stress_integration" text="Added Seasonal Frucht Stress integration" />
-        <text name="ft_auto_added_soil_fertilizer_integration" text="Added Soil Fertilizer integration" />
+        <text name="ft_auto_added_npc_favor_integration" text="Unterstützung für die Mod FS25_NPC_Favor hinzugefügt" />
+        <text name="ft_auto_added_seasonal_crop_stress_integration" text="Unterstützung für die Mod FS25_SeasonalCropStress hinzugefügt" />
+        <text name="ft_auto_added_soil_fertilizer_integration" text="Unterstützung für die Mod FS25_SoilFertilizer hinzugefügt" />
         <text name="ft_auto_added_translations_for_26_languages" text="Übersetzungen für 26 Sprachen hinzugefügt" />
-        <text name="ft_auto_address_these_fields_first_to_protect_your_harvest" text="Bearbeite diese Felder zuerst, um deine Ernte zu schützen." />
-        <text name="ft_auto_adds_funds_to_your_farm_account" text="Adds funds to your farm account.&#10;" />
-        <text name="ft_auto_adjusted_in_the_market_dynamics_mod_settings" text="adjusted in the Markt Dynamics mod settings." />
+        <text name="ft_auto_address_these_fields_first_to_protect_your_harvest" text="Bearbeite diese Felder zuerst, um deine Ernte zu sichern." />
+        <text name="ft_auto_adds_funds_to_your_farm_account" text="Fügt deinem Hof-Bankguthaben Geld hinzu.&#10;" />
+        <text name="ft_auto_adjusted_in_the_market_dynamics_mod_settings" text="angepasst in den Markt Dynamik Einstellungen." />
         <text name="ft_auto_adm" text="ADM" />
         <text name="ft_auto_admin" text="Admin" />
         <text name="ft_auto_admin_2" text="admin" />
-        <text name="ft_auto_admin_controls_money_time_vehicle_repair_fuel" text="Admin controls: money, time, Fahrzeug reparieren/Kraftstoff" />
-        <text name="ft_auto_advances_to_tomorrow_if_time_has_passed_today" text="Advances to tomorrow if time has passed today." />
-        <text name="ft_auto_advice_discounts_and_early_warnings" text="advice, discounts, and early warnings." />
-        <text name="ft_auto_after_a_fixed_duration" text="after a fixed duration." />
-        <text name="ft_auto_agent_shows_vehicle_name_asking_price_range_agent" text="agent. Anzeigens Fahrzeug name, asking Preis range, agent&#10;" />
+        <text name="ft_auto_admin_controls_money_time_vehicle_repair_fuel" text="Administrator: Geld, Zeit, Fahrzeug Reparieren/Tanken" />
+        <text name="ft_auto_advances_to_tomorrow_if_time_has_passed_today" text="Springt zum nächsten Tag, wenn die Uhrzeit bereits überschritten wurde." />
+        <text name="ft_auto_advice_discounts_and_early_warnings" text="Ratschläge, Rabatte und Warnungen." />
+        <text name="ft_auto_after_a_fixed_duration" text="nach einer festen Zeit." />
+        <text name="ft_auto_agent_shows_vehicle_name_asking_price_range_agent" text="Verkäufer zeigt den Fahrzeugnamen und fragt nach der Preisspanne&#10;" />
         <text name="ft_auto_agraconnect" text="AgraConnect" />
         <text name="ft_auto_agraconnect_2" text="agraconnect" />
         <text name="ft_auto_agrar" text="agrar" />
         <text name="ft_auto_ai" text="AI" />
         <text name="ft_auto_ai_2" text="[AI]" />
-        <text name="ft_auto_ai_badge_appears_when_the_vehicle_is_driven_by_a_hired" text="AI badge appears when Fahrzeug is driven by ein hired Arbeiter.&#10;" />
+        <text name="ft_auto_ai_badge_appears_when_the_vehicle_is_driven_by_a_hired" text="AI-Badge erscheint wenn das Fahrzeug von einem Angestellten gesteuert wird.&#10;" />
         <text name="ft_auto_akita" text="akita" />
         <text name="ft_auto_akita83" text="Akita83" />
-        <text name="ft_auto_all" text="All" />
-        <text name="ft_auto_all_2" text="all" />
-        <text name="ft_auto_all_apps" text="all apps" />
-        <text name="ft_auto_all_apps_rewritten_with_new_drawer_pattern" text="All apps rewritten with new drawer pattern" />
-        <text name="ft_auto_all_done" text="All done!" />
-        <text name="ft_auto_all_four_nutrients_should_be_green_for_optimal_yield" text="All four nutrients should be green for optimal yield.&#10;" />
-        <text name="ft_auto_all_known_companion_mod_integrations_are_listed_here" text="All kjetztn companion mod integrations are listed here.&#10;" />
-        <text name="ft_auto_all_owned_fields_with_crop_and_growth_state" text="Alle Felder mit Frucht- und Wachstumsstatus" />
-        <text name="ft_auto_all_owned_vehicles_fuel_wear_operating_hours" text="Alle eigenen Fahrzeuge – Kraftstoff, Verschleiß, Betriebsstunden" />
+        <text name="ft_auto_all" text="alle" />
+        <text name="ft_auto_all_2" text="alle" />
+        <text name="ft_auto_all_apps" text="alle apps" />
+        <text name="ft_auto_all_apps_rewritten_with_new_drawer_pattern" text="Alle Apps neu geschrieben." />
+        <text name="ft_auto_all_done" text="Alles erledigt!" />
+        <text name="ft_auto_all_four_nutrients_should_be_green_for_optimal_yield" text="Alle vier Makronährstoffe sollten für einen optimalen Ertrag grün gefärbt sein.&#10;" />
+        <text name="ft_auto_all_known_companion_mod_integrations_are_listed_here" text="Alle bekannten und kompatiblen, integrierten Mods sind hier aufgelistet.&#10;" />
+        <text name="ft_auto_all_owned_fields_with_crop_and_growth_state" text="Alle Felder mit Kultur und Wachstumsstufe" />
+        <text name="ft_auto_all_owned_vehicles_fuel_wear_operating_hours" text="Alle eigenen Fahrzeuge mit Kraftstofffüllstand, Verschleiß und Betriebsstunden" />
         <text name="ft_auto_always_active" text="(immer aktiv)" />
         <text name="ft_auto_amount" text="$amount" />
         <text name="ft_auto_amount_2" text="AMOUNT" />
         <text name="ft_auto_amount_3" text="Betrag" />
-        <text name="ft_auto_amounts_1k_10k_100k_1m" text="Amounts: +$1K · +$10K · +$100K · +$1M" />
-        <text name="ft_auto_amounts_shown_in_litres_sorted_largest_first" text="Betrags shown in litres, sorted largest-first.&#10;" />
-        <text name="ft_auto_an_empty_bar_means_the_field_is_critically_dry" text="Ein leerer Balken bedeutet, dass das Feld kritisch trocken ist." />
-        <text name="ft_auto_and_a_colour_coded_bar" text="and a colour-coded bar.&#10;" />
-        <text name="ft_auto_and_applying_slurry_or_solid_manure" text="and applying slurry or solid manure." />
-        <text name="ft_auto_and_cleanliness_together_keeping_all_three_bars_green" text="and cleanliness together. Keeping all three bars green&#10;" />
-        <text name="ft_auto_and_event_frequency_settings" text="und Ereignis frequency settings." />
-        <text name="ft_auto_and_fatigue_sort_and_filter_the_list_pin_a" text="and fatigue. Sort and filter the list. PIN a&#10;" />
-        <text name="ft_auto_and_how_long_the_job_took" text="and how long the job took." />
-        <text name="ft_auto_and_is_currently_working_on" text="and is currently working on.&#10;" />
-        <text name="ft_auto_and_is_independent_of_contract_decorative_states" text="und is indeStalldent of contract/decorative states." />
-        <text name="ft_auto_and_liquid_manure_tanks" text="and liquid manure tanks." />
-        <text name="ft_auto_and_returns_a_configurable_percentage_as_a_rebate" text="and returns a configurable percentage as a rebate." />
-        <text name="ft_auto_and_the_selected_vehicle_has_more_than_2_wear" text="and the selected Fahrzeug has more than 2% wear.&#10;" />
-        <text name="ft_auto_and_time_of_day" text="und Tageszeit." />
-        <text name="ft_auto_and_total_owed_red_across_all_pending_invoices" text="and total owed (red) across all Stallding invoices." />
+        <text name="ft_auto_amounts_1k_10k_100k_1m" text="Betrag: +1.000 € · +10.000 € · +100.000 € · +1.000.000 €" />
+        <text name="ft_auto_amounts_shown_in_litres_sorted_largest_first" text="Beträge angezeigt in Litern, Höchstmenge zuerst.&#10;" />
+        <text name="ft_auto_an_empty_bar_means_the_field_is_critically_dry" text="Ein leerer Balken bedeutet, dass das Feld zu trocken ist." />
+        <text name="ft_auto_and_a_colour_coded_bar" text="und ein farbiger Balken.&#10;" />
+        <text name="ft_auto_and_applying_slurry_or_solid_manure" text="und ausbringen von Gülle oder Mist." />
+        <text name="ft_auto_and_cleanliness_together_keeping_all_three_bars_green" text="und Sauberkeit zusammen, halten alle drei Balken im Grünen Bereich&#10;" />
+        <text name="ft_auto_and_event_frequency_settings" text="und Ereignishäufigkeit." />
+        <text name="ft_auto_and_fatigue_sort_and_filter_the_list_pin_a" text="und Müdigkeit. Sortiere und Ffltere die Liste. Hefte eine an&#10;" />
+        <text name="ft_auto_and_how_long_the_job_took" text="und wie lange der Auftrag gedauert hat." />
+        <text name="ft_auto_and_is_currently_working_on" text="und arbeitet derzeit daran.&#10;" />
+        <text name="ft_auto_and_is_independent_of_contract_decorative_states" text="und ist unabhägig vom optischen Zustand des Auftrags." />
+        <text name="ft_auto_and_liquid_manure_tanks" text="und Flüssigdüngerbehälter." />
+        <text name="ft_auto_and_returns_a_configurable_percentage_as_a_rebate" text="und gibt einen konfigurierbaren Prozentsatz als Rabatt." />
+        <text name="ft_auto_and_the_selected_vehicle_has_more_than_2_wear" text="und das ausgewählte Fahrzeug hat mehr als 2% Abnutzung.&#10;" />
+        <text name="ft_auto_and_time_of_day" text="und die Tageszeit." />
+        <text name="ft_auto_and_total_owed_red_across_all_pending_invoices" text="und über alle offenen Rechnungen (Mahnungen) zusammen." />
         <text name="ft_auto_ani" text="ANI" />
         <text name="ft_auto_animal" text="Tier" />
         <text name="ft_auto_animal_auto_care" text="animal_auto_care" />
-        <text name="ft_auto_animal_care" text="Tier Care" />
+        <text name="ft_auto_animal_care" text="Tierpflege" />
         <text name="ft_auto_animal_pens" text="Tierställe" />
-        <text name="ft_auto_animal_pens_food_water_cleanliness" text="Tierställe – Futter, Wasser, Sauberkeit" />
-        <text name="ft_auto_animal_pens_with_per_metric_color_bars" text="Tier Ställe mit per-metric Farbe Balkens" />
+        <text name="ft_auto_animal_pens_food_water_cleanliness" text="Tierställe, Futter, Wasser, Hygiene" />
+        <text name="ft_auto_animal_pens_with_per_metric_color_bars" text="Tierställe mit Farbbalken" />
         <text name="ft_auto_animal_vet_system" text="animal_vet_system" />
         <text name="ft_auto_animalautocare" text="AnimalAutoCare" />
-        <text name="ft_auto_animalautocare_status_and_safe_care_trigger" text="AnimalAutoCare status and safe care trigger" />
+        <text name="ft_auto_animalautocare_status_and_safe_care_trigger" text="AnimalAutoCare Zustand und SafeCare Auslöser" />
         <text name="ft_auto_animalautocare_was_not_detected" text="AnimalAutoCare wurde nicht erkannt." />
         <text name="ft_auto_animals" text="Tiere" />
         <text name="ft_auto_animals_2" text="animals" />
         <text name="ft_auto_animals_3" text="animals_" />
-        <text name="ft_auto_animals_number_of_animal_pens_on_your_farm" text="Tiere: number of animal Ställe on your farm.&#10;" />
-        <text name="ft_auto_animals_without_water_lose_productivity_quickly" text="Tiere without water lose productivity quickly." />
+        <text name="ft_auto_animals_number_of_animal_pens_on_your_farm" text="Anzahl deiner Ställe.&#10;" />
+        <text name="ft_auto_animals_without_water_lose_productivity_quickly" text="Tiere ohne Zugang zu Wasser verlieren schnell an Produktivität." />
         <text name="ft_auto_animalvetsystem" text="AnimalVetSystem" />
-        <text name="ft_auto_animalvetsystem_illness_and_treatment_monitor" text="AnimalVetSystem illness and treatment monitor" />
+        <text name="ft_auto_animalvetsystem_illness_and_treatment_monitor" text="AnimalVetSystem Krankheits- und Behandlungsübersicht (Herdbuch)." />
         <text name="ft_auto_animalvetsystem_was_not_detected" text="AnimalVetSystem wurde nicht erkannt." />
-        <text name="ft_auto_any_field" text="Any Feld" />
-        <text name="ft_auto_any_placeable_with_bulk_storage_you_own" text="Jedes platzierbare Objekt mit Massengutlager in deinem Besitz:&#10;" />
-        <text name="ft_auto_any_vehicle_within_35_metres_appears_automatically" text="Any Fahrzeug within 35 metres appears automatically.&#10;" />
+        <text name="ft_auto_any_field" text="jedes Feld" />
+        <text name="ft_auto_any_placeable_with_bulk_storage_you_own" text="Jedes platzierbare Objekt mit Schüttgutlager in deinem Besitz:&#10;" />
+        <text name="ft_auto_any_vehicle_within_35_metres_appears_automatically" text="Jedes Fahrzeug innerhalb von 35 m erscheint automatisch.&#10;" />
         <text name="ft_auto_app" text="App" />
         <text name="ft_auto_app_2" text="app" />
-        <text name="ft_auto_app_cannot_be_undone" text="app. Cannot be undone." />
+        <text name="ft_auto_app_cannot_be_undone" text="App. Kann nicht Rückgängig gemacht werden." />
         <text name="ft_auto_app_error" text="App-Fehler" />
         <text name="ft_auto_app_labels" text="APP-BESCHRIFTUNGEN: " />
         <text name="ft_auto_app_registered" text="app_registered" />
-        <text name="ft_auto_app_select_sound_click_when_switching_sidebar_apps" text="App Select Ton: klicken when switching sideBalken apps.&#10;" />
+        <text name="ft_auto_app_select_sound_click_when_switching_sidebar_apps" text="Geräusch beim Wechseln in der App-Auswahl der Seitenleiste.&#10;" />
         <text name="ft_auto_app_select_sound_off" text="App-Ton: Aus" />
         <text name="ft_auto_app_select_sound_on" text="App-Ton: An" />
-        <text name="ft_auto_app_store" text="App Store" />
+        <text name="ft_auto_app_store" text="AppStore" />
         <text name="ft_auto_app_store_2" text="app_store" />
         <text name="ft_auto_app_switched" text="app_switched" />
         <text name="ft_auto_appearance" text="DARSTELLUNG" />
         <text name="ft_auto_append" text="apStalld" />
-        <text name="ft_auto_apply_fertilizer" text="Apply fertilizer" />
-        <text name="ft_auto_apply_lime_to_raise_ph_or_sulphur_to_lower_it" text="Apply lime to raise pH or sulphur to lower it." />
-        <text name="ft_auto_apply_the_correct_fertiliser_type_to_raise_each_one" text="Apply the correct fertiliser type to raise each one." />
-        <text name="ft_auto_appregistry_dynamic_app_registration_system" text="AppRegistry: dynamic app registration system" />
+        <text name="ft_auto_apply_fertilizer" text="Dünger ausbringen" />
+        <text name="ft_auto_apply_lime_to_raise_ph_or_sulphur_to_lower_it" text="Bringe Kalk aus um den pH-Wert zu steigern oder Schwefel um ihn zu senken." />
+        <text name="ft_auto_apply_the_correct_fertiliser_type_to_raise_each_one" text="Bringe das richtige Düngemittel aus um den jeweiligen Nährstoffgehalt zu erhöhen." />
+        <text name="ft_auto_appregistry_dynamic_app_registration_system" text="AppRegistry: dynamische App-Registration" />
         <text name="ft_auto_apps" text="APPS" />
         <text name="ft_auto_apps_loaded" text="Apps geladen" />
-        <text name="ft_auto_are_below_the_original_ground_height" text="are below the original ground height." />
+        <text name="ft_auto_are_below_the_original_ground_height" text="sind unter der ursprünglichen Bodenhöhe." />
         <text name="ft_auto_area" text="Fläche" />
         <text name="ft_auto_area_2" text="Area: " />
-        <text name="ft_auto_area_total_farmland_owned_in_hectares" text="Area: total farmland im Besitz in hectares.&#10;" />
-        <text name="ft_auto_at" text=" at " />
-        <text name="ft_auto_attached" text="Attached" />
-        <text name="ft_auto_attached_implements_are_listed_below_the_speed" text="Attached implements are listed below the speed." />
+        <text name="ft_auto_area_total_farmland_owned_in_hectares" text="Gesamtfläche im Besitz (in Hektar)&#10;" />
+        <text name="ft_auto_at" text=" auf " />
+        <text name="ft_auto_attached" text="Angehängt" />
+        <text name="ft_auto_attached_implements_are_listed_below_the_speed" text="Angebaute Geräte sind unterhalb der Geschwindigkeit aufgelistet." />
         <text name="ft_auto_author" text="Autor" />
-        <text name="ft_auto_automatic_detection" text="AUTOMATIC DETECTION" />
-        <text name="ft_auto_automatically_via_its_public_api" text="automatically via its public API.&#10;" />
+        <text name="ft_auto_automatic_detection" text="Automatische Erkennung" />
+        <text name="ft_auto_automatically_via_its_public_api" text="automatisch über die öffentliche API.&#10;" />
         <text name="ft_auto_autumn" text="Herbst" />
         <text name="ft_auto_available" text="Verfügbar" />
-        <text name="ft_auto_back" text="&lt; BACK" />
-        <text name="ft_auto_back_2" text="back" />
+        <text name="ft_auto_back" text="&lt; Zurück" />
+        <text name="ft_auto_back_2" text="zurück" />
         <text name="ft_auto_background" text="HINTERGRUND: " />
         <text name="ft_auto_background_color" text="HINTERGRUNDFARBE" />
-        <text name="ft_auto_backhoe" text="backhoe" />
-        <text name="ft_auto_balance" text="Balance" />
-        <text name="ft_auto_balance_2" text="balance" />
-        <text name="ft_auto_balance_3" text="balance_" />
-        <text name="ft_auto_balance_loan_income_expenses_net_pl_fields_vehicles_sea" text="balance,loan,income,exStällees,net_pl,Felder,Fahrzeuge,season,Tag,time,weather" />
-        <text name="ft_auto_balance_manage_deals_in_the_usedplus_finance_menu" text="balance. Manage deals in the UsedPlus finance menu." />
-        <text name="ft_auto_balance_your_current_available_money" text="Balance: your current available money.&#10;" />
-        <text name="ft_auto_bale_hay_straw" text="Bale hay / straw" />
-        <text name="ft_auto_baling" text="Baling" />
+        <text name="ft_auto_backhoe" text="Bagger" />
+        <text name="ft_auto_balance" text="Kontostand" />
+        <text name="ft_auto_balance_2" text="Kontostand" />
+        <text name="ft_auto_balance_3" text="Kontostand" />
+        <text name="ft_auto_balance_loan_income_expenses_net_pl_fields_vehicles_sea" text="Kontostand,Kredit,Einnahmen,Ausgaben,net_pl,Felder,Fahrzeuge,Jahreszeit,Tag,Uhrzeit,Wetter" />
+        <text name="ft_auto_balance_manage_deals_in_the_usedplus_finance_menu" text="Kontostand. Verwalte deine Angebote im Gebraucht+ Finanzmenü." />
+        <text name="ft_auto_balance_your_current_available_money" text="Kontostand: dein aktuell verfügbares Geld.&#10;" />
+        <text name="ft_auto_bale_hay_straw" text="Stroh- oder Heuballen" />
+        <text name="ft_auto_baling" text="Ballenpressen" />
         <text name="ft_auto_bank" text="Bank" />
-        <text name="ft_auto_bar_length_reflects_the_rain_scale_value_0_100" text="Bar length reflects the rain scale value (0-100%)." />
+        <text name="ft_auto_bar_length_reflects_the_rain_scale_value_0_100" text="Die Länge der Anzeige gibt die Stärke des Regens wieder (0-100%)." />
         <text name="ft_auto_base_fee" text="Grundgebühr" />
-        <text name="ft_auto_base_fee_deducted_d" text="Base fee deducted: %d €" />
-        <text name="ft_auto_base_fee_s_day" text="Base fee: %s €/Tag" />
-        <text name="ft_auto_base_rate" text="Base Rate" />
+        <text name="ft_auto_base_fee_deducted_d" text="Grundgebühr abgezogen: %d €" />
+        <text name="ft_auto_base_fee_s_day" text="Grundgebühr: %s €/Tag" />
+        <text name="ft_auto_base_rate" text="Grundrate" />
         <text name="ft_auto_bck" text="BCK" />
-        <text name="ft_auto_best_sell_prices" text="BEST SELL PRICES" />
-        <text name="ft_auto_best_sell_prices_per_1_000_l" text="BEST SELL PRICES  (per 1,000 L)" />
-        <text name="ft_auto_between_25_and_75_of_the_listing_window" text="between 25% and 75% of the listing window.&#10;" />
+        <text name="ft_auto_best_sell_prices" text="Höchstpreis (Verkauf)" />
+        <text name="ft_auto_best_sell_prices_per_1_000_l" text="Höchstpreis pro 1.000 Liter" />
+        <text name="ft_auto_between_25_and_75_of_the_listing_window" text="zwischen 25% und 75% aufgezeichneten Zeitraums.&#10;" />
         <text name="ft_auto_boolean" text="boolean" />
-        <text name="ft_auto_breakdowns_repair_before_reaching_80" text="breakdowns — reparieren before reaching 80%." />
+        <text name="ft_auto_breakdowns_repair_before_reaching_80" text="Ausfälle — reparieren bevore 80% erreicht werden." />
         <text name="ft_auto_browse_and_manage_installed_apps" text="Installierte Apps durchsuchen und verwalten" />
-        <text name="ft_auto_bucket" text="bucket" />
-        <text name="ft_auto_bucket_fill_level_and_material_type_as_a_bar" text="bucket fill level and material type as a bar.&#10;" />
-        <text name="ft_auto_bucket_loader_load_counter" text="Schaufel-/Lader-Ladungszähler" />
-        <text name="ft_auto_bucket_tracker" text="Schaufelzähler" />
+        <text name="ft_auto_bucket" text="Ladevolumen" />
+        <text name="ft_auto_bucket_fill_level_and_material_type_as_a_bar" text="Füllvolumen und Art des Material als Leiste.&#10;" />
+        <text name="ft_auto_bucket_loader_load_counter" text="Schaufel- und Ladungszähler" />
+        <text name="ft_auto_bucket_tracker" text="Ladungsübersicht" />
         <text name="ft_auto_bucket_tracker_2" text="bucket_tracker" />
-        <text name="ft_auto_bucket_tracker_app_introduced" text="Bucket Tracker app introduced" />
-        <text name="ft_auto_bucket_tracker_summary_stat_cards" text="Bucket Tracker: summary stat cards" />
+        <text name="ft_auto_bucket_tracker_app_introduced" text="Ladungsübersicht" />
+        <text name="ft_auto_bucket_tracker_summary_stat_cards" text="Ladungsübersicht: Zusammenfassung" />
         <text name="ft_auto_bug_reports" text="Fehler melden:" />
-        <text name="ft_auto_building" text="Building" />
-        <text name="ft_auto_building_list" text="BUILDING LIST" />
-        <text name="ft_auto_building_relationships" text="BUILDING RELATIONSHIPS" />
-        <text name="ft_auto_buildings" text=" buildings" />
+        <text name="ft_auto_building" text="Gebäude" />
+        <text name="ft_auto_building_list" text="Gebäude Liste" />
+        <text name="ft_auto_building_relationships" text="Zusammenhänge zwischen Gebäuden" />
+        <text name="ft_auto_buildings" text=" Gebäude" />
         <text name="ft_auto_built_in" text="BUILT-IN" />
         <text name="ft_auto_built_in_2" text="Integriert" />
-        <text name="ft_auto_built_in_apps_show_built_in_as_their_version" text="Integriert apps show 'Integriert' as their version.&#10;" />
-        <text name="ft_auto_bullet_points_below_list_individual_changes" text="Bullet points below list individual changes." />
+        <text name="ft_auto_built_in_apps_show_built_in_as_their_version" text="Integrierte Apps werden in der Version 'Integriert' angezeigt.&#10;" />
+        <text name="ft_auto_bullet_points_below_list_individual_changes" text="Die folgenden Stichpunkte zeigen die Veränderungen." />
         <text name="ft_auto_busy" text="Beschäftigt" />
-        <text name="ft_auto_buy_equipment" text="Buy equipment" />
+        <text name="ft_auto_buy_equipment" text="Ausrüstung kaufen" />
         <text name="ft_auto_c" text="-- C" />
         <text name="ft_auto_cancel" text="ABBRECHEN" />
         <text name="ft_auto_canola" text="RAPS" />
-        <text name="ft_auto_capacity_e_g_78_390l_500l" text="capacity (e.g. 78%  (390L / 500L)).&#10;" />
-        <text name="ft_auto_care_cost" text="Care Cost" />
-        <text name="ft_auto_care_now" text="Care Now" />
+        <text name="ft_auto_capacity_e_g_78_390l_500l" text="Kapazität (z.B. 78%  (390 L / 500 L)).&#10;" />
+        <text name="ft_auto_care_cost" text="Pflegekosten" />
+        <text name="ft_auto_care_now" text="Pflegen" />
         <text name="ft_auto_cases" text="FÄLLE" />
-        <text name="ft_auto_categories_shown_field_shop_mission_vehicle" text="Categories shown: Field, Shop, Mission, Vehicle,&#10;" />
+        <text name="ft_auto_categories_shown_field_shop_mission_vehicle" text="Kategorien angezeigt: Feld, Händler, Auftrag, Fahrzeug,&#10;" />
         <text name="ft_auto_change_provider_s" text="CHANGE PROVIDER: %s" />
-        <text name="ft_auto_change_renamed_the_confusing_desel_button_to_unpin_work" text="Change: renamed the confusing 'DESEL' button to 'UNPIN' (Werkstatt and Income)" />
+        <text name="ft_auto_change_renamed_the_confusing_desel_button_to_unpin_work" text="den verwirrenden 'DESEL' in 'UNPIN' umbenannt (Werkstatt und Finanzen)" />
         <text name="ft_auto_changelog" text="Changelog" />
         <text name="ft_auto_changelog_and_update_history" text="Änderungsverlauf und Updates" />
-        <text name="ft_auto_changes_are_saved_automatically" text="Changes are saved automatically." />
+        <text name="ft_auto_changes_are_saved_automatically" text="Änderungen werden automatisch gespeichert." />
         <text name="ft_auto_changes_take_effect_immediately" text="Änderungen werden sofort übernommen." />
-        <text name="ft_auto_changes_the_screen_background_of_the_tablet" text="Changes the screen background of the tablet.&#10;" />
-        <text name="ft_auto_charge" text="LADEN" />
-        <text name="ft_auto_charge_briefly_to_continue" text="Kurz laden, um fortzufahren." />
-        <text name="ft_auto_check" text="Check" />
+        <text name="ft_auto_changes_the_screen_background_of_the_tablet" text="Ändert den Hintergrund des Tablets.&#10;" />
+        <text name="ft_auto_charge" text="AUFLADEN" />
+        <text name="ft_auto_charge_briefly_to_continue" text="Kurz aufladen, um fortzufahren." />
+        <text name="ft_auto_check" text="Prüfen" />
         <text name="ft_auto_check_2" text="^check" />
-        <text name="ft_auto_check_contracts" text="Check Aufträge" />
-        <text name="ft_auto_check_repo" text="Check Repo" />
-        <text name="ft_auto_check_weather" text="Check weather" />
-        <text name="ft_auto_check_your_storage_app_to_ensure_inputs_are_stocked" text="Check your Lager app to ensure inputs are stocked.&#10;" />
-        <text name="ft_auto_checkbox_style_farm_todo_list" text="Hof-Aufgabenliste mit Kontrollkästchen" />
-        <text name="ft_auto_cheese_factory" text="Cheese Factory" />
+        <text name="ft_auto_check_contracts" text="Prüfe Aufträge" />
+        <text name="ft_auto_check_repo" text="Prüfe Repository" />
+        <text name="ft_auto_check_weather" text="Prüfe Wetter" />
+        <text name="ft_auto_check_your_storage_app_to_ensure_inputs_are_stocked" text="Überprüfe deine Lager-App um sicherzustellen, ob auch alles eingelagert wird.&#10;" />
+        <text name="ft_auto_checkbox_style_farm_todo_list" text="To-Do Liste für Aufgaben auf deinem Hof" />
+        <text name="ft_auto_cheese_factory" text="Käserei" />
         <text name="ft_auto_cheesefactory" text="cheeseFactory" />
         <text name="ft_auto_choose_network_provider" text="Netzanbieter wählen" />
         <text name="ft_auto_chore_bumped_version_to_2_2_0_0" text="Chore: Bumped version to 2.2.0.0" />
-        <text name="ft_auto_clean_animal_pens" text="Sauber animal Ställe" />
-        <text name="ft_auto_cleanliness_percentage_for_chickens_and_sheep" text="cleanliness percentage for chickens and sheep.&#10;" />
+        <text name="ft_auto_clean_animal_pens" text="Ställe reinigen" />
+        <text name="ft_auto_cleanliness_percentage_for_chickens_and_sheep" text="Sauberkeit in Prozent für Hühner und Schafe.&#10;" />
         <text name="ft_auto_clear" text="CLEAR" />
-        <text name="ft_auto_clear_2" text="Klar" />
+        <text name="ft_auto_clear_2" text="Entfernen" />
         <text name="ft_auto_clear_3" text="clear" />
-        <text name="ft_auto_clear_all" text="ALLE LÖSCHEN" />
-        <text name="ft_auto_clear_all_d" text="CLEAR ALL (%d)" />
-        <text name="ft_auto_clear_completed_remove_all_done_tasks_at_once" text="CLEAR COMPLETED — remove all done tasks at once" />
-        <text name="ft_auto_clear_d_completed" text="CLEAR %d COMPLETED" />
-        <text name="ft_auto_clears_all_load_history_and_resets_the_session_totals" text="Klars all load history and resets the session totals&#10;" />
+        <text name="ft_auto_clear_all" text="ALLE ENTFERNEN" />
+        <text name="ft_auto_clear_all_d" text="Alle entfernen (%d)" />
+        <text name="ft_auto_clear_completed_remove_all_done_tasks_at_once" text="Entfernen erfolgreich - alle erledigten Aufgaben wurden entfernt." />
+        <text name="ft_auto_clear_d_completed" text="%d erfolgreich entfernt" />
+        <text name="ft_auto_clears_all_load_history_and_resets_the_session_totals" text="entfernt alle gespeicherten Ladevorgänge und setzt die Werte für die gesamte Spiel-Session zurück.&#10;" />
         <text name="ft_auto_click" text="click" />
-        <text name="ft_auto_click_open_on_any_app_row_to_switch_to_it_directly" text="Klicken ÖFFNEN on any app row zu switch zu it directly.&#10;" />
-        <text name="ft_auto_click_select_on_a_vehicle_to_pin_its_diagnostics_in" text="Klicken SELECT on ein Fahrzeug zu pin its diagnostics in&#10;" />
-        <text name="ft_auto_click_select_on_any_field_row_to_open_its_detailed" text="Klicken SELECT on any Feld row zu oStall its detailed&#10;" />
-        <text name="ft_auto_click_the_button_to_cycle_through_available_options" text="Klicken button zu wechseln through available options.&#10;" />
-        <text name="ft_auto_click_to_change_saved_in_modsettings" text="Zum Wechseln klicken | gespeichert in modSettings" />
-        <text name="ft_auto_click_to_cycle_app_opened_first_when_tablet_starts" text="Zum Wechseln klicken  |  App oStalled first when tablet starts" />
-        <text name="ft_auto_click_to_cycle_icon_label_text_size" text="Zum Wechseln klicken  |  Icon label text size" />
-        <text name="ft_auto_click_to_cycle_screen_background_color" text="Zum Wechseln klicken  |  Screen background color" />
-        <text name="ft_auto_click_to_cycle_through_6_preset_dark_themes" text="Zum Wechseln klicken through 6 preset dark themes:&#10;" />
-        <text name="ft_auto_click_to_cycle_white_gold_or_each_app_s_accent" text="Zum Wechseln klicken | Weiss, Gold oder App-Farbe" />
-        <text name="ft_auto_click_to_instantly_restore_the_vehicle_to_new_condition" text="Klicken zu instantly restore Fahrzeug zu new condition." />
-        <text name="ft_auto_click_unpin_to_close_the_detail_view" text="Klicken UNANHEFTEN zu close detail view." />
-        <text name="ft_auto_clock_farm_name_in_persistent_topbar" text="Clock + farm name in persistent topbar" />
-        <text name="ft_auto_close" text="SCHLIESSEN" />
-        <text name="ft_auto_close_tablet" text="Schliessen tablet" />
-        <text name="ft_auto_closed" text="Schliessend" />
-        <text name="ft_auto_cloud" text="CLOUD" />
+        <text name="ft_auto_click_open_on_any_app_row_to_switch_to_it_directly" text="Drücke auf eine App um direkt zu ihr zu wechseln.&#10;" />
+        <text name="ft_auto_click_select_on_a_vehicle_to_pin_its_diagnostics_in" text="Drücke auf auswählen um ein die Daten eines Fahrzeugs anzuheften&#10;" />
+        <text name="ft_auto_click_select_on_any_field_row_to_open_its_detailed" text="Drücke auf ein beliebiges Feld um seine Detailseite zu sehen&#10;" />
+        <text name="ft_auto_click_the_button_to_cycle_through_available_options" text="Drücke den Knopf um durch die verfügbaren Optionen zu wechseln&#10;" />
+        <text name="ft_auto_click_to_change_saved_in_modsettings" text="Zum Wechseln drücken | gespeichert in modSettings" />
+        <text name="ft_auto_click_to_cycle_app_opened_first_when_tablet_starts" text="Zum Wechseln drücken  |  App wird geöffnet wenn das Tablet zum ersten Mal angezeigt wird" />
+        <text name="ft_auto_click_to_cycle_icon_label_text_size" text="Zum Wechseln drücken  |  Icon-Label Textgröße" />
+        <text name="ft_auto_click_to_cycle_screen_background_color" text="Zum Wechseln drücken  |  Hintergrundfarbe" />
+        <text name="ft_auto_click_to_cycle_through_6_preset_dark_themes" text="6 vorausgewählte Dunkle Farbschemen:&#10;" />
+        <text name="ft_auto_click_to_cycle_white_gold_or_each_app_s_accent" text="Zum Wechseln drücken | Weiß, Gold oder jede App-Farbe" />
+        <text name="ft_auto_click_to_instantly_restore_the_vehicle_to_new_condition" text="Fahrzeug auf Neuzustand zurücksetzen." />
+        <text name="ft_auto_click_unpin_to_close_the_detail_view" text="Anheften Rückgängig machen um die Detailansicht zu schließen." />
+        <text name="ft_auto_clock_farm_name_in_persistent_topbar" text="Uhrzeit und Hofname permanent in der oberen Leiste." />
+        <text name="ft_auto_close" text="SCHLIEẞEN" />
+        <text name="ft_auto_close_tablet" text="Tablet schließen" />
+        <text name="ft_auto_closed" text="Geschlossen" />
+        <text name="ft_auto_cloud" text="Wolke" />
         <text name="ft_auto_cloud_cover" text="CLOUD COVER" />
         <text name="ft_auto_cloud_cover_2" text="Bewölkung" />
         <text name="ft_auto_cloudy" text="Bewölkt" />
         <text name="ft_auto_cloudy_2" text="cloudy" />
-        <text name="ft_auto_cold" text="Cold" />
-        <text name="ft_auto_collect" text=" COLLECT" />
-        <text name="ft_auto_collect_bales" text="Collect bales" />
-        <text name="ft_auto_collect_productions" text="Collect productions" />
-        <text name="ft_auto_columns_crop_ha_state" text="COLUMNS: # / FRUCHT / HA / STATUS" />
-        <text name="ft_auto_combine" text="Combine" />
-        <text name="ft_auto_complete_favors_for_an_npc_to_increase_their" text="Complete favors for an NPC to increase their&#10;" />
-        <text name="ft_auto_complete_v2_overhaul_new_sidebar_layout" text="Complete V2 overhaul — new sidebar layout" />
-        <text name="ft_auto_completed" text="Completed" />
-        <text name="ft_auto_completed_collect_reward_from_npc" text="COMPLETED - COLLECT REWARD FROM NPC" />
-        <text name="ft_auto_completion_updates_automatically" text="Completion updates automatically." />
-        <text name="ft_auto_component_wear_as_a_percentage_0_new_100_worn" text="Component wear as a percentage (0% = new, 100% = worn).&#10;" />
-        <text name="ft_auto_component_wear_percentage_0_new_100_worn_out" text="Component wear percentage (0% = new, 100% = worn out).&#10;" />
-        <text name="ft_auto_comprehensive_farm_statistics_snapshot" text="Umfassende Hofstatistik-Übersicht" />
+        <text name="ft_auto_cold" text="Kalt" />
+        <text name="ft_auto_collect" text=" Sammeln" />
+        <text name="ft_auto_collect_bales" text="Ballen laden" />
+        <text name="ft_auto_collect_productions" text="Sammel Produktionen" />
+        <text name="ft_auto_columns_crop_ha_state" text="COLUMNS: # / KULTUR / HEKTAR / STATUS" />
+        <text name="ft_auto_combine" text="Mähdrescher" />
+        <text name="ft_auto_complete_favors_for_an_npc_to_increase_their" text="tue deinen Nachbarn einen Gefallen um ihr [X] zu erhöhen&#10;" />
+        <text name="ft_auto_complete_v2_overhaul_new_sidebar_layout" text="Rundum erneuerte V2 - neues Seitenleisten Layout" />
+        <text name="ft_auto_completed" text="erledigt" />
+        <text name="ft_auto_completed_collect_reward_from_npc" text="Erledigt - Hole deine Belohnung bei deinem Nachbar ab" />
+        <text name="ft_auto_completion_updates_automatically" text="Erfüllung wird automatisch aktualisiert." />
+        <text name="ft_auto_component_wear_as_a_percentage_0_new_100_worn" text="Gerätegebrauchsspuren als Prozentsatz (0% = neu, 100% = gebraucht).&#10;" />
+        <text name="ft_auto_component_wear_percentage_0_new_100_worn_out" text="Gerätegebrauchsspuren als Prozentsatz (0% = neuwertig, 100% = stark abgenutzt).&#10;" />
+        <text name="ft_auto_comprehensive_farm_statistics_snapshot" text="Hofstatistik" />
         <text name="ft_auto_con" text="CON" />
         <text name="ft_auto_condition_hero_card" text="CONDITION HERO CARD" />
         <text name="ft_auto_conditions" text="CONDITIONS" />
-        <text name="ft_auto_configure_this_in_the_income_mod_settings" text="Configure this in the Income Mod settings." />
-        <text name="ft_auto_confirm_clear_all_d" text="CONFIRM CLEAR ALL (%d)" />
-        <text name="ft_auto_confirm_start_job" text="CONFIRM — START JOB" />
-        <text name="ft_auto_connected" text="Connected" />
-        <text name="ft_auto_console_commands_for_power_users" text="Console commands for power users" />
-        <text name="ft_auto_console_useful_for_troubleshooting_leave_off_during" text="console. Useful for troubleshooting. Leave off during&#10;" />
-        <text name="ft_auto_consolecommandhelp" text="consoleCommandHelp" />
+        <text name="ft_auto_configure_this_in_the_income_mod_settings" text="Das kannst du in den Einstellungen der FS25_IncomeMod einstellen." />
+        <text name="ft_auto_confirm_clear_all_d" text="Sicher, dass du alle (%d) entfernen möchtest?" />
+        <text name="ft_auto_confirm_start_job" text="Ja, Job starten." />
+        <text name="ft_auto_connected" text="Verbunden" />
+        <text name="ft_auto_console_commands_for_power_users" text="Konsolenbefehle für erfahrene Benutzer." />
+        <text name="ft_auto_console_useful_for_troubleshooting_leave_off_during" text="Debug-Konsole. Nützlich für Problemlösen. Abgeschaltet lassen während&#10;" />
+        <text name="ft_auto_consolecommandhelp" text="consoleCommandHilfe" />
         <text name="ft_auto_consolecommandtabletapp" text="consoleCommandTabletApp" />
-        <text name="ft_auto_consolecommandtabletclose" text="consoleCommandTabletSchliessen" />
-        <text name="ft_auto_consolecommandtabletdisable" text="consoleCommandTabletDisable" />
-        <text name="ft_auto_consolecommandtabletenable" text="consoleCommandTabletEnable" />
-        <text name="ft_auto_consolecommandtabletkeybind" text="consoleCommandTabletKeybind" />
-        <text name="ft_auto_consolecommandtabletopen" text="consoleCommandTabletOStall" />
+        <text name="ft_auto_consolecommandtabletclose" text="consoleCommandTabletSchließen" />
+        <text name="ft_auto_consolecommandtabletdisable" text="consoleCommandTabletDeaktivieren" />
+        <text name="ft_auto_consolecommandtabletenable" text="consoleCommandTabletAktivieren" />
+        <text name="ft_auto_consolecommandtabletkeybind" text="consoleCommandTabletTastenbelegung" />
+        <text name="ft_auto_consolecommandtabletopen" text="consoleCommandTabletÖffnen" />
         <text name="ft_auto_consolecommandtabletresetsettings" text="consoleCommandTabletResetEinstellungen" />
-        <text name="ft_auto_consolecommandtabletsetnotifications" text="consoleCommandTabletSetNotifications" />
+        <text name="ft_auto_consolecommandtabletsetnotifications" text="consoleCommandTabletSetBenachrichtigungen" />
         <text name="ft_auto_consolecommandtabletsetstartupapp" text="consoleCommandTabletSetStartupApp" />
-        <text name="ft_auto_consolecommandtabletshowsettings" text="consoleCommandTabletShowEinstellungen" />
+        <text name="ft_auto_consolecommandtabletshowsettings" text="consoleCommandTabletZeigeEinstellungen" />
         <text name="ft_auto_consolecommandtablettoggle" text="consoleCommandTabletToggle" />
-        <text name="ft_auto_consulting" text="Consulting" />
-        <text name="ft_auto_contract" text="Contract" />
-        <text name="ft_auto_contractor" text="Contractor" />
+        <text name="ft_auto_consulting" text="Beratung" />
+        <text name="ft_auto_contract" text="Vertrag" />
+        <text name="ft_auto_contractor" text="Auftragnehmer" />
         <text name="ft_auto_contracts" text="VERTRÄGE" />
         <text name="ft_auto_contracts_2" text="Aufträge" />
         <text name="ft_auto_contracts_3" text="Aufträge" />
-        <text name="ft_auto_contracts_appear_here_available_ones_do_not" text="Aufträge appear here — available ones do not." />
-        <text name="ft_auto_contracts_board_in_the_pause_menu_only_accepted" text="Aufträge board in the pause menu. Only accepted&#10;" />
-        <text name="ft_auto_contracts_in_amber_are_expiring_soon_2_game_hours" text="Aufträge in amber are expiring soon (&lt; 2 game hours).&#10;" />
-        <text name="ft_auto_contracts_marked_done_are_complete_but_unpaid" text="Aufträge marked DONE are complete but unpaid.&#10;" />
-        <text name="ft_auto_controls_how_wages_are_calculated" text="Controls how wages are calculated:&#10;" />
-        <text name="ft_auto_controls_when_income_is_paid_out" text="Controls when income is paid out:&#10;" />
+        <text name="ft_auto_contracts_appear_here_available_ones_do_not" text="Aufträge erscheinen hier - verfügbare nicht." />
+        <text name="ft_auto_contracts_board_in_the_pause_menu_only_accepted" text="Aufträge Übersicht im Pause-Menü. Nur geduldet&#10;" />
+        <text name="ft_auto_contracts_in_amber_are_expiring_soon_2_game_hours" text="Aufträge in Gelb laufen bald ab (&lt; 2 Spielstunden).&#10;" />
+        <text name="ft_auto_contracts_marked_done_are_complete_but_unpaid" text="Aufträge mit DONE markiert sind abgearbeitet aber noch unbezahlt.&#10;" />
+        <text name="ft_auto_controls_how_wages_are_calculated" text="Stellt ein, wie Löhne berechnet werden:&#10;" />
+        <text name="ft_auto_controls_when_income_is_paid_out" text="Kontrolliert wie Einkommen gezahlt wird:&#10;" />
         <text name="ft_auto_cool" text="Cool" />
         <text name="ft_auto_core" text="CORE" />
         <text name="ft_auto_cost_mode" text="COST MODE" />
         <text name="ft_auto_cost_mode_2" text="Cost Mode" />
-        <text name="ft_auto_count_of_accepted_contracts_currently_in_progress" text="Count of accepted Aufträge currently in progress.&#10;" />
+        <text name="ft_auto_count_of_accepted_contracts_currently_in_progress" text="Anzahl von angenommenen Aufträgen die derzeit in Bearbeitung sind.&#10;" />
         <text name="ft_auto_create" text="CREATE" />
-        <text name="ft_auto_create_invoices_via_the_roleplayphone_app" text="Create invoices via the RoleplayPhone app." />
+        <text name="ft_auto_create_invoices_via_the_roleplayphone_app" text="Erstelle Rechnungen mit der RoleplayPhone App." />
         <text name="ft_auto_credit" text="CREDIT" />
         <text name="ft_auto_credit_score" text="CREDIT SCORE" />
         <text name="ft_auto_credit_score_2" text="Credit Score" />
-        <text name="ft_auto_crop" text="FRUCHT" />
-        <text name="ft_auto_crop_sale" text="Frucht Sale" />
-        <text name="ft_auto_crop_stress" text="Frucht Stress" />
+        <text name="ft_auto_crop" text="Kultur" />
+        <text name="ft_auto_crop_sale" text="Kulturverkauf" />
+        <text name="ft_auto_crop_stress" text="Pflanzenstress" />
         <text name="ft_auto_crop_stress_2" text="crop_stress" />
-        <text name="ft_auto_crop_stress_mod_not_detected" text="Frucht Stress mod not detected." />
+        <text name="ft_auto_crop_stress_mod_not_detected" text="FS25_SeasonalCropStress mod nicht erkannt." />
         <text name="ft_auto_crps" text="CRPS" />
-        <text name="ft_auto_cultivating" text="Cultivating" />
-        <text name="ft_auto_cumulative_tax_paid_across_the_current_session" text="Cumulative tax paid across the current session.&#10;" />
-        <text name="ft_auto_current_air_temperature_in_celsius_with_a_feel_label" text="Current air temperature in Celsius with a feel label:&#10;" />
+        <text name="ft_auto_cultivating" text="Anbauen" />
+        <text name="ft_auto_cumulative_tax_paid_across_the_current_session" text="Gesamt gezahlte Steuern während der aktuellen Spiel-Sitzung.&#10;" />
+        <text name="ft_auto_current_air_temperature_in_celsius_with_a_feel_label" text="Aktuelle Lufttemperatur in °C mit gefühlter Temperatur:&#10;" />
         <text name="ft_auto_current_balance" text="CURRENT BALANCE" />
-        <text name="ft_auto_current_balance_2" text="Current Balance" />
+        <text name="ft_auto_current_balance_2" text="Aktueller Kontostand" />
         <text name="ft_auto_current_conditions_and_forecast" text="Aktuelles Wetter und Vorhersage" />
         <text name="ft_auto_current_event" text="CURRENT EVENT" />
         <text name="ft_auto_category" text="Kategorie" />
@@ -733,59 +733,59 @@
         <text name="ft_auto_event_types" text="Ereignistypen" />
         <text name="ft_auto_market_movers_per_1_000_l" text="MARKTBEWEGUNGEN  (pro 1.000 L)" />
         <text name="ft_auto_special" text="Spezial" />
-        <text name="ft_auto_volatility" text="Volatilität" />
+        <text name="ft_auto_volatility" text="Verdunstung" />
         <text name="ft_auto_wildlife" text="Wildtiere" />
-        <text name="ft_auto_current_fuel_as_a_percentage_of_tank_capacity" text="Current Kraftstoff as ein Prozentsatz of tank capacity.&#10;" />
-        <text name="ft_auto_current_in_game_day_season_if_seasons_mod_is_active" text="Current in-game Tag, season (if Seasons mod is aktiv),&#10;" />
-        <text name="ft_auto_current_wage_level_cost_mode_active" text="current wage Stufe, cost mode, aktiv&#10;" />
-        <text name="ft_auto_current_x_z_position" text="current X/Z position.&#10;" />
+        <text name="ft_auto_current_fuel_as_a_percentage_of_tank_capacity" text="Aktueller Kraftstofffüllstand als Prozentsatz des Behältervolumens.&#10;" />
+        <text name="ft_auto_current_in_game_day_season_if_seasons_mod_is_active" text="Aktueller in-game Tag, Jahreszeit (Wenn die Jahreszeiten aktiv sind),&#10;" />
+        <text name="ft_auto_current_wage_level_cost_mode_active" text="aktuelle Gehaltsstufe, derzeit aktiver Kostenmodus&#10;" />
+        <text name="ft_auto_current_x_z_position" text="aktuelle horizontale/vertikale Position.&#10;" />
         <text name="ft_auto_custom" text="Custom" />
         <text name="ft_auto_custom_2" text="custom" />
-        <text name="ft_auto_custom_set_via_console" text="Custom (set via console)" />
+        <text name="ft_auto_custom_set_via_console" text="Custom (setze über die Konsole)" />
         <text name="ft_auto_customising_widgets" text="CUSTOMISING WIDGETS" />
         <text name="ft_auto_customize" text="customize" />
-        <text name="ft_auto_customize_widgets" text="Customize Widgets" />
+        <text name="ft_auto_customize_widgets" text="Benutzerdefinierte Widgets" />
         <text name="ft_auto_d" text="$%d" />
         <text name="ft_auto_d_2" text="%d%%" />
         <text name="ft_auto_d_active_cases" text="%d aktive Fälle" />
-        <text name="ft_auto_d_d_open" text="%d/%d oStall" />
-        <text name="ft_auto_d_d_working" text="%d  (%d working)" />
+        <text name="ft_auto_d_d_open" text="%d/%d öffnen" />
+        <text name="ft_auto_d_d_working" text="%d  (%d arbeiten)" />
         <text name="ft_auto_d_day" text="%d €/Tag" />
         <text name="ft_auto_d_day_02d_02d" text="%d Tag %02d:%02d" />
-        <text name="ft_auto_d_day_s_remaining" text="%d Tag%s remaining" />
-        <text name="ft_auto_d_dh_left" text="%d%%  %dh left" />
-        <text name="ft_auto_d_dl_dl" text="%d%%  (%dL / %dL)" />
+        <text name="ft_auto_d_day_s_remaining" text="%d Tag%s verbleibend" />
+        <text name="ft_auto_d_dh_left" text="%d%%  %dh verbleibend" />
+        <text name="ft_auto_d_dl_dl" text="%d%%  (%d L / %d L)" />
         <text name="ft_auto_d_fields" text="%d Felder" />
-        <text name="ft_auto_d_fields_d_asleep" text="%d Felder  ·  %d asleep" />
-        <text name="ft_auto_d_hr_s_remaining" text="%d hr%s remaining" />
-        <text name="ft_auto_d_in_game_hours" text="%d in-game hours" />
+        <text name="ft_auto_d_fields_d_asleep" text="%d Felder  ·  %d Nicht verfolgt" />
+        <text name="ft_auto_d_hr_s_remaining" text="%d hr%s verbleibend" />
+        <text name="ft_auto_d_in_game_hours" text="%d in-game Stunden" />
         <text name="ft_auto_d_l" text="%d L" />
-        <text name="ft_auto_d_moisture" text="%d%% moisture" />
+        <text name="ft_auto_d_moisture" text="%d%% Feuchtigkeit" />
         <text name="ft_auto_d_s" text="%d%%  (%s)" />
-        <text name="ft_auto_daily_once_per_in_game_day" text="Daily = once per in-game Tag.&#10;" />
+        <text name="ft_auto_daily_once_per_in_game_day" text="täglich, einmal pro in-game Tag.&#10;" />
         <text name="ft_auto_dash" text="DASH" />
         <text name="ft_auto_dashboard" text="Übersicht" />
         <text name="ft_auto_dashboard_2" text="dashboard" />
         <text name="ft_auto_dashboard_weather_app_store_settings" text="dashboard,weather,app_store,settings" />
-        <text name="ft_auto_dashboard_weather_fields_animals_workshop" text="Übersicht, Wetter, Fields, Tiere, Werkstatt" />
+        <text name="ft_auto_dashboard_weather_fields_animals_workshop" text="Übersicht, Wetter, Felder, Tiere, Werkstatt" />
         <text name="ft_auto_data_refreshed" text="data_refreshed" />
-        <text name="ft_auto_data_refreshes_every_3_seconds" text="Data refreshes every 3 seconds." />
+        <text name="ft_auto_data_refreshes_every_3_seconds" text="Daten werden alle drei Sekunden neugeladen." />
         <text name="ft_auto_day" text="DAY" />
         <text name="ft_auto_day_2" text="Tag" />
         <text name="ft_auto_day_3" text="Tag " />
         <text name="ft_auto_day_4" text="Tag +" />
         <text name="ft_auto_day_5" text="Tag" />
-        <text name="ft_auto_day_and_time_show_the_in_game_clock_24h" text="Tag and time show the in-game clock (24h)." />
-        <text name="ft_auto_days_since_harvest" text="Tags Since Harvest" />
-        <text name="ft_auto_deadwood" text="Deadwood" />
+        <text name="ft_auto_day_and_time_show_the_in_game_clock_24h" text="Tag und Uhrzeit zeigen die in-Game Uhr." />
+        <text name="ft_auto_days_since_harvest" text="Tage seit letzter Ernte" />
+        <text name="ft_auto_deadwood" text="Totholz" />
         <text name="ft_auto_deal" text="DEAL" />
         <text name="ft_auto_debug_mode" text="Debug" />
         <text name="ft_auto_debug_mode_off" text="Debug: Aus" />
         <text name="ft_auto_debug_mode_on" text="Debug: An" />
         <text name="ft_auto_debug_mode_s" text="Debug Mode: %s&#10;" />
-        <text name="ft_auto_deco_decorative_fake_field_auto_detected" text="DECO   = decorative / fake Feld (auto-detected)." />
-        <text name="ft_auto_deep_space" text="Tiefes All" />
-        <text name="ft_auto_deep_space_ocean_blue_forest_green" text="Tiefes All, Ocean Blue, Forest Green,&#10;" />
+        <text name="ft_auto_deco_decorative_fake_field_auto_detected" text="DECO   = dekoratives Feld (automatisch erkannt)." />
+        <text name="ft_auto_deep_space" text="Deep Space" />
+        <text name="ft_auto_deep_space_ocean_blue_forest_green" text="Deep Space, Ocean Blue, Forest Green,&#10;" />
         <text name="ft_auto_default" text="STANDARD" />
         <text name="ft_auto_default_2" text="default" />
         <text name="ft_auto_defaulted" text="defaulted" />
@@ -795,167 +795,167 @@
         <text name="ft_auto_dig" text="DIG" />
         <text name="ft_auto_digging" text="Digging" />
         <text name="ft_auto_digging_2" text="digging" />
-        <text name="ft_auto_dimmed_rows_are_supported_but_not_currently_installed" text="Dimmed rows are supported but not currently installed.&#10;" />
+        <text name="ft_auto_dimmed_rows_are_supported_but_not_currently_installed" text="Dimmed rows werden unterstützt sind aber derzeit nicht installiert.&#10;" />
         <text name="ft_auto_disable" text="DISABLE" />
-        <text name="ft_auto_disable_farm_tablet" text="Disable Farm Tablet" />
+        <text name="ft_auto_disable_farm_tablet" text="Farm Tablet deaktiveren" />
         <text name="ft_auto_disabled" text="DISABLED" />
         <text name="ft_auto_disabled_2" text="Disabled" />
         <text name="ft_auto_disabled_3" text="disabled" />
         <text name="ft_auto_display" text="Anzeige" />
         <text name="ft_auto_display_damage" text="DISPLAYSCHADEN" />
-        <text name="ft_auto_display_damage_2" text="Anzeige damage" />
-        <text name="ft_auto_display_damage_from_a_drop" text="Anzeige damage from a drop" />
-        <text name="ft_auto_display_damage_from_a_drop_tablet_is_being_repaired" text="Anzeige damage from a drop. Tablet is being repaired." />
-        <text name="ft_auto_display_damage_s" text="ANZEIGESCHADEN: %s" />
-        <text name="ft_auto_display_in_stock_duration_approx_1_in_game_hour" text="Anzeige in stock - duration: approx. 1 in-game hour" />
-        <text name="ft_auto_display_ordered_duration_approx_1_in_game_day" text="Anzeige ordered - Dauer: approx. 1 in-game Tag" />
+        <text name="ft_auto_display_damage_2" text="Displayschaden" />
+        <text name="ft_auto_display_damage_from_a_drop" text="Displayschaden durch einen Sturz." />
+        <text name="ft_auto_display_damage_from_a_drop_tablet_is_being_repaired" text="Displayschaden durch einen Sturz. Deinn Tablet wird repariert." />
+        <text name="ft_auto_display_damage_s" text="DISPLAYSCHADEN: %s" />
+        <text name="ft_auto_display_in_stock_duration_approx_1_in_game_hour" text="Ersatzteil auf Lager - Dauer für den Austausch: vorraussichtlich 1 in-game Stunde" />
+        <text name="ft_auto_display_ordered_duration_approx_1_in_game_day" text="Ersatzteil bestellt - Dauer für den Austausch: vorraussichtlich 1 in-game Tag" />
         <text name="ft_auto_display_position_scale" text="ANZEIGE — POSITION &amp; SKALIERUNG" />
-        <text name="ft_auto_displays_fs25_marketdynamics_status" text="Anzeiges FS25_MarktDynamics status:&#10;" />
-        <text name="ft_auto_displays_fs25_randomworldevents_status" text="Anzeiges FS25_RandomWorldEvents status:&#10;" />
-        <text name="ft_auto_displays_fs25_workercosts_status" text="Anzeiges FS25_WorkerCosts status:&#10;" />
-        <text name="ft_auto_displays_the_current_status_of_fs25_incomemod" text="Anzeiges the current status of FS25_IncomeMod.&#10;" />
-        <text name="ft_auto_displays_the_status_of_fs25_taxmod" text="Anzeiges the status of FS25_TaxMod.&#10;" />
+        <text name="ft_auto_displays_fs25_marketdynamics_status" text="Anzeige FS25_MarktDynamics status:&#10;" />
+        <text name="ft_auto_displays_fs25_randomworldevents_status" text="Anzeige FS25_RandomWorldEvents status:&#10;" />
+        <text name="ft_auto_displays_fs25_workercosts_status" text="Anzeige FS25_WorkerCosts status:&#10;" />
+        <text name="ft_auto_displays_the_current_status_of_fs25_incomemod" text="zeigt den aktuellen Status der FS25_IncomeMod.&#10;" />
+        <text name="ft_auto_displays_the_status_of_fs25_taxmod" text="zeigt den aktuellen Status der FS25_TaxMod.&#10;" />
         <text name="ft_auto_dn_de_dm" text="%dN / %dE / %dM" />
-        <text name="ft_auto_docs_releases" text="Doku / Versionen:" />
+        <text name="ft_auto_docs_releases" text="Dokumentation (Release):" />
         <text name="ft_auto_done" text="DONE" />
-        <text name="ft_auto_done_collect_reward" text="DONE — COLLECT REWARD" />
-        <text name="ft_auto_done_mark_a_task_as_completed" text="DONE — mark a task as completed (■)&#10;" />
-        <text name="ft_auto_download_the_latest_version_from_the_mod_page_on" text="Download the latest version from the mod page on&#10;" />
-        <text name="ft_auto_drag_a_corner_handle_to_scale_the_whole_tablet" text="Drag a corner handle to scale the whole tablet.&#10;" />
-        <text name="ft_auto_drag_left_or_right_edge_to_adjust_width_only" text="Drag left or right edge to adjust Breite only.&#10;" />
-        <text name="ft_auto_drag_the_body_to_reposition_it_anywhere_on_screen" text="Drag the body to reposition it anywhere on screen.&#10;" />
-        <text name="ft_auto_drop_png_files_into_the_ftbackground_folder_inside_your" text="Drop PNG files into the FTHintergrund folder inside your&#10;" />
-        <text name="ft_auto_due" text="Due: " />
-        <text name="ft_auto_due_date" text="DUE DATE" />
-        <text name="ft_auto_due_in_d_day_s" text="Due in %d Tag%s" />
-        <text name="ft_auto_due_today" text="Due today" />
+        <text name="ft_auto_done_collect_reward" text="Erledigt - Belohnung einsammeln" />
+        <text name="ft_auto_done_mark_a_task_as_completed" text="Erledigt - Markiere die Aufgabe als erledigt&#10;" />
+        <text name="ft_auto_download_the_latest_version_from_the_mod_page_on" text="Lade die aktuellste Version der Mod von der Modding-Seite&#10;" />
+        <text name="ft_auto_drag_a_corner_handle_to_scale_the_whole_tablet" text="Zieh an einer Ecke um die Größe des gesamten Tablet anzupassen.&#10;" />
+        <text name="ft_auto_drag_left_or_right_edge_to_adjust_width_only" text="Zieh an der Leiste links oder rechts um nur die Breite anzupassen.&#10;" />
+        <text name="ft_auto_drag_the_body_to_reposition_it_anywhere_on_screen" text="Zieh irgendwo am Tablet um es belibieg zu positionieren.&#10;" />
+        <text name="ft_auto_drop_png_files_into_the_ftbackground_folder_inside_your" text="Füge PNG-Dateien zum FTBackground Verzeichnis hinzu&#10;" />
+        <text name="ft_auto_due" text="fällig: " />
+        <text name="ft_auto_due_date" text="Fälligkeitsdatum" />
+        <text name="ft_auto_due_in_d_day_s" text="Fällig in %d Tag%s" />
+        <text name="ft_auto_due_today" text="Heute fällig" />
         <text name="ft_auto_dur" text="DUR" />
-        <text name="ft_auto_duration" text="Duration" />
-        <text name="ft_auto_duration_d_in_game_hours" text="DURATION: %d IN-GAME HOURS" />
-        <text name="ft_auto_duration_is_calculated_in_in_game_time_and_the" text="Duration is calculated in in-game time and the&#10;" />
-        <text name="ft_auto_duration_of_a_network_outage_1_2_3_4_hours" text="Duration of a network outage: 1 / 2 / 3 / 4 hours" />
-        <text name="ft_auto_each_block_shows_the_version_number_on_the_left_and" text="Each block shows the version number on the left and&#10;" />
-        <text name="ft_auto_each_card_shows_the_animal_type_current_count_and_the" text="Each card shows the animal type, current count, and the&#10;" />
-        <text name="ft_auto_each_crop_you_have_in_storage" text="each crop you have in storage.&#10;" />
-        <text name="ft_auto_each_entry_shows_field_vehicle_task_day_started" text="Each entry shows Feld, Fahrzeug, task, Tag started,&#10;" />
-        <text name="ft_auto_each_entry_shows_predicted_condition_and_max_temperatur" text="Each entry shows predicted condition and max temperature." />
-        <text name="ft_auto_each_entry_shows_the_building_name_and_how_many_of_its" text="Each entry shows the building name and how many of its&#10;" />
-        <text name="ft_auto_each_favor_shows_npc_name_description_completion" text="Each favor shows NPC name, description, completion&#10;" />
-        <text name="ft_auto_each_row_shows_field_id_crop_type_moisture" text="Each row shows Feld ID, crop type, moisture %,&#10;" />
+        <text name="ft_auto_duration" text="Dauer" />
+        <text name="ft_auto_duration_d_in_game_hours" text="DAUER: %d IN-GAME STUNDEN" />
+        <text name="ft_auto_duration_is_calculated_in_in_game_time_and_the" text="Die DAUER wird in in-Game Zeit berechnet und die&#10;" />
+        <text name="ft_auto_duration_of_a_network_outage_1_2_3_4_hours" text="Dauer eines Netzwerkausfalls: 1, 2, 3 oder 4 Stunden" />
+        <text name="ft_auto_each_block_shows_the_version_number_on_the_left_and" text="In jedem Feld wird die Versionsnummer links angezeigt und&#10;" />
+        <text name="ft_auto_each_card_shows_the_animal_type_current_count_and_the" text="jede Karte zeigt die Tierart, die Bestandsgröße und&#10;" />
+        <text name="ft_auto_each_crop_you_have_in_storage" text="Kultur die du eingelagert hast.&#10;" />
+        <text name="ft_auto_each_entry_shows_field_vehicle_task_day_started" text="Jeder Eintrag zeigt welches Fahrzeug an welchem Tag welche Aufgabe auf welchem Feld begonnen wurde&#10;" />
+        <text name="ft_auto_each_entry_shows_predicted_condition_and_max_temperatur" text="Jeder Eintrag zeigt die vorraussichtliche Wetterlage und maximale Temperatur." />
+        <text name="ft_auto_each_entry_shows_the_building_name_and_how_many_of_its" text="Jeder Eintrag zeigt den Gebäudenamen und wie viele davon&#10;" />
+        <text name="ft_auto_each_favor_shows_npc_name_description_completion" text="Jeder Gefallen zeigt den Namen des NPC, eine Beschreibung und den Fortschritt&#10;" />
+        <text name="ft_auto_each_row_shows_field_id_crop_type_moisture" text="Jede Zeile zeigt die ID des Felds, die angebaute Kultur, die Feuchtigkeit in %,&#10;" />
         <text name="ft_auto_edgetabcontext_browser_tab" text="EdgeTabContext / browser tab" />
         <text name="ft_auto_edit" text="EDIT" />
-        <text name="ft_auto_elapsed" text="  ·  Elapsed: " />
+        <text name="ft_auto_elapsed" text="  ·  Vergangen: " />
         <text name="ft_auto_empty" text="  (empty)" />
         <text name="ft_auto_empty_2" text="LEER" />
         <text name="ft_auto_empty_3" text="Leer" />
         <text name="ft_auto_empty_4" text="empty" />
-        <text name="ft_auto_empty_pens_are_shown_dimmed" text="Leer Ställe are shown dimmed." />
+        <text name="ft_auto_empty_pens_are_shown_dimmed" text="Leere Ställe werden ausgegraut dargstellt." />
         <text name="ft_auto_enable" text="ENABLE" />
         <text name="ft_auto_enable_disable" text="ENABLE / DISABLE" />
-        <text name="ft_auto_enable_disable_notifications" text="Enable/disable notifications" />
-        <text name="ft_auto_enable_farm_tablet" text="Enable Farm Tablet" />
+        <text name="ft_auto_enable_disable_notifications" text="Benachrichtigungen (De-)aktivieren" />
+        <text name="ft_auto_enable_farm_tablet" text="Farm Tablet Aktivieren" />
         <text name="ft_auto_enabled" text="Enabled" />
         <text name="ft_auto_enabled_2" text="enabled" />
-        <text name="ft_auto_enabled_s" text="Enabled: %s&#10;" />
+        <text name="ft_auto_enabled_s" text="%s&#10; wurde aktiviert" />
         <text name="ft_auto_enables_verbose_console_logging_for_troubleshooting" text="Schreibt ausführliche Meldungen in die Konsole" />
-        <text name="ft_auto_enter_a_vehicle_first_then_pin" text="Enter ein Fahrzeug first, then ANHEFTEN" />
-        <text name="ft_auto_enter_edit_mode" text="BEARBEITUNGSMODUS ÖFFNEN" />
-        <text name="ft_auto_environment_not_loaded_yet" text="Environment not loaded yet." />
-        <text name="ft_auto_equipment_dealer" text="Equipment Dealer" />
-        <text name="ft_auto_equipment_rental" text="Equipment Rental" />
-        <text name="ft_auto_error_app_s_not_found_or_not_enabled" text="Error: App '%s' not found oder not aktiviert" />
-        <text name="ft_auto_error_farm_tablet_not_initialized" text="Error: Farm Tablet not initialized" />
-        <text name="ft_auto_est_interval" text="Est. Interval" />
-        <text name="ft_auto_etc_it_appears_here_with_its_name_events_end" text="etc.) it appears here with its name. Events end&#10;" />
-        <text name="ft_auto_event" text="Event" />
-        <text name="ft_auto_event_frequency" text="Event Frequency" />
+        <text name="ft_auto_enter_a_vehicle_first_then_pin" text="Steige erst in ein Fahrzeug ein, bevor du es anheftest." />
+        <text name="ft_auto_enter_edit_mode" text="BEARBEITUNGSMODUS STARTEN" />
+        <text name="ft_auto_environment_not_loaded_yet" text="Umgebung noch nicht geladen." />
+        <text name="ft_auto_equipment_dealer" text="Händler" />
+        <text name="ft_auto_equipment_rental" text="Mietservice" />
+        <text name="ft_auto_error_app_s_not_found_or_not_enabled" text="Error: App '%s' nicht gefunden oder aktiviert" />
+        <text name="ft_auto_error_farm_tablet_not_initialized" text="Error: Farm Tablet wurde nicht initialisiert" />
+        <text name="ft_auto_est_interval" text="vorraussichtliches Intervall" />
+        <text name="ft_auto_etc_it_appears_here_with_its_name_events_end" text="etc.) es erscheint hier mit seinem Namen. Das Ereignis endet&#10;" />
+        <text name="ft_auto_event" text="Ereignis" />
+        <text name="ft_auto_event_frequency" text="Ereignishäufigkeit" />
         <text name="ft_auto_eventbus_decoupled_pub_sub_communication" text="EventBus: decoupled pub/sub communication" />
-        <text name="ft_auto_events" text="Ereigniss" />
-        <text name="ft_auto_events_like_droughts_trade_disruptions_and" text="Events like droughts, trade disruptions, and&#10;" />
-        <text name="ft_auto_events_run" text="Events Run" />
-        <text name="ft_auto_every_worker_with_level_lifetime_hours_jobs" text="Every Arbeiter mit Stufe, lifetime hours, jobs,&#10;" />
-        <text name="ft_auto_everyone_automatically" text="everyone automatically." />
-        <text name="ft_auto_excavation" text="Excavation" />
+        <text name="ft_auto_events" text="Ereignisse" />
+        <text name="ft_auto_events_like_droughts_trade_disruptions_and" text="Ereignisse wie Dürren, Handelsbeschränkungen und&#10;" />
+        <text name="ft_auto_events_run" text="Ereignisse starten" />
+        <text name="ft_auto_every_worker_with_level_lifetime_hours_jobs" text="Jeder Mitarbeiter mit Erfahrungsstufe, gesamt gearbeitete Stunden und Jobs,&#10;" />
+        <text name="ft_auto_everyone_automatically" text="automatisch jeder." />
+        <text name="ft_auto_excavation" text="Ausgrabung" />
         <text name="ft_auto_excavation_tracking_and_soil_scanner" text="Grabungsdaten und Bodenscanner" />
-        <text name="ft_auto_excavator" text="excavator" />
-        <text name="ft_auto_excellent" text="Excellent" />
-        <text name="ft_auto_exit_edit_mode" text="EXIT EDIT MODE" />
-        <text name="ft_auto_expenses" text="ExStällees" />
-        <text name="ft_auto_expenses_2" text="exStällees" />
-        <text name="ft_auto_expired" text="EXPIRED" />
-        <text name="ft_auto_expiring" text=" EXPIRING" />
-        <text name="ft_auto_expiring_2" text=" expiring" />
-        <text name="ft_auto_expiring_3" text="EXPIRING" />
-        <text name="ft_auto_factories" text="FACTORIES" />
-        <text name="ft_auto_factories_open" text="Factories OStall" />
-        <text name="ft_auto_factory" text="Factory" />
-        <text name="ft_auto_factory_week_schedule" text="factory_week_schedule" />
-        <text name="ft_auto_factoryweekschedule" text="FactoryWeekSchedule" />
-        <text name="ft_auto_factoryweekschedule_overview_with_workers_events_and_fi" text="FactoryWeekSchedule overview mit Arbeiter, Ereigniss und fire state" />
-        <text name="ft_auto_factoryweekschedule_was_not_detected" text="FactoryWeekSchedule was not detected." />
+        <text name="ft_auto_excavator" text="Bagger" />
+        <text name="ft_auto_excellent" text="Ausgezeichnet" />
+        <text name="ft_auto_exit_edit_mode" text="Bearbeitungsmodus verlassen" />
+        <text name="ft_auto_expenses" text="Ausgaben" />
+        <text name="ft_auto_expenses_2" text="Kosten" />
+        <text name="ft_auto_expired" text="Abgelaufen" />
+        <text name="ft_auto_expiring" text=" Läuft ab" />
+        <text name="ft_auto_expiring_2" text="Wird ablaufen" />
+        <text name="ft_auto_expiring_3" text="Ablaufend" />
+        <text name="ft_auto_factories" text="Fabriken" />
+        <text name="ft_auto_factories_open" text="Geöffnete Fabriken" />
+        <text name="ft_auto_factory" text="Fabrik" />
+        <text name="ft_auto_factory_week_schedule" text="Produktionsplan" />
+        <text name="ft_auto_factoryweekschedule" text="Produktionsplan" />
+        <text name="ft_auto_factoryweekschedule_overview_with_workers_events_and_fi" text="Übersicht des Produktionsplan mit Arbeitern, Ereignissen und Status der BMA" />
+        <text name="ft_auto_factoryweekschedule_was_not_detected" text="FactoryWeekSchedule wurde nicht erkannt." />
         <text name="ft_auto_fair" text="Fair" />
-        <text name="ft_auto_false" text="false" />
+        <text name="ft_auto_false" text="Falsch" />
         <text name="ft_auto_farm" text="FARM" />
         <text name="ft_auto_farm_2" text="Farm " />
         <text name="ft_auto_farm_admin" text="Hof-Admin" />
         <text name="ft_auto_farm_admin_2" text="farm_admin" />
-        <text name="ft_auto_farm_overview_balance_fields_vehicles_world_state" text="Hofübersicht: Kontostand, Felder, Fahrzeuge und Weltstatus" />
+        <text name="ft_auto_farm_overview_balance_fields_vehicles_world_state" text="Hofübersicht: Kontostand, Felder, Fahrzeuge und globaler Status" />
         <text name="ft_auto_farm_stats" text="Hofstatistik" />
         <text name="ft_auto_farm_stats_2" text="farm_stats" />
-        <text name="ft_auto_farm_supply" text="Farm Supply" />
+        <text name="ft_auto_farm_supply" text="Versorgung" />
         <text name="ft_auto_farm_tablet" text="Farm Tablet" />
         <text name="ft_auto_farm_tablet_2" text="Farm Tablet: " />
-        <text name="ft_auto_farm_tablet_console_commands" text="=== Farm Tablet Console Commands ===&#10;" />
-        <text name="ft_auto_farm_tablet_console_commands_registered" text="Farm Tablet console commands registered" />
+        <text name="ft_auto_farm_tablet_console_commands" text="=== Farm Tablet Konsolenbefehle ===&#10;" />
+        <text name="ft_auto_farm_tablet_console_commands_registered" text="Farm Tablet Konsolenbefehle wurden registriert" />
         <text name="ft_auto_farm_tablet_debug_mode" text="Farm Tablet: Debug mode " />
-        <text name="ft_auto_farm_tablet_disabled" text="Farm Tablet disabled" />
-        <text name="ft_auto_farm_tablet_enabled" text="Farm Tablet enabled" />
-        <text name="ft_auto_farm_tablet_keybind_changed_to_s" text="Farm Tablet: Keybind changed to: %s" />
-        <text name="ft_auto_farm_tablet_notifications" text="Farm Tablet: Notifications " />
+        <text name="ft_auto_farm_tablet_disabled" text="Farm Tablet deaktiviert" />
+        <text name="ft_auto_farm_tablet_enabled" text="Farm Tablet aktiviert" />
+        <text name="ft_auto_farm_tablet_keybind_changed_to_s" text="Farm Tablet: Tastenbelegung geändert zu: %s" />
+        <text name="ft_auto_farm_tablet_notifications" text="Farm Tablet: Benachrichtigungen " />
         <text name="ft_auto_farm_tablet_s" text="Farm Tablet %s" />
         <text name="ft_auto_farm_tablet_settings" text="=== Farm Tablet Einstellungen ===&#10;" />
-        <text name="ft_auto_farm_tablet_settings_initialized" text="Farm Tablet: Einstellungen initialized" />
-        <text name="ft_auto_farm_tablet_settings_loaded_enabled_s_key_s_startup_s" text="Farm Tablet: Einstellungen Loaded. Enabled: %s, Key: %s, Startup: %s" />
-        <text name="ft_auto_farm_tablet_settings_reset_to_default" text="Farm Tablet settings reset to default!" />
-        <text name="ft_auto_farm_tablet_settings_reset_to_defaults" text="Farm Tablet: Einstellungen reset to defaults" />
-        <text name="ft_auto_farm_tablet_settings_saved_keybind_s_startup_s" text="Farm Tablet: Einstellungen Saved. Keybind: %s, Startup: %s" />
-        <text name="ft_auto_farm_tablet_settings_ui_injected_successfully" text="Farm Tablet: Einstellungen UI injected successfully" />
-        <text name="ft_auto_farm_tablet_sound_effects" text="Farm Tablet: Ton effects " />
-        <text name="ft_auto_farm_tablet_startup_app_changed_to_s" text="Farm Tablet: Startup app changed to: %s" />
-        <text name="ft_auto_farm_tablet_startup_app_set_to" text="Farm Tablet: Startup app set to " />
-        <text name="ft_auto_farm_tablet_ui_refreshed" text="Farm Tablet: UI refreshed" />
+        <text name="ft_auto_farm_tablet_settings_initialized" text="Farm Tablet: Einstellungen initialisiert" />
+        <text name="ft_auto_farm_tablet_settings_loaded_enabled_s_key_s_startup_s" text="Farm Tablet: Einstellungen wurden geladen. Aktiviert: %s, Tastenkombination: %s, Standard-App: %s" />
+        <text name="ft_auto_farm_tablet_settings_reset_to_default" text="Alle Einstellungen des Farm Tablet werden auf Standardwerte zurückgesetzt!" />
+        <text name="ft_auto_farm_tablet_settings_reset_to_defaults" text="Farm Tablet: Einstellungen auf Standardwerte zurückgesetzt." />
+        <text name="ft_auto_farm_tablet_settings_saved_keybind_s_startup_s" text="Farm Tablet: Einstellungen gespeichert. tastenkombination: %s, Standard-App: %s" />
+        <text name="ft_auto_farm_tablet_settings_ui_injected_successfully" text="Farm Tablet: Interfaceeinstellungen erfolgreich eingebunden" />
+        <text name="ft_auto_farm_tablet_sound_effects" text="Farm Tablet: Geräusche" />
+        <text name="ft_auto_farm_tablet_startup_app_changed_to_s" text="Farm Tablet: Standard-App zu: %s geändert" />
+        <text name="ft_auto_farm_tablet_startup_app_set_to" text="Farm Tablet: Standard-App geändert zu: " />
+        <text name="ft_auto_farm_tablet_ui_refreshed" text="Farm Tablet: UI wurde neu geladen" />
         <text name="ft_auto_farm_totals" text="FARM TOTALS" />
         <text name="ft_auto_farmarea" text="farmarea_" />
         <text name="ft_auto_farming" text="FARMING" />
         <text name="ft_auto_farmland_s" text="^Farmland:%s*" />
         <text name="ft_auto_farmtablet" text="FarmTablet" />
         <text name="ft_auto_farmtablet_2" text="[FarmTablet] " />
-        <text name="ft_auto_farmtablet_autodetect_animalautocare_detected" text="[FarmTablet] autoDetect: AnimalAutoCare detected" />
-        <text name="ft_auto_farmtablet_autodetect_animalvetsystem_detected" text="[FarmTablet] autoDetect: AnimalVetSystem detected" />
-        <text name="ft_auto_farmtablet_autodetect_complete_d_apps_registered" text="[FarmTablet] autoDetect complete — %d apps registered" />
-        <text name="ft_auto_farmtablet_autodetect_crop_stress_detected" text="[FarmTablet] autoDetect: Frucht Stress detected" />
-        <text name="ft_auto_farmtablet_autodetect_factoryweekschedule_detected" text="[FarmTablet] autoDetect: FactoryWeekSchedule detected" />
-        <text name="ft_auto_farmtablet_autodetect_fieldsentry_detected" text="[FarmTablet] autoDetect: FieldSentry detected" />
-        <text name="ft_auto_farmtablet_autodetect_income_mod_detected" text="[FarmTablet] autoDetect: Income Mod detected" />
-        <text name="ft_auto_farmtablet_autodetect_market_dynamics_detected" text="[FarmTablet] autoDetect: Markt Dynamics detected" />
-        <text name="ft_auto_farmtablet_autodetect_npc_favor_detected" text="[FarmTablet] autoDetect: NPC Favor detected" />
-        <text name="ft_auto_farmtablet_autodetect_personnel_pro_staff_app_enabled" text="[FarmTablet] autoDetect: Personal (Pro-Staff) app enabled" />
-        <text name="ft_auto_farmtablet_autodetect_random_world_events_detected" text="[FarmTablet] autoDetect: Random World Events detected" />
-        <text name="ft_auto_farmtablet_autodetect_realisticdealer_detected" text="[FarmTablet] autoDetect: RealisticDealer detected" />
-        <text name="ft_auto_farmtablet_autodetect_registering_invoices_app_built_in" text="[FarmTablet] autoDetect: Registering Rechnungen app (built-in + RoleplayPhone integration)" />
-        <text name="ft_auto_farmtablet_autodetect_soil_fertilizer_detected" text="[FarmTablet] autoDetect: Soil Fertilizer detected" />
-        <text name="ft_auto_farmtablet_autodetect_tax_mod_detected" text="[FarmTablet] autoDetect: Tax Mod detected" />
-        <text name="ft_auto_farmtablet_autodetect_usedplus_detected" text="[FarmTablet] autoDetect: UsedPlus detected" />
-        <text name="ft_auto_farmtablet_autodetect_worker_costs_detected" text="[FarmTablet] autoDetect: Worker Costs detected" />
+        <text name="ft_auto_farmtablet_autodetect_animalautocare_detected" text="[FarmTablet] autoDetect: AnimalAutoCare erkannt" />
+        <text name="ft_auto_farmtablet_autodetect_animalvetsystem_detected" text="[FarmTablet] autoDetect: AnimalVetSystem erkannt" />
+        <text name="ft_auto_farmtablet_autodetect_complete_d_apps_registered" text="[FarmTablet] autoDetect complete — %d Apps registriert" />
+        <text name="ft_auto_farmtablet_autodetect_crop_stress_detected" text="[FarmTablet] autoDetect: FS25_SeasonalCropStress erkannt" />
+        <text name="ft_auto_farmtablet_autodetect_factoryweekschedule_detected" text="[FarmTablet] autoDetect: FS25_FactoryWeekSchedule erkannt" />
+        <text name="ft_auto_farmtablet_autodetect_fieldsentry_detected" text="[FarmTablet] autoDetect: FieldSentry erkannt" />
+        <text name="ft_auto_farmtablet_autodetect_income_mod_detected" text="[FarmTablet] autoDetect: FS25_IncomeMod erkannt" />
+        <text name="ft_auto_farmtablet_autodetect_market_dynamics_detected" text="[FarmTablet] autoDetect: FS25_MarktetDynamics erkannt" />
+        <text name="ft_auto_farmtablet_autodetect_npc_favor_detected" text="[FarmTablet] autoDetect: FS25_NPCFavor erkannt" />
+        <text name="ft_auto_farmtablet_autodetect_personnel_pro_staff_app_enabled" text="[FarmTablet] autoDetect: Pro-Staff App aktiviert" />
+        <text name="ft_auto_farmtablet_autodetect_random_world_events_detected" text="[FarmTablet] autoDetect: FS25_RandomWorldEvents erkannt" />
+        <text name="ft_auto_farmtablet_autodetect_realisticdealer_detected" text="[FarmTablet] autoDetect: FS25_RealisticDealer erkannt" />
+        <text name="ft_auto_farmtablet_autodetect_registering_invoices_app_built_in" text="[FarmTablet] autoDetect: Rechnungen App wird registriert (built-in + RoleplayPhone Integration)" />
+        <text name="ft_auto_farmtablet_autodetect_soil_fertilizer_detected" text="[FarmTablet] autoDetect: FS25_SoilFertilizer erkannt" />
+        <text name="ft_auto_farmtablet_autodetect_tax_mod_detected" text="[FarmTablet] autoDetect: FS25_TaxMod erkannt" />
+        <text name="ft_auto_farmtablet_autodetect_usedplus_detected" text="[FarmTablet] autoDetect: FS25_UsedPlus erkannt" />
+        <text name="ft_auto_farmtablet_autodetect_worker_costs_detected" text="[FarmTablet] autoDetect: FS25_WorkerCosts erkannt" />
         <text name="ft_auto_farmtablet_back_handler_error_for_app_s_s" text="FarmTablet: back handler error for app '%s': %s" />
-        <text name="ft_auto_farmtablet_could_not_create_overlay_for_sliceid_s" text="FarmTablet: Could not create overlay foder sliceId: %s" />
-        <text name="ft_auto_farmtablet_edit_mode_off_position_scale_saved" text="[FarmTablet] Edit mode AUS — position/scale saved" />
-        <text name="ft_auto_farmtablet_edit_mode_on_drag_to_move_corners_to_resize" text="[FarmTablet] Edit mode ON — drag to move, corners to resize, right-click to exit" />
+        <text name="ft_auto_farmtablet_could_not_create_overlay_for_sliceid_s" text="FarmTablet: Could not create overlay for sliceId: %s" />
+        <text name="ft_auto_farmtablet_edit_mode_off_position_scale_saved" text="[FarmTablet] Bearbeitungsmodus deaktiviert - Position und Größe gespeichert" />
+        <text name="ft_auto_farmtablet_edit_mode_on_drag_to_move_corners_to_resize" text="[FarmTablet] Bearbeitungsmodus aktiviert - ziehen zum Bewegen, an den Ecken ziehen um die Größe zu verändern, Rechtsklick zum Verlassen" />
         <text name="ft_auto_farmtablet_eventbus_error_in_listener_for" text="[FarmTablet EventBus] Error in listener for '" />
         <text name="ft_auto_farmtablet_integration_call_failed_s" text="[FarmTablet] Integration call failed: %s" />
-        <text name="ft_auto_farmtablet_invoicemanager_loaded_d_invoices" text="[FarmTablet/InvoiceManager] Loaded %d invoices" />
-        <text name="ft_auto_farmtablet_invoicemanager_max_invoice_limit_reached_d" text="[FarmTablet/InvoiceManager] Max invoice limit reached (%d)" />
-        <text name="ft_auto_farmtablet_invoicemanager_saved_d_invoices" text="[FarmTablet/InvoiceManager] Saved %d invoices" />
+        <text name="ft_auto_farmtablet_invoicemanager_loaded_d_invoices" text="[FarmTablet/InvoiceManager] %d Rechnungen geladen" />
+        <text name="ft_auto_farmtablet_invoicemanager_max_invoice_limit_reached_d" text="[FarmTablet/InvoiceManager] Maximale Rechnungsanzahl erreicht (%d)" />
+        <text name="ft_auto_farmtablet_invoicemanager_saved_d_invoices" text="[FarmTablet/InvoiceManager] %d Rechnungen gespeichert" />
         <text name="ft_auto_farmtablet_renderer_skipped_nil_text_entry_text_s_x_s_y" text="FarmTablet Renderer: skipped nil text entry — text=%s x=%s y=%s" />
         <text name="ft_auto_farmtablet_system" text="[FarmTablet System] " />
         <text name="ft_auto_farmtablet_ui" text="[FarmTablet UI] " />
@@ -963,124 +963,124 @@
         <text name="ft_auto_farmtablet_v2_dedicated_server_detected_skipping_initia" text="[FarmTablet v2] Dedicated server detected – skipping initialisation." />
         <text name="ft_auto_farmtablet_v2_initializing" text="[FarmTablet v2] Initializing..." />
         <text name="ft_auto_farmtablet_v2_module_loaded" text="[FarmTablet v2] Module loaded." />
-        <text name="ft_auto_farmtablet_v2_ready" text="[FarmTablet v2] Erntebereit." />
+        <text name="ft_auto_farmtablet_v2_ready" text="[FarmTablet v2] ready." />
         <text name="ft_auto_farmtablet_v2_shutdown_complete" text="[FarmTablet v2] Shutdown complete." />
         <text name="ft_auto_farmtabletfocus" text="FarmTabletFocus" />
-        <text name="ft_auto_fatigue_pricier_net_out_across_the_crew" text="fatigue (pricier) net out across the crew." />
+        <text name="ft_auto_fatigue_pricier_net_out_across_the_crew" text="Müdigkeit unter der Belegschaft." />
         <text name="ft_auto_favorites" text="favorites" />
         <text name="ft_auto_favors" text="FAVORS" />
-        <text name="ft_auto_favourites" text="Favourites" />
-        <text name="ft_auto_favourites_2" text="favourites" />
+        <text name="ft_auto_favourites" text="Favoriten" />
+        <text name="ft_auto_favourites_2" text="Favoriten" />
         <text name="ft_auto_fbm" text="fbm" />
-        <text name="ft_auto_feed_animals" text="Feed animals" />
+        <text name="ft_auto_feed_animals" text="Tierfütterung" />
         <text name="ft_auto_fert" text="[FERT!]" />
-        <text name="ft_auto_fertilizing" text="Fertilizing" />
-        <text name="ft_auto_field" text=" - Field " />
-        <text name="ft_auto_field_2" text="FIELD" />
-        <text name="ft_auto_field_3" text="Field" />
-        <text name="ft_auto_field_4" text="Field " />
-        <text name="ft_auto_field_5" text="Field: " />
-        <text name="ft_auto_field_jobs" text="Field Jobs" />
+        <text name="ft_auto_fertilizing" text="Düngend" />
+        <text name="ft_auto_field" text=" - Feld " />
+        <text name="ft_auto_field_2" text="Feld" />
+        <text name="ft_auto_field_3" text="Feld" />
+        <text name="ft_auto_field_4" text="Feld " />
+        <text name="ft_auto_field_5" text="Feld: " />
+        <text name="ft_auto_field_jobs" text="Feldarbeiten" />
         <text name="ft_auto_field_jobs_2" text="field_jobs" />
-        <text name="ft_auto_field_list" text="FIELD LIST" />
-        <text name="ft_auto_field_list_with_phase_badges_row_highlights" text="Field list with phase badges + row highlights" />
-        <text name="ft_auto_field_maintenance" text="Field maintenance" />
+        <text name="ft_auto_field_list" text="FELD LISTE" />
+        <text name="ft_auto_field_list_with_phase_badges_row_highlights" text="Feldübersicht mit Icons und Markierungen" />
+        <text name="ft_auto_field_maintenance" text="Feldpflege" />
         <text name="ft_auto_field_manager" text="Feldmanager" />
         <text name="ft_auto_field_mgr" text="Field Mgr" />
-        <text name="ft_auto_field_sentry" text="Feldwächter" />
-        <text name="ft_auto_field_sentry_2" text="field_sentry" />
+        <text name="ft_auto_field_sentry" text="Feldmonitor" />
+        <text name="ft_auto_field_sentry_2" text="Feldmonitor" />
         <text name="ft_auto_field_status" text="field_status" />
-        <text name="ft_auto_field_work" text="Field Work" />
+        <text name="ft_auto_field_work" text="Feldarbeit" />
         <text name="ft_auto_fieldcount" text="fieldcount_" />
         <text name="ft_auto_fields" text="FIELDS" />
         <text name="ft_auto_fields_2" text="FIELDS  (" />
         <text name="ft_auto_fields_3" text="Felder" />
         <text name="ft_auto_fields_4" text="Felder" />
         <text name="ft_auto_fields_5" text="fields_" />
-        <text name="ft_auto_fields_count_of_fields_your_farm_owns_with_crop_or_empt" text="Felder: count of Felder dein farm owns (mit crop oder empty).&#10;" />
-        <text name="ft_auto_fields_land_you_own_with_a_crop_growing" text="Fields: land you own with a crop growing.&#10;" />
-        <text name="ft_auto_fieldsentry_decides_which_fields_the_soil_simulation_ru" text="FeldSentry decides which Felder soil simulation runs&#10;" />
-        <text name="ft_auto_fieldsentry_is_not_available" text="FieldSentry is not available." />
-        <text name="ft_auto_fieldsentry_per_field_soil_sim_status_sleep_and_meadow" text="FeldSentry — per-Feld soil-sim Status, sleep und meadow toggles" />
+        <text name="ft_auto_fields_count_of_fields_your_farm_owns_with_crop_or_empt" text="Felder: Anzahl an Feldern die deinem Hof gehören (bestellt oder brachliegend).&#10;" />
+        <text name="ft_auto_fields_land_you_own_with_a_crop_growing" text="Fields: Felder in deinem Besitz, auf denen eine Kultur wächst.&#10;" />
+        <text name="ft_auto_fieldsentry_decides_which_fields_the_soil_simulation_ru" text="der Feldmonitor legt fest, auf welchen Feldern die Bodensimulation angewendet wird&#10;" />
+        <text name="ft_auto_fieldsentry_is_not_available" text="Feldmonitor nicht verfügbar." />
+        <text name="ft_auto_fieldsentry_per_field_soil_sim_status_sleep_and_meadow" text="Feldmonitor - Feldspezifische Bodensimulation, Zustand und Wahl zwischen Brachfläche oder Grünland" />
         <text name="ft_auto_fill" text="Fill" />
-        <text name="ft_auto_fill_fuel" text="KRAFTSTOFF FÜLLEN" />
-        <text name="ft_auto_fill_fuel_fills_fuel_and_adblue_to_max" text="FILL KRAFTSTAUS  — fills Kraftstoff (und AdBlue) zu max&#10;" />
-        <text name="ft_auto_filled_time_elapsed_an_offer_can_arrive_any_time" text="Filled = time elapsed. An offer can arrive any time&#10;" />
+        <text name="ft_auto_fill_fuel" text="Kraftstoff Tanken" />
+        <text name="ft_auto_fill_fuel_fills_fuel_and_adblue_to_max" text="Kraftstoff auffüllen - füllt Kraftstoff (und AdBlue) bis zum Maximum auf&#10;" />
+        <text name="ft_auto_filled_time_elapsed_an_offer_can_arrive_any_time" text="Füllzeit abgelaufen. Ein Angebot kann jederzeit erscheinen.&#10;" />
         <text name="ft_auto_filltype" text="fillType_" />
         <text name="ft_auto_filter" text="FILTER: " />
         <text name="ft_auto_fin" text="FIN" />
         <text name="ft_auto_finance" text="FINANCE" />
         <text name="ft_auto_finance_deals" text="FINANCE DEALS" />
         <text name="ft_auto_finances" text="FINANCES" />
-        <text name="ft_auto_finish_current_first" text="finish current first" />
-        <text name="ft_auto_finish_job" text="FINISH JOB" />
-        <text name="ft_auto_finishing_a_job" text="FINISHING A JOB" />
-        <text name="ft_auto_fire" text="FIRE" />
-        <text name="ft_auto_fire_and_pin_workers_to_vehicles" text="fire, und pin Arbeiter zu Fahrzeuge." />
-        <text name="ft_auto_fire_system" text="Fire System" />
+        <text name="ft_auto_finish_current_first" text="schließe den aktuellen zuerst ab" />
+        <text name="ft_auto_finish_job" text="Auftrag abschließen" />
+        <text name="ft_auto_finishing_a_job" text="Einen Auftrag abschließen" />
+        <text name="ft_auto_fire" text="Feuer" />
+        <text name="ft_auto_fire_and_pin_workers_to_vehicles" text="Feuer und Mitarbeit einem Fahrzeug zuweisen." />
+        <text name="ft_auto_fire_system" text="BMA" />
         <text name="ft_auto_fired_s_severance_s" text="Fired %s (severance %s)" />
-        <text name="ft_auto_fix_app_icon_textures_are_now_mipmapped_dds_clearing_mo" text="Fix: app-icon textures are jetzt mipmapped DDS, clearing most of the texture warnings from log.txt" />
-        <text name="ft_auto_fix_app_name_translation_keys_in_appregistry" text="Fix: app name translation keys in AppRegistry" />
-        <text name="ft_auto_fix_app_store_now_scrolls_all_mod_apps_visible" text="Fix: App Store jetzt scrolls (all mod apps visible)" />
-        <text name="ft_auto_fix_camera_lock_and_mouse_cursor_while_tablet_open" text="Fix: camera lock and mouse cursor while tablet oStall" />
-        <text name="ft_auto_fix_companion_mod_setting_changes_server_only_in_mp" text="Fix: companion mod setting changes server-only in MP" />
-        <text name="ft_auto_fix_cross_mod_detection_for_npc_soil_cropstress_apps" text="Fix: cross-mod detection for NPC/Soil/FruchtStress apps" />
-        <text name="ft_auto_fix_paging_arrows_and_toggles_now_update_instantly_remo" text="Fix: paging arrows and toggles jetzt update instantly (removed an up-to-4s delay)" />
-        <text name="ft_auto_fix_production_app_no_longer_reads_stalled_while_a_prod" text="Fix: Production app no longer reads 'gestoppt' while ein production is running" />
-        <text name="ft_auto_fix_remove_broken_texture_atlas_causing_overlay_warning" text="Fix: remove broken texture atlas causing overlay warnings on every oStall" />
-        <text name="ft_auto_fix_settingsui_key_name_alignment" text="Fix: EinstellungenUI key name alignment" />
-        <text name="ft_auto_fix_soil_app_shows_n_p_k_in_ppm_so_the_numbers_match_th" text="Fix: Soil app shows N/P/K in ppm so the numbers match the Soil Fertilizer HUD" />
-        <text name="ft_auto_fix_tablet_content_refreshes_every_4s_while_open" text="Fix: tablet content refreshes every 4s while oStall" />
-        <text name="ft_auto_fix_the_status_bar_signal_battery_power_dock_and_home_i" text="Fix: the status bar signal/battery/power, dock and home indicator jetzt render on the home and lock screens" />
-        <text name="ft_auto_fix_the_worker_costs_app_roster_now_scrolls_past_the_fi" text="Fix: Arbeiter Costs app roster jetzt scrolls past first 5 staff" />
-        <text name="ft_auto_fix_translations_missing_from_zip_package" text="Fix: translations missing from zip package" />
-        <text name="ft_auto_fix_updated_the_updateapp_to_latest_changelogs" text="Fix: updated the UpdateApp to latest changelogs" />
-        <text name="ft_auto_fix_updates_app_now_scrolls_all_entries_visible" text="Fix: Updates app jetzt scrolls (all entries visible)" />
-        <text name="ft_auto_fix_use_getfenv_0_to_detect_cross_mod_globals_in_autode" text="Fix: use getfenv(0) to detect cross-mod globals in autoDetect()" />
-        <text name="ft_auto_fix_vehicle_camera_no_longer_zooms_when_scrolling_insid" text="Fix: Fahrzeug camera no longer zooms when scrolling inside the tablet" />
-        <text name="ft_auto_fixed_nav_button_overflow_on_small_screens" text="Fixed nav button overflow on small screens" />
+        <text name="ft_auto_fix_app_icon_textures_are_now_mipmapped_dds_clearing_mo" text="Fix: App-Icons werden nun mit DDS gemipmapped, entfernt die meisten Textur-Warnungen aus dem Protokoll" />
+        <text name="ft_auto_fix_app_name_translation_keys_in_appregistry" text="Fix: App-Namen Übersetzungen im AppRegistry" />
+        <text name="ft_auto_fix_app_store_now_scrolls_all_mod_apps_visible" text="Fix: AppStore ist jetzt scrollbar (alle mod Apps sichtbar)" />
+        <text name="ft_auto_fix_camera_lock_and_mouse_cursor_while_tablet_open" text="Fix: Bewegungssperre der Kamera und des Mauszeigers, Sobald das Tablet geöffnet ist" />
+        <text name="ft_auto_fix_companion_mod_setting_changes_server_only_in_mp" text="Fix: Enstellungen Integrierter Mods werden im Multiplayer nur auf dem Server gespeichert" />
+        <text name="ft_auto_fix_cross_mod_detection_for_npc_soil_cropstress_apps" text="Fix: Cross-Mod Erkennung für folgende Apps: FS25_SoilFertilizer, FS25_SeasonalCropStress und FS25_NPCFavors" />
+        <text name="ft_auto_fix_paging_arrows_and_toggles_now_update_instantly_remo" text="Fix: Navigationselemente werden nun sofort aktualisiert (eine bis zu 4-sekündige Verzögerung entfernt)" />
+        <text name="ft_auto_fix_production_app_no_longer_reads_stalled_while_a_prod" text="Fix: In der Produktionsapp wird eine Produktion nicht länger als gestoppt angezeigt, wenn diese läuft" />
+        <text name="ft_auto_fix_remove_broken_texture_atlas_causing_overlay_warning" text="Fix: Defekte Texturen entfernt, welche Oberlay-Warnungen ausgelöst haben" />
+        <text name="ft_auto_fix_settingsui_key_name_alignment" text="Fix: Anpassung der angezeigten Tastenbelgungen in den Einstellungen" />
+        <text name="ft_auto_fix_soil_app_shows_n_p_k_in_ppm_so_the_numbers_match_th" text="Fix: Düngung-App zeigt nun die Makronährstoffe (N, P, K) in ppm an, damit die Zahlen mit der HUD übereinstimmen" />
+        <text name="ft_auto_fix_tablet_content_refreshes_every_4s_while_open" text="Fix: Tablet-Inhalt wird alle 4 Sekunden neugeladen, solange es geöffnet ist" />
+        <text name="ft_auto_fix_the_status_bar_signal_battery_power_dock_and_home_i" text="Fix: die Statusanzeige, Akkustand, Netzwerkempfang und andere Anzeigen werden jetzt auf der Startseite und dem Sperrbildschirm angezeigt" />
+        <text name="ft_auto_fix_the_worker_costs_app_roster_now_scrolls_past_the_fi" text="Fix: Personal-App zeigt nun mehr als 5 Einträge" />
+        <text name="ft_auto_fix_translations_missing_from_zip_package" text="Fix: fehlende Übersetzungen aus der .zip-Datei" />
+        <text name="ft_auto_fix_updated_the_updateapp_to_latest_changelogs" text="Fix: die Updates-App auf den letzten Changelog aktualisiert" />
+        <text name="ft_auto_fix_updates_app_now_scrolls_all_entries_visible" text="Fix: Updates-App zeigt nun alle Einträge" />
+        <text name="ft_auto_fix_use_getfenv_0_to_detect_cross_mod_globals_in_autode" text="Fix: getfenv(0) wird nun benutzt um globale Cross-mods in autoDetect() zu erkennen" />
+        <text name="ft_auto_fix_vehicle_camera_no_longer_zooms_when_scrolling_insid" text="Fix: der Zoom der Fahrzeugkamera wird nun nicht mehr beeinflusst, wenn man im Tablet scrollt" />
+        <text name="ft_auto_fixed_nav_button_overflow_on_small_screens" text="überstehende Teile der Navigation auf kleinen Bildschirmen behoben" />
         <text name="ft_auto_fld" text="FLD" />
         <text name="ft_auto_fleet" text="FLEET" />
-        <text name="ft_auto_fleet_2" text="fleet" />
+        <text name="ft_auto_fleet_2" text="Fuhrpark" />
         <text name="ft_auto_fleet_3" text="fleet_" />
-        <text name="ft_auto_fleet_manager" text="Flottenmanager" />
+        <text name="ft_auto_fleet_manager" text="Fuhrpark" />
         <text name="ft_auto_fleet_manager_2" text="fleet_manager" />
         <text name="ft_auto_fog" text="FOG" />
-        <text name="ft_auto_fog_2" text="Fog" />
-        <text name="ft_auto_fog_3" text="fog" />
-        <text name="ft_auto_foggy" text="Foggy" />
+        <text name="ft_auto_fog_2" text="Nebel" />
+        <text name="ft_auto_fog_3" text="Nebel" />
+        <text name="ft_auto_foggy" text="Nebelig" />
         <text name="ft_auto_food" text="FUTTER" />
-        <text name="ft_auto_food_bar" text="FUTTER BAR" />
+        <text name="ft_auto_food_bar" text="FUTTER ANZEIGE" />
         <text name="ft_auto_food_d" text="FUTTER  %d%%" />
-        <text name="ft_auto_for_confirmation_press_it_again_within_4_seconds" text="for confirmation. Press it again within 4 seconds&#10;" />
-        <text name="ft_auto_force_a_field_to_sleep_or_wake_it_your_choice_persists" text="Force ein Feld zu sleep (oder wake it). Your choice persists&#10;" />
+        <text name="ft_auto_for_confirmation_press_it_again_within_4_seconds" text="Um zu bestätigen, drücke innerhalb von 4 Sekunden erneut&#10;" />
+        <text name="ft_auto_force_a_field_to_sleep_or_wake_it_your_choice_persists" text="Erzwinge ein Feld Brachzuliegen. Deine Auswahl bleibt bestehen.&#10;" />
         <text name="ft_auto_forecast" text="FORECAST" />
-        <text name="ft_auto_forest_green" text="Forest Green" />
+        <text name="ft_auto_forest_green" text="Waldgrün" />
         <text name="ft_auto_fork" text="fork" />
         <text name="ft_auto_frame" text="frame" />
-        <text name="ft_auto_freezing" text="Freezing" />
-        <text name="ft_auto_freezing_0_cold_8_cool_16_mild_24" text="Freezing (&lt;0)  Cold (&lt;8)  Cool (&lt;16)  Mild (&lt;24)&#10;" />
-        <text name="ft_auto_frequency" text="Frequency" />
-        <text name="ft_auto_frequency_1_10_controls_how_often_events" text="Frequency (1-10) controls how often Ereigniss&#10;" />
-        <text name="ft_auto_frequency_intensity" text="FREQUENCY / INTENSITY" />
-        <text name="ft_auto_frequent" text="Frequent" />
-        <text name="ft_auto_frequent_2" text="frequent" />
-        <text name="ft_auto_friend" text="Friend" />
-        <text name="ft_auto_friend_70_neutral_40_cold_40" text="Friend &gt;= 70  |  Neutral &gt;= 40  |  Cold &lt; 40.&#10;" />
-        <text name="ft_auto_frontloader" text="frontloader" />
+        <text name="ft_auto_freezing" text="Frost" />
+        <text name="ft_auto_freezing_0_cold_8_cool_16_mild_24" text="Frost (&lt;0)  Kalt (&lt;8)  Kühl (&lt;16)  Raumtemperatur (&lt;24)&#10;" />
+        <text name="ft_auto_frequency" text="Häufigkeit" />
+        <text name="ft_auto_frequency_1_10_controls_how_often_events" text="Häufigkeit (1-10) stellt ein wie oft Ereignisse auftreten&#10;" />
+        <text name="ft_auto_frequency_intensity" text="HÄUFIGKEIT / INTENSITÄT" />
+        <text name="ft_auto_frequent" text="Häufig" />
+        <text name="ft_auto_frequent_2" text="häufig" />
+        <text name="ft_auto_friend" text="Freund" />
+        <text name="ft_auto_friend_70_neutral_40_cold_40" text="Freundlich &gt;= 70  |  Neutral &gt;= 40  |  Kalt &lt; 40.&#10;" />
+        <text name="ft_auto_frontloader" text="Frontlader" />
         <text name="ft_auto_fs25_farmtablet" text="/FS25_FarmTablet" />
         <text name="ft_auto_ft_binaryoption_template_not_found" text="ft: BinaryOption template not found!" />
         <text name="ft_auto_ft_dataprovider_cached_game_data_queries" text="FT_DataProvider: cached game data queries" />
         <text name="ft_auto_ft_description_template_not_found" text="ft: Description template not found!" />
         <text name="ft_auto_ft_ensureresetbutton_settingsframe_invalid" text="ft: ensureResetButton - settingsFrame invalid" />
-        <text name="ft_auto_ft_failed_to_create_settings_section" text="ft: Failed zu create settings section!" />
+        <text name="ft_auto_ft_failed_to_create_settings_section" text="ft: Failed to create settings section!" />
         <text name="ft_auto_ft_missing_translation_for_key" text="ft: Missing translation for key: " />
         <text name="ft_auto_ft_multioption_template_not_found" text="ft: MultiOption template not found!" />
         <text name="ft_auto_ft_renderer_centralized_drawing_api" text="FT_Renderer: centralized drawing API" />
         <text name="ft_auto_ft_reset_button_added_to_footer" text="ft: Reset button added to footer" />
-        <text name="ft_auto_ft_settings_injection_failed" text="ft: Einstellungen injection failed: " />
-        <text name="ft_auto_ft_settings_layout_not_found" text="ft: Einstellungen layout not found!" />
-        <text name="ft_auto_ft_settings_page_not_found_cannot_inject_settings" text="ft: Einstellungen page not found - cannot inject settings!" />
+        <text name="ft_auto_ft_settings_injection_failed" text="ft: settings injection failed: " />
+        <text name="ft_auto_ft_settings_layout_not_found" text="ft: settings layout not found!" />
+        <text name="ft_auto_ft_settings_page_not_found_cannot_inject_settings" text="ft: settings page not found - cannot inject settings!" />
         <text name="ft_auto_ftbackground" text="/FTHintergrund" />
         <text name="ft_auto_ftbackground_2" text="/FTHintergrund/" />
         <text name="ft_auto_ftinvoices" text="FTRechnungen" />
@@ -1090,8 +1090,8 @@
         <text name="ft_auto_ftstoragepeaks" text="FTLagerPeaks" />
         <text name="ft_auto_fuel" text="KRAFTSTOFF" />
         <text name="ft_auto_fuel_2" text="Kraftstoff" />
-        <text name="ft_auto_fuel_bar" text="KRAFTSTAUS BAR" />
-        <text name="ft_auto_full_irrigation_guidance" text="full irrigation guidance." />
+        <text name="ft_auto_fuel_bar" text="KRAFTSTOFFSTATUS" />
+        <text name="ft_auto_full_irrigation_guidance" text="Kompletter Leitfaden zur Verdunstung." />
         <text name="ft_auto_function" text="function" />
         <text name="ft_auto_functionhooks_class_s_not_found" text="[FunctionHooks] Class '%s' not found" />
         <text name="ft_auto_functionhooks_failed_to_hook_s_s" text="[FunctionHooks] Failed to hook %s: %s" />
@@ -1105,12 +1105,12 @@
         <text name="ft_auto_g_cropstressmanager" text="g_cropStressManager" />
         <text name="ft_auto_g_farmtablet" text="g_FarmTablet" />
         <text name="ft_auto_g_soilfertilitymanager" text="g_SoilFertilityManager" />
-        <text name="ft_auto_g_vehiclesalemanager" text="g_FahrzeugSaleManager" />
-        <text name="ft_auto_game_time" text="Game time: " />
+        <text name="ft_auto_g_vehiclesalemanager" text="g_VehicleSaleManager" />
+        <text name="ft_auto_game_time" text="Spielzeit: " />
         <text name="ft_auto_general" text="Allgemein" />
-        <text name="ft_auto_general_work" text="General Work" />
+        <text name="ft_auto_general_work" text="Arbeit (allgemein)" />
         <text name="ft_auto_germinated" text="Germinated" />
-        <text name="ft_auto_getactivecontracts" text="getActiveAufträge" />
+        <text name="ft_auto_getactivecontracts" text="getActiveContracts" />
         <text name="ft_auto_getactivedebt" text="getActiveDebt" />
         <text name="ft_auto_getactiveillnesscount" text="getActiveIllnessCount" />
         <text name="ft_auto_getcreditscore" text="getCreditScore" />
@@ -1119,27 +1119,27 @@
         <text name="ft_auto_getmcclines" text="getMCCLines" />
         <text name="ft_auto_github_com_realistic_farming_fs25_farmtablet" text="github.com/Realistic-Farming/FS25_FarmTablet" />
         <text name="ft_auto_github_com_realistic_farming_fs25_farmtablet_issues" text="github.com/Realistic-Farming/FS25_FarmTablet/issues" />
-        <text name="ft_auto_github_or_kingmods_to_get_new_features_and_fixes" text="GitHub or KingMods to get new features and fixes." />
+        <text name="ft_auto_github_or_kingmods_to_get_new_features_and_fixes" text="GitHub oder KingMods für neue Funktionen und Fehlerbehebungen." />
         <text name="ft_auto_gold" text="GOLD" />
-        <text name="ft_auto_good" text="Good" />
-        <text name="ft_auto_grain_elevator" text="Grain Elevator" />
-        <text name="ft_auto_grain_silos_bunker_silos_silage_pits_manure_stores" text="grain silos, bunker silos, silage pits, manure stores,&#10;" />
+        <text name="ft_auto_good" text="Gut" />
+        <text name="ft_auto_grain_elevator" text="Getreide-Förderband" />
+        <text name="ft_auto_grain_silos_bunker_silos_silage_pits_manure_stores" text="Getreidesilo, Fahrsilo, Getreidegosse, Misthaufen,&#10;" />
         <text name="ft_auto_grapple" text="grapple" />
         <text name="ft_auto_grass" text="GRAS" />
-        <text name="ft_auto_green_30_yellow_65_red_65" text="Green &lt;= 30%  |  Yellow &lt;= 65%  |  Red &gt; 65%." />
-        <text name="ft_auto_green_30_yellow_65_red_65_2" text="Green &lt;= 30%  |  Yellow &lt;= 65%  |  Red &gt; 65%.&#10;" />
-        <text name="ft_auto_green_40_yellow_25_red_25" text="Green &gt;= 40%  |  Yellow &gt;= 25%  |  Red &lt; 25%." />
-        <text name="ft_auto_green_50_yellow_20_red_20" text="Green &gt;= 50%  |  Yellow &gt;= 20%  |  Red &lt; 20%." />
-        <text name="ft_auto_green_60_yellow_25_red_25" text="Green &gt;= 60%  |  Yellow &gt;= 25%  |  Red &lt; 25%.&#10;" />
-        <text name="ft_auto_green_good_yellow_fair_red_poor" text="Green = Good  |  Yellow = Fair  |  Red = Poor.&#10;" />
-        <text name="ft_auto_green_positive_red_overdrawn" text="Green = positive, Red = overdrawn.&#10;" />
-        <text name="ft_auto_green_ready_to_harvest_blue_growing_normally_yellow_nee" text="Green  = Erntebereit zu Ernte.&#10;Blue   = Wächst normally.&#10;Yellow = Needs attention (fertilise, plough, roll, etc.).&#10;Grey   = Fallow / empty Feld." />
+        <text name="ft_auto_green_30_yellow_65_red_65" text="Grün &lt;= 30%  |  Gelb &lt;= 65%  |  Rot &gt; 65%." />
+        <text name="ft_auto_green_30_yellow_65_red_65_2" text="Grün &lt;= 30%  |  Gelb &lt;= 65%  |  Rot &gt; 65%.&#10;" />
+        <text name="ft_auto_green_40_yellow_25_red_25" text="Grün &gt;= 40%  |  Gelb &gt;= 25%  |  Rot &lt; 25%." />
+        <text name="ft_auto_green_50_yellow_20_red_20" text="Grün &gt;= 50%  |  Gelb &gt;= 20%  |  Rot &lt; 20%." />
+        <text name="ft_auto_green_60_yellow_25_red_25" text="Grün &gt;= 60%  |  Gelb &gt;= 25%  |  Rot &lt; 25%.&#10;" />
+        <text name="ft_auto_green_good_yellow_fair_red_poor" text="Grün = Gute  |  Gelb = Ausreichend  |  Rot = Schlecht.&#10;" />
+        <text name="ft_auto_green_positive_red_overdrawn" text="Grün = gut, Rot = zu viel.&#10;" />
+        <text name="ft_auto_green_ready_to_harvest_blue_growing_normally_yellow_nee" text="Grün  = Erntereif.&#10;Blaue   = normales Wachstum.&#10;Gelb = benötigt Aufmerksamkeit (Düngen, Pflügen oder Walzen).&#10;Grau   = Brachland." />
         <text name="ft_auto_ground_level" text="Bodenhöhe" />
-        <text name="ft_auto_ground_level_the_terrain_height_in_metres_at_your" text="Ground Level: the terrain height in metres at your&#10;" />
-        <text name="ft_auto_grouped_into_built_in_farming_and" text="grouped into Integriert, Farming, and&#10;" />
-        <text name="ft_auto_grow" text="GROW" />
-        <text name="ft_auto_growing" text="Wächst" />
-        <text name="ft_auto_growing_2" text="growing" />
+        <text name="ft_auto_ground_level_the_terrain_height_in_metres_at_your" text="Bodenhöhe: die Höhe in Metern auf der du dich befindest&#10;" />
+        <text name="ft_auto_grouped_into_built_in_farming_and" text="zusammengefasst in Integriert, Agrar, und&#10;" />
+        <text name="ft_auto_grow" text="Wachsen" />
+        <text name="ft_auto_growing" text="Im Wachstum" />
+        <text name="ft_auto_growing_2" text="Wachsend" />
         <text name="ft_auto_gui" text="gui/" />
         <text name="ft_auto_h" text=" h" />
         <text name="ft_auto_h_2" text="/h" />
@@ -1148,34 +1148,34 @@
         <text name="ft_auto_ha" text=" ha" />
         <text name="ft_auto_ha_2" text="/ha" />
         <text name="ft_auto_ha_3" text="HA" />
-        <text name="ft_auto_haeufig" text="Haeufig" />
-        <text name="ft_auto_haeufig_2" text="haeufig" />
+        <text name="ft_auto_haeufig" text="Häufig" />
+        <text name="ft_auto_haeufig_2" text="häufig" />
         <text name="ft_auto_haeufig_3" text="häufig" />
-        <text name="ft_auto_harvest_crops" text="Harvest crops" />
-        <text name="ft_auto_harvested" text="Harvested" />
-        <text name="ft_auto_harvesting" text="Harvesting" />
-        <text name="ft_auto_heavy_storm" text="Heavy Storm" />
-        <text name="ft_auto_help" text="Help" />
+        <text name="ft_auto_harvest_crops" text="Ernte Kultur" />
+        <text name="ft_auto_harvested" text="Abgeerntet" />
+        <text name="ft_auto_harvesting" text="Erntend" />
+        <text name="ft_auto_heavy_storm" text="Starker Sturm" />
+        <text name="ft_auto_help" text="Hilfe" />
         <text name="ft_auto_help_panel_sound_off" text="Hilfe-Ton: Aus" />
         <text name="ft_auto_help_panel_sound_on" text="Hilfe-Ton: An" />
-        <text name="ft_auto_help_panel_sound_paging_when_the_fs25_help_opens" text="Help Panel Ton: paging when the FS25 help oStälle.&#10;" />
-        <text name="ft_auto_hero_card_for_balance_on_dashboard" text="Hero card for balance on Übersicht" />
-        <text name="ft_auto_high_wear_reduces_efficiency_repair_before_reaching_80" text="High wear reduces efficiency — reparieren before reaching 80%.&#10;" />
-        <text name="ft_auto_high_wear_reduces_vehicle_efficiency_and_can_cause" text="High wear reduces Fahrzeug efficiency and can cause&#10;" />
-        <text name="ft_auto_higher_organic_matter_improves_water_retention_and" text="Higher organic matter improves water retention and&#10;" />
-        <text name="ft_auto_higher_reputation_unlocks_better_favor_rewards" text="Higher reputation unlocks better favor rewards." />
-        <text name="ft_auto_higher_score_better_loan_terms_and_lower_interest" text="Higher score = better loan terms and lower interest." />
+        <text name="ft_auto_help_panel_sound_paging_when_the_fs25_help_opens" text="Hilfe-Seite Ton: abspielen, wenn die LS25 Hilfe-Seite geöffnet wird.&#10;" />
+        <text name="ft_auto_hero_card_for_balance_on_dashboard" text="Anzeige für Kontostand im Dashboard." />
+        <text name="ft_auto_high_wear_reduces_efficiency_repair_before_reaching_80" text="Eine hohe Abnutzung reduziert die Leistung - repariere dein Fahrzeug bevor sie 80% erreicht.&#10;" />
+        <text name="ft_auto_high_wear_reduces_vehicle_efficiency_and_can_cause" text="Eine hohe Abnutzung reduziert die Leistung deines Fahrzeugs und kann [X] verursachen&#10;" />
+        <text name="ft_auto_higher_organic_matter_improves_water_retention_and" text="Eine höhere Organische Substanz im Boden verbessert die Wasseraufnahme und&#10;" />
+        <text name="ft_auto_higher_reputation_unlocks_better_favor_rewards" text="eine höhere Beliebtheit schaltet bessere Belohnungen für erfüllte Gefallen frei." />
+        <text name="ft_auto_higher_score_better_loan_terms_and_lower_interest" text="ein höherer Score gibt dir bessere Bedingungen für Kredite und geringere Zinsen." />
         <text name="ft_auto_hire" text="EINSTELLEN" />
-        <text name="ft_auto_hire_2" text="hire" />
-        <text name="ft_auto_hire_tab" text="EINSTELLEN TAB" />
-        <text name="ft_auto_hired_s_signing_s" text="Hired %s (signing %s)" />
-        <text name="ft_auto_history" text="HISTORY" />
-        <text name="ft_auto_history_2" text="History · " />
-        <text name="ft_auto_history_3" text="history" />
-        <text name="ft_auto_hof" text="hof" />
-        <text name="ft_auto_home" text="home" />
-        <text name="ft_auto_home_background" text="STARTSEITEN-HINTERGRUND" />
-        <text name="ft_auto_home_background_2" text="STARTSEITEN-HINTERGRUND: " />
+        <text name="ft_auto_hire_2" text="ANSTELLEN" />
+        <text name="ft_auto_hire_tab" text="Anstellungen" />
+        <text name="ft_auto_hired_s_signing_s" text="%s eingestellt (Vertrag unterzeichnet: %s)" />
+        <text name="ft_auto_history" text="Rückblick" />
+        <text name="ft_auto_history_2" text="Rückblick · " />
+        <text name="ft_auto_history_3" text="Rückblick" />
+        <text name="ft_auto_hof" text="Hof" />
+        <text name="ft_auto_home" text="Startseite" />
+        <text name="ft_auto_home_background" text="HINTERGRUND-STARTSEITE" />
+        <text name="ft_auto_home_background_2" text="HINTERGRUND-STARTSEITE: " />
         <text name="ft_auto_host_listen_server_only" text="Host / listen-server only" />
         <text name="ft_auto_host_only" text="Host Only" />
         <text name="ft_auto_hot" text="Hot" />
@@ -1183,1067 +1183,1067 @@
         <text name="ft_auto_hotspot_manager" text="Hotspot-Manager" />
         <text name="ft_auto_hotspot_manager_2" text="hotspot_manager" />
         <text name="ft_auto_hotspots" text="HOTSPOTS" />
-        <text name="ft_auto_hourly_charged_every_in_game_hour" text="Hourly = charged every in-game hour.&#10;" />
-        <text name="ft_auto_hourly_every_in_game_hour" text="Hourly = every in-game hour.&#10;" />
-        <text name="ft_auto_hours" text="Hours" />
-        <text name="ft_auto_hours_2" text="hours" />
-        <text name="ft_auto_hours_status" text="HOURS / STATUS" />
-        <text name="ft_auto_how_clean_the_pen_is_straw_level_for_pigs_and_cows" text="How clean the Stall is — straw level for pigs and cows,&#10;" />
-        <text name="ft_auto_how_much_tax_is_charged_per_cycle" text="How much tax is charged per cycle.&#10;" />
-        <text name="ft_auto_humidity" text="Humidity" />
+        <text name="ft_auto_hourly_charged_every_in_game_hour" text="Stündlich, wird jede in-Game Stunde abgebucht.&#10;" />
+        <text name="ft_auto_hourly_every_in_game_hour" text="Stündlich, jede in-Game Stunde&#10;" />
+        <text name="ft_auto_hours" text="Stunden" />
+        <text name="ft_auto_hours_2" text="Stunden" />
+        <text name="ft_auto_hours_status" text="STUNDEN / STATUS" />
+        <text name="ft_auto_how_clean_the_pen_is_straw_level_for_pigs_and_cows" text="Wie Sauber der Stall ist - Einstreulevel für Kühe und Schweine,&#10;" />
+        <text name="ft_auto_how_much_tax_is_charged_per_cycle" text="Wie viele Steuern pro Zyklus fällig sind&#10;" />
+        <text name="ft_auto_humidity" text="Feuchtigkeit" />
         <text name="ft_auto_icon" text="icon:" />
         <text name="ft_auto_icon_fallback" text="icon:_fallback" />
         <text name="ft_auto_icons" text="icons/" />
         <text name="ft_auto_idle" text="Idle" />
         <text name="ft_auto_idle_2" text="idle" />
-        <text name="ft_auto_if_a_field_has_more_than_5_accumulated_drought" text="If ein Feld has more thein 5% accumulated drought&#10;" />
-        <text name="ft_auto_if_a_vehicle_is_missing_check_it_is_assigned_to" text="If a Fahrzeug is missing, check it is assigned to&#10;" />
-        <text name="ft_auto_if_absolute_nutrient_levels_look_fine" text="if absolute nutrient levels look fine.&#10;" />
-        <text name="ft_auto_if_fs25_roleplayphone_v0_4_0_is_installed" text="If FS25_RoleplayPhone v0.4.0+ is installed,&#10;" />
-        <text name="ft_auto_if_that_time_has_already_passed_today" text="If that time has already passed today,&#10;" />
-        <text name="ft_auto_if_you_own_more_fields_than_fit_on_screen_the_list_scro" text="If du own more Felder thein fit on screen list&#10;scrolls automatically. Use mouse wheel zu scroll." />
-        <text name="ft_auto_illness" text="Illness" />
-        <text name="ft_auto_image_s_in_ftbackground_click_to_cycle" text=" image(s) in FTHintergrund  |  click to cycle" />
+        <text name="ft_auto_if_a_field_has_more_than_5_accumulated_drought" text="Wenn ein Feld mehr als 5% Trockenheit angesammelt hat&#10;" />
+        <text name="ft_auto_if_a_vehicle_is_missing_check_it_is_assigned_to" text="Fehlt ein Fahrzeug, überprüfe ob es zugewiesen ist&#10;" />
+        <text name="ft_auto_if_absolute_nutrient_levels_look_fine" text="wenn der gesamte Nährstofflevel gut aussieht.&#10;" />
+        <text name="ft_auto_if_fs25_roleplayphone_v0_4_0_is_installed" text="Wenn FS25_RoleplayPhone v0.4.0+ installiert ist,&#10;" />
+        <text name="ft_auto_if_that_time_has_already_passed_today" text="Wenn die Zeit heute bereits erreicht wurde,&#10;" />
+        <text name="ft_auto_if_you_own_more_fields_than_fit_on_screen_the_list_scro" text="Wenn du mehr Felder besiztzt als angezeigt werden können, wird automatisch gescrollt. Nutze das Mausrad zum scrollen." />
+        <text name="ft_auto_illness" text="Krankheit" />
+        <text name="ft_auto_image_s_in_ftbackground_click_to_cycle" text=" Bild(er) in FTHintergrund  |  drücke zum Wechseln" />
         <text name="ft_auto_img" text="img:" />
         <text name="ft_auto_implement" text="Implement" />
-        <text name="ft_auto_improved_progress_bars_with_glow_effects" text="Improved progress bars with glow effects" />
-        <text name="ft_auto_improvement_added_scroll_helper_to_support_all_apps_wit" text="Improvement: Added Scroll helper zu support all apps mit long content" />
-        <text name="ft_auto_in_each_version_newest_first" text="in each version, newest first." />
-        <text name="ft_auto_inactive" text="Inactive" />
+        <text name="ft_auto_improved_progress_bars_with_glow_effects" text="Verbesserte Fortschrittanzeige mit Leuchteffekt" />
+        <text name="ft_auto_improvement_added_scroll_helper_to_support_all_apps_wit" text="Improvement: Scroll-Helfer hinzugefügt um alle Apps mit viel Inhalt zu unterstützen" />
+        <text name="ft_auto_in_each_version_newest_first" text="in jeder Version, neuste zuerst." />
+        <text name="ft_auto_inactive" text="Inaktiv" />
         <text name="ft_auto_inc" text="INC" />
-        <text name="ft_auto_including_position_scale_key_sounds_and_startup" text="including position, scale, key, sounds, and startup&#10;" />
-        <text name="ft_auto_income" text="Income" />
-        <text name="ft_auto_income_2" text="income" />
-        <text name="ft_auto_income_and_expenses_tracked_since_this_session_started" text="Income and exStällees tracked since this session started&#10;" />
-        <text name="ft_auto_income_expenses_net_p_l" text="INCOME / EXSTÄLLEES / NET P/L" />
-        <text name="ft_auto_income_mod" text="Income Mod" />
+        <text name="ft_auto_including_position_scale_key_sounds_and_startup" text="inklusive Postion, Größe, Tastenbelegung, Geräusche und Start-App&#10;" />
+        <text name="ft_auto_income" text="Einkommen" />
+        <text name="ft_auto_income_2" text="Einkommen" />
+        <text name="ft_auto_income_and_expenses_tracked_since_this_session_started" text="jedes Einkommen und alle Ausgaben seit Sitzungsstart.&#10;" />
+        <text name="ft_auto_income_expenses_net_p_l" text="EINKOMMEN / AUSGABEN / NET P/L" />
+        <text name="ft_auto_income_mod" text="FS25_IncomeMod" />
         <text name="ft_auto_income_mod_2" text="income_mod" />
-        <text name="ft_auto_income_mod_controls_and_statistics" text="Income Mod controls and statistics" />
-        <text name="ft_auto_income_mod_integration_app" text="Income Mod integration app" />
-        <text name="ft_auto_income_mod_is_not_installed" text="Income Mod is not installed." />
-        <text name="ft_auto_income_money_earned_expenses_money_spent" text="Income: money earned. ExStällees: money sStallt.&#10;" />
-        <text name="ft_auto_incoming" text="incoming" />
-        <text name="ft_auto_incoming_money_owed_to_you" text="INCOMING  (money owed to you)" />
+        <text name="ft_auto_income_mod_controls_and_statistics" text="IncomeMod Einstellungen und Statistiken" />
+        <text name="ft_auto_income_mod_integration_app" text="FS25_IncomeMod IncomeMod App Integration" />
+        <text name="ft_auto_income_mod_is_not_installed" text="FS25_IncomeMod ist nicht installiert." />
+        <text name="ft_auto_income_money_earned_expenses_money_spent" text="Einkommen: verdientes Geld. Ausgaben: ausgegebenes Geld.&#10;" />
+        <text name="ft_auto_incoming" text="Einnahmen" />
+        <text name="ft_auto_incoming_money_owed_to_you" text="Einnahmen  (Geld das dir geschuldet wird)" />
         <text name="ft_auto_info" text="Info" />
-        <text name="ft_auto_initial_release" text="Initial release" />
-        <text name="ft_auto_inputs" text="EINGÄNGE" />
-        <text name="ft_auto_inputs_outputs" text="INPUTS / OUTPUTS" />
-        <text name="ft_auto_install" text="Install " />
-        <text name="ft_auto_install_fs25_incomemod_to_use_this_app" text="Install FS25_IncomeMod to use this app." />
-        <text name="ft_auto_install_fs25_marketdynamics_to_use_this_app" text="Install FS25_MarktDynamics to use this app." />
-        <text name="ft_auto_install_fs25_npcfavor_to_use_this_app" text="Install FS25_NPCFavor to use this app." />
-        <text name="ft_auto_install_fs25_randomworldevents_to_use_this_app" text="Install FS25_RandomWorldEvents to use this app." />
-        <text name="ft_auto_install_fs25_seasonalcropstress_to_use_this_app" text="Install FS25_SeasonalFruchtStress to use this app." />
-        <text name="ft_auto_install_fs25_soilfertilizer_to_use_this_app" text="Install FS25_SoilFertilizer to use this app." />
-        <text name="ft_auto_install_fs25_taxmod_to_use_this_app" text="Install FS25_TaxMod to use this app." />
-        <text name="ft_auto_install_fs25_usedplus_to_use_this_app" text="Install FS25_UsedPlus to use this app." />
-        <text name="ft_auto_install_fs25_workercosts_to_manage_personnel" text="Install FS25_WorkerCosts to manage personnel." />
-        <text name="ft_auto_install_fs25_workercosts_to_use_this_app" text="Install FS25_WorkerCosts to use this app." />
-        <text name="ft_auto_install_that_mod_and_open_its_own_help_section_for" text="Install that mod and oStall its own Help section for&#10;" />
-        <text name="ft_auto_installed" text=" installed" />
-        <text name="ft_auto_installments_d_d" text="Installments: %d/%d" />
+        <text name="ft_auto_initial_release" text="Ursprüngliche Veröffentlichung" />
+        <text name="ft_auto_inputs" text="EINGABEN" />
+        <text name="ft_auto_inputs_outputs" text="EINGABEN / AUSGABEN" />
+        <text name="ft_auto_install" text="Installiere " />
+        <text name="ft_auto_install_fs25_incomemod_to_use_this_app" text="Installiere FS25_IncomeMod, um die App zu nutzen." />
+        <text name="ft_auto_install_fs25_marketdynamics_to_use_this_app" text="Installiere FS25_MarktDynamics, um die App zu nutzen." />
+        <text name="ft_auto_install_fs25_npcfavor_to_use_this_app" text="Installiere FS25_NPCFavor, um die App zu nutzen." />
+        <text name="ft_auto_install_fs25_randomworldevents_to_use_this_app" text="Installiere FS25_RandomWorldEvents, um die App zu nutzen." />
+        <text name="ft_auto_install_fs25_seasonalcropstress_to_use_this_app" text="Installiere FS25_SeasonalFruchtStress, um die App zu nutzen." />
+        <text name="ft_auto_install_fs25_soilfertilizer_to_use_this_app" text="Installiere FS25_SoilFertilizer, um die App zu nutzen." />
+        <text name="ft_auto_install_fs25_taxmod_to_use_this_app" text="Installiere FS25_TaxMod, um die App zu nutzen." />
+        <text name="ft_auto_install_fs25_usedplus_to_use_this_app" text="Installiere FS25_UsedPlus, um die App zu nutzen." />
+        <text name="ft_auto_install_fs25_workercosts_to_manage_personnel" text="Installiere FS25_WorkerCosts, um deine Mitarbeiter zu verwalten." />
+        <text name="ft_auto_install_fs25_workercosts_to_use_this_app" text="Installiere FS25_WorkerCosts, um die App zu nutzen." />
+        <text name="ft_auto_install_that_mod_and_open_its_own_help_section_for" text="Installiere die Mod und öffne deren Hilfe-Seite für&#10;" />
+        <text name="ft_auto_installed" text=" installiert" />
+        <text name="ft_auto_installments_d_d" text="Installationen: %d/%d" />
         <text name="ft_auto_integrated" text="Integrated" />
-        <text name="ft_auto_integrates_with_fs25_seasonalcropstress_to_display" text="Integrates with FS25_SeasonalFruchtStress to display&#10;" />
-        <text name="ft_auto_integrates_with_fs25_soilfertilizer_to_display" text="Integrates with FS25_SoilFertilizer to display&#10;" />
+        <text name="ft_auto_integrates_with_fs25_seasonalcropstress_to_display" text="Bindet die Mod FS25_SeasonalCropStress ein, um anzuzeigen&#10;" />
+        <text name="ft_auto_integrates_with_fs25_soilfertilizer_to_display" text="Bindet die Mod FS25_SoilFertilizer ein, um anzuzeigen&#10;" />
         <text name="ft_auto_integration" text="Integration" />
-        <text name="ft_auto_intensity" text="Intensity" />
-        <text name="ft_auto_intensity_2" text="Intensity: " />
-        <text name="ft_auto_intensity_and_event_counter" text="Intensität, und Ereignis counter." />
+        <text name="ft_auto_intensity" text="Intensität" />
+        <text name="ft_auto_intensity_2" text="Intensität: " />
+        <text name="ft_auto_intensity_and_event_counter" text="Intensität, und Anzahl an Ereignissen." />
         <text name="ft_auto_inv" text="INV" />
         <text name="ft_auto_inv_1" text="inv_1" />
         <text name="ft_auto_inv_2" text="inv_" />
         <text name="ft_auto_invalid_hook_type" text="Invalid hook type: " />
         <text name="ft_auto_invalid_value_use_true_or_false" text="Invalid value. Use 'true' oder 'false'" />
-        <text name="ft_auto_inventory" text="INVENTORY" />
-        <text name="ft_auto_invoice" text="invoice" />
-        <text name="ft_auto_invoice_tracker" text="INVOICE TRACKER" />
-        <text name="ft_auto_invoice_tracker_built_in_roleplayphone_integration" text="Invoice tracker — built-in + RoleplayPhone integration" />
+        <text name="ft_auto_inventory" text="INVENTAR" />
+        <text name="ft_auto_invoice" text="Rechnung" />
+        <text name="ft_auto_invoice_tracker" text="RECHNUNGSVERFOLGUNG" />
+        <text name="ft_auto_invoice_tracker_built_in_roleplayphone_integration" text="Rechnungsverfolgung - built-in + RoleplayPhone Integration" />
         <text name="ft_auto_invoices" text="Rechnungen" />
-        <text name="ft_auto_invoices_created_on_the_phone_appear_here" text="invoices created on the phone appear here&#10;" />
+        <text name="ft_auto_invoices_created_on_the_phone_appear_here" text="Auf deinem Telefon ausgestellte Rechnungen erscheinen hier&#10;" />
         <text name="ft_auto_invoices_phone" text="Rechnungen / Telefon" />
-        <text name="ft_auto_irrigate_those_fields_immediately_to_stop_yield_loss" text="Irrigate those Felder immediately zu stop Ertrag loss." />
-        <text name="ft_auto_it_advances_to_tomorrow_at_that_time" text="it advances to tomorrow at that time." />
+        <text name="ft_auto_irrigate_those_fields_immediately_to_stop_yield_loss" text="Bewässere diese Felder sofort um die Ertragsverluste einzudämmen." />
+        <text name="ft_auto_it_advances_to_tomorrow_at_that_time" text="sie schreitet zum nächsten Tag zur selben Uhrzeit vor." />
         <text name="ft_auto_items" text="EINTRÄGE" />
-        <text name="ft_auto_items_number_of_individual_load_entries_in_history" text="ITEMS = number of individual load entries in history." />
-        <text name="ft_auto_job" text=" job" />
-        <text name="ft_auto_jobs" text="JOBS" />
-        <text name="ft_auto_jobs_2" text="jobs" />
-        <text name="ft_auto_jobs_completed_and_current_fatigue_bar" text="jobs completed, and current fatigue bar.&#10;" />
-        <text name="ft_auto_jumps_the_clock_to_a_preset_time_of_day" text="Jumps clock zu ein preset Tageszeit.&#10;" />
-        <text name="ft_auto_just_on_meadow_rules_independent_of_the_sleep_state" text="just on meadow rules. IndeStalldent of the sleep state." />
-        <text name="ft_auto_keep_track_of_farm_tasks" text="Keep track of farm tasks.&#10;&#10;" />
-        <text name="ft_auto_keeping_up_to_date" text="KEEPING UP TO DATE" />
+        <text name="ft_auto_items_number_of_individual_load_entries_in_history" text="ITEMS = Anzahl individueller Einträge in der Historie." />
+        <text name="ft_auto_job" text=" Aufträge" />
+        <text name="ft_auto_jobs" text="Aufträge" />
+        <text name="ft_auto_jobs_2" text="Aufträge" />
+        <text name="ft_auto_jobs_completed_and_current_fatigue_bar" text="abgeschlossene Aufträge und aktuelle Müdigkeit.&#10;" />
+        <text name="ft_auto_jumps_the_clock_to_a_preset_time_of_day" text="setzte die Uhrzeit auf eine voreingestellte Tageszeit.&#10;" />
+        <text name="ft_auto_just_on_meadow_rules_independent_of_the_sleep_state" text="nur auf Grünland, unabhängig vom Zustand des Feldes." />
+        <text name="ft_auto_keep_track_of_farm_tasks" text="Behalte deine Aufgaben im Blick.&#10;&#10;" />
+        <text name="ft_auto_keeping_up_to_date" text="AUF DEM AKTUELLEN STAND BLEIBEN" />
         <text name="ft_auto_kein_netz" text="KEIN NETZ" />
         <text name="ft_auto_label_color" text="Label-Farbe: " />
-        <text name="ft_auto_label_size" text="BESCHRIFTUNGSGRÖSSE: " />
-        <text name="ft_auto_land_lease" text="Land Lease" />
+        <text name="ft_auto_label_size" text="SCHRIFTGRÖẞE: " />
+        <text name="ft_auto_land_lease" text="Pacht" />
         <text name="ft_auto_landnetz" text="LandNetz" />
         <text name="ft_auto_landnetz_2" text="landnetz" />
-        <text name="ft_auto_large" text="LARGE" />
-        <text name="ft_auto_last_action" text="LAST ACTION" />
-        <text name="ft_auto_last_crop" text="Last Frucht" />
-        <text name="ft_auto_launch" text="launch" />
-        <text name="ft_auto_leave_npc_contracted_or_decorative_land_alone" text="leave NPC-contracted or decorative land alone." />
-        <text name="ft_auto_left_stripe_blue_rain_orange_storm_grey_overcast" text="left stripe: blue = rain, orange = storm, grey = overcast,&#10;" />
+        <text name="ft_auto_large" text="GROẞ" />
+        <text name="ft_auto_last_action" text="LETZTE AKTION" />
+        <text name="ft_auto_last_crop" text="Letzte Kultur" />
+        <text name="ft_auto_launch" text="Starte" />
+        <text name="ft_auto_leave_npc_contracted_or_decorative_land_alone" text="Finger weg von NPC-Flächen oder dekorativen Ländereien." />
+        <text name="ft_auto_left_stripe_blue_rain_orange_storm_grey_overcast" text="Linker Streifen: Blau = Regen, Orange = Sturm, Grau = Bewölkt,&#10;" />
         <text name="ft_auto_level" text="Level" />
         <text name="ft_auto_level_2" text="level" />
         <text name="ft_auto_levels" text="Levels" />
         <text name="ft_auto_light" text="Leicht" />
-        <text name="ft_auto_lists_all_crops_currently_stored_across_your_owned_silo" text="Lists all crops currently stored across your im Besitz silos.&#10;" />
-        <text name="ft_auto_lists_every_active_npc_with_their_relationship_score" text="Lists every aktiv NPC mit their relationship score&#10;" />
-        <text name="ft_auto_lists_every_app_registered_with_the_farm_tablet" text="Lists every app registered with the Farm Tablet,&#10;" />
-        <text name="ft_auto_lists_every_selling_station_and_its_current_price_for" text="Lists every selling station und its current Preis for&#10;" />
-        <text name="ft_auto_lists_the_8_most_recent_dump_cycles_with_material" text="Lists the 8 most recent dump cycles with material&#10;" />
-        <text name="ft_auto_lists_the_fill_types_the_building_consumes_and_produces" text="Lists the fill types the building consumes and produces.&#10;" />
-        <text name="ft_auto_litres_remaining_and_total_capacity_shown_beside_the_ba" text="Litres remaining and total capacity shown beside the bar.&#10;" />
+        <text name="ft_auto_lists_all_crops_currently_stored_across_your_owned_silo" text="Zeigt alle eingelagerten Kulturen in all deinen Silos an.&#10;" />
+        <text name="ft_auto_lists_every_active_npc_with_their_relationship_score" text="Zeigt alle aktiven NPC mit ihrem Verhältnis zu dir.&#10;" />
+        <text name="ft_auto_lists_every_app_registered_with_the_farm_tablet" text="Zeigt jede installierte App auf dem Farm Tablet,&#10;" />
+        <text name="ft_auto_lists_every_selling_station_and_its_current_price_for" text="Zeigt jede Ankaufstation und den aktuellen Preis für&#10;" />
+        <text name="ft_auto_lists_the_8_most_recent_dump_cycles_with_material" text="Zeigt die letzten acht Ladevorgänge mit Material&#10;" />
+        <text name="ft_auto_lists_the_fill_types_the_building_consumes_and_produces" text="Zeigt die Materialien die ein Gebäude verbraucht und produziert.&#10;" />
+        <text name="ft_auto_litres_remaining_and_total_capacity_shown_beside_the_ba" text="Liter verbleibend und Gesamtvolumen.&#10;" />
         <text name="ft_auto_live_updates" text="LIVE UPDATES" />
-        <text name="ft_auto_load_history" text="LOAD HISTORY" />
-        <text name="ft_auto_load_history_2" text="LOAD HISTORY  (" />
-        <text name="ft_auto_loader" text="loader" />
-        <text name="ft_auto_loading" text="Loading" />
-        <text name="ft_auto_loads" text="LOADS" />
-        <text name="ft_auto_loads_total_dump_cycles_recorded_this_session" text="LOADS = total dump cycles recorded this session.&#10;" />
-        <text name="ft_auto_loan" text="LOAN" />
-        <text name="ft_auto_loan_2" text="Loan" />
-        <text name="ft_auto_loan_3" text="loan" />
-        <text name="ft_auto_loan_4" text="loan_" />
-        <text name="ft_auto_loan_amount" text="Loein Betrag" />
-        <text name="ft_auto_loan_amount_shown_alongside_balance_if_active" text="Loein amount shown alongside balance if aktiv." />
-        <text name="ft_auto_loan_outstanding_loan_amount_0_if_debt_free" text="Loan: outstanding loan amount (0 if debt-free).&#10;" />
-        <text name="ft_auto_loan_payment" text="Loan Payment" />
+        <text name="ft_auto_load_history" text="LADE HISTORIE" />
+        <text name="ft_auto_load_history_2" text="LADE HISTORIE  (" />
+        <text name="ft_auto_loader" text="Lader" />
+        <text name="ft_auto_loading" text="Laden" />
+        <text name="ft_auto_loads" text="LADUNGEN" />
+        <text name="ft_auto_loads_total_dump_cycles_recorded_this_session" text="Ladungen, alle in dieser Spielsitzung aufgezeichneten Ladevorgänge.&#10;" />
+        <text name="ft_auto_loan" text="Kredit" />
+        <text name="ft_auto_loan_2" text="Kredit" />
+        <text name="ft_auto_loan_3" text="Kredit" />
+        <text name="ft_auto_loan_4" text="Kredit_" />
+        <text name="ft_auto_loan_amount" text="Kredithöhe" />
+        <text name="ft_auto_loan_amount_shown_alongside_balance_if_active" text="Kredithöhe und Kontostand." />
+        <text name="ft_auto_loan_outstanding_loan_amount_0_if_debt_free" text="Kredit: Höhe der noch offenen Auszahlung (0, wenn Schuldenfrei).&#10;" />
+        <text name="ft_auto_loan_payment" text="Kreditzahlung" />
         <text name="ft_auto_lock" text="lock" />
-        <text name="ft_auto_log_field_work_sessions_field_vehicle_task_duration" text="Feldarbeiten protokollieren – Feld, Fahrzeug, Aufgabe, Dauer" />
-        <text name="ft_auto_longer_bar_more_moisture_in_the_soil" text="Longer bar = more moisture in the soil.&#10;" />
+        <text name="ft_auto_log_field_work_sessions_field_vehicle_task_duration" text="Feldarbeiten aufzeichnen - Feld, Fahrzeug, Aufgabe, Dauer" />
+        <text name="ft_auto_longer_bar_more_moisture_in_the_soil" text="Je länger der Balken desto mehr Feuchtigkeit befindet sich im Boden.&#10;" />
         <text name="ft_auto_low_cleanliness_reduces_output_and_animal_happiness" text="Low cleanliness reduces output and animal happiness." />
-        <text name="ft_auto_low_medium_high_tiers_are_configured_in" text="Low / Mittel / High tiers are configured in&#10;" />
-        <text name="ft_auto_low_medium_high_tiers_are_set_in_the_mod_settings" text="Low / Mittel / High tiers are set in the mod settings.&#10;" />
+        <text name="ft_auto_low_medium_high_tiers_are_configured_in" text="Gering / Mittel / Hoch werden in [X] eingestellt&#10;" />
+        <text name="ft_auto_low_medium_high_tiers_are_set_in_the_mod_settings" text="Gering / Mittel / Hoch werden in den Modeinstellungen geändert&#10;" />
         <text name="ft_auto_m" text="m  " />
         <text name="ft_auto_m_left" text="m left" />
-        <text name="ft_auto_maintenance" text="Maintenance" />
+        <text name="ft_auto_maintenance" text="Wartung" />
         <text name="ft_auto_maize" text="CORN" />
-        <text name="ft_auto_manage_via_roleplayphone_app" text="Manage via RoleplayPhone app" />
-        <text name="ft_auto_manage_your_pro_staff_roster_review_hire" text="Manage your Pro-Staff roster: review, hire,&#10;" />
-        <text name="ft_auto_management_menu_to_turn_them_on" text="management menu to turn them on)." />
-        <text name="ft_auto_manual_you_put_it_to_sleep" text="MANUAL = you put it to sleep.&#10;" />
-        <text name="ft_auto_mark_a_field_as_permanent_grassland_it_still_simulates" text="Mark ein Feld as permanent grassland. It still simulates,&#10;" />
-        <text name="ft_auto_market" text="market" />
-        <text name="ft_auto_market_dynamics" text="Markt Dynamics" />
+        <text name="ft_auto_manage_via_roleplayphone_app" text="Verwalte mit der RoleplayPhone App" />
+        <text name="ft_auto_manage_your_pro_staff_roster_review_hire" text="Verwalte deine Pro-Staff Belegschaft: Überprüfen, Einstellen,&#10;" />
+        <text name="ft_auto_management_menu_to_turn_them_on" text="Verwaltungsmenü um anzuschalten)." />
+        <text name="ft_auto_manual_you_put_it_to_sleep" text="MANUAL = du hast es schlafen gelegt&#10;" />
+        <text name="ft_auto_mark_a_field_as_permanent_grassland_it_still_simulates" text="Lege ein Feld als Grünland fest, es simuliert weiterhin&#10;" />
+        <text name="ft_auto_market" text="Markt" />
+        <text name="ft_auto_market_dynamics" text="Börse" />
         <text name="ft_auto_market_dynamics_2" text="market_dynamics" />
-        <text name="ft_auto_market_dynamics_is_not_installed" text="Markt Dynamics is not installed." />
-        <text name="ft_auto_market_prices_and_dynamic_events" text="Markt Preiss und dynamic Ereigniss" />
-        <text name="ft_auto_marketplace" text="Marktplace" />
-        <text name="ft_auto_master_toggle_for_all_tablet_sounds" text="Master toggle for all tablet sounds.&#10;" />
-        <text name="ft_auto_matching_mod_is_loaded_in_your_savegame" text="matching mod is loaded in your savegame." />
+        <text name="ft_auto_market_dynamics_is_not_installed" text="FS25_MarketDynamics ist nicht installiert." />
+        <text name="ft_auto_market_prices_and_dynamic_events" text="Börse und dynamische Events" />
+        <text name="ft_auto_marketplace" text="Handel" />
+        <text name="ft_auto_master_toggle_for_all_tablet_sounds" text="Gesamtschalter für alle Tablet-Geräusche.&#10;" />
+        <text name="ft_auto_matching_mod_is_loaded_in_your_savegame" text="passender Mod ist in deinem Spielstand geladen." />
         <text name="ft_auto_material" text="MATERIAL" />
         <text name="ft_auto_materialhandler" text="materialhandler" />
-        <text name="ft_auto_matter_levels_for_each_of_your_owned_fields" text="matter Stufes foder each of dein im Besitz Felder." />
-        <text name="ft_auto_maximises_milk_eggs_wool_and_manure_output" text="maximises milk, eggs, wool, and manure output." />
-        <text name="ft_auto_meadow" text="MEADOW" />
-        <text name="ft_auto_meadow_2" text="meadow" />
-        <text name="ft_auto_meadow_toggle" text="MEADOW TOGGLE" />
+        <text name="ft_auto_matter_levels_for_each_of_your_owned_fields" text="Stoff-Verfügbarkeit für jedes deiner Felder." />
+        <text name="ft_auto_maximises_milk_eggs_wool_and_manure_output" text="maximiert die Produktion von Milch, Eiern, Wolle und Mist." />
+        <text name="ft_auto_meadow" text="GRÜNLAND" />
+        <text name="ft_auto_meadow_2" text="Grünland" />
+        <text name="ft_auto_meadow_toggle" text="Grünland Schalter" />
         <text name="ft_auto_medium" text="MITTEL" />
         <text name="ft_auto_medium_2" text="Mittel" />
         <text name="ft_auto_medium_3" text="medium" />
         <text name="ft_auto_midnight" text="MITTERNACHT" />
-        <text name="ft_auto_midnight_purple" text="Mitternacht Purple" />
-        <text name="ft_auto_midnight_purple_warm_dark_slate_grey" text="Mitternacht Purple, Warm Dark, Slate Grey." />
+        <text name="ft_auto_midnight_purple" text="Mitternachtslila" />
+        <text name="ft_auto_midnight_purple_warm_dark_slate_grey" text="Mitternachtslila, Dunkelwarm, Schiefergrau." />
         <text name="ft_auto_mild" text="Mild" />
-        <text name="ft_auto_mission" text="Mission" />
+        <text name="ft_auto_mission" text="Auftrag" />
         <text name="ft_auto_mkt" text="MKT" />
-        <text name="ft_auto_mod_integration_categories" text="Mod Integration categories." />
-        <text name="ft_auto_mod_integrations" text="MOD INTEGRATIONS" />
-        <text name="ft_auto_mod_not_installed" text="mod not installed" />
+        <text name="ft_auto_mod_integration_categories" text="Mod-Integrationen - Kategorien." />
+        <text name="ft_auto_mod_integrations" text="MOD INTEGRATIONEN" />
+        <text name="ft_auto_mod_not_installed" text="Mod nicht installiert" />
         <text name="ft_auto_moderate" text="Mittel" />
         <text name="ft_auto_mods" text="MODS" />
-        <text name="ft_auto_modsettings" text="modEinstellungen" />
-        <text name="ft_auto_moisture_bar" text="MOISTURE BAR" />
-        <text name="ft_auto_moisture_data_not_yet_available" text="Moisture data not yet available." />
+        <text name="ft_auto_modsettings" text="modSettings" />
+        <text name="ft_auto_moisture_bar" text="FEUCHTIGKEITSANZEIGE" />
+        <text name="ft_auto_moisture_data_not_yet_available" text="Daten zur Feuchtigkeit sind noch nicht verfügbar." />
         <text name="ft_auto_money" text="GELD" />
-        <text name="ft_auto_money_others_owe_you_incoming" text="money others owe you (INCOMING).&#10;" />
-        <text name="ft_auto_month_costs" text="MONTH COSTS" />
-        <text name="ft_auto_month_to_date" text="Month To Date" />
-        <text name="ft_auto_monthly_accumulated_and_charged_at_month_end" text="Monthly = accumulated and charged at month end." />
-        <text name="ft_auto_monthly_total" text="Monthly Total" />
-        <text name="ft_auto_more_tap_history" text=" more — tap HISTORY" />
-        <text name="ft_auto_mostly_cloudy" text="Meist Bewölkt" />
-        <text name="ft_auto_mount_a_wheel_loader_excavator_or_material_handler" text="mount a wheel loader, excavator, or material handler.&#10;" />
-        <text name="ft_auto_mow_grass" text="Mow grass" />
-        <text name="ft_auto_mowing" text="Mowing" />
-        <text name="ft_auto_mowing_cutting" text="Mowing / Cutting" />
+        <text name="ft_auto_money_others_owe_you_incoming" text="Geld welches dir noch geschuldet wird (EINNAHMEN).&#10;" />
+        <text name="ft_auto_month_costs" text="Monatliche Kosten" />
+        <text name="ft_auto_month_to_date" text="Monat zu Datum" />
+        <text name="ft_auto_monthly_accumulated_and_charged_at_month_end" text="Monatlich zusammengezählt, Abrechnung am Monatsende." />
+        <text name="ft_auto_monthly_total" text="Monat (gesamt)" />
+        <text name="ft_auto_more_tap_history" text=" mehr - drücke Historie" />
+        <text name="ft_auto_mostly_cloudy" text="überwiegend Bewölkt" />
+        <text name="ft_auto_mount_a_wheel_loader_excavator_or_material_handler" text="Benutze einen Radlader, Bagger oder ein anderes Gerät mit dem du Güter bewegen kannst.&#10;" />
+        <text name="ft_auto_mow_grass" text="Mähe Gras" />
+        <text name="ft_auto_mowing" text="Mähend" />
+        <text name="ft_auto_mowing_cutting" text="Mähen und Schneiden" />
         <text name="ft_auto_multi" text="^multi" />
-        <text name="ft_auto_multi_day_outlook_day_1_through_day_5" text="Multi-Tag outlook — Tag +1 through Tag +5.&#10;" />
+        <text name="ft_auto_multi_day_outlook_day_1_through_day_5" text="5-Tages-Vorhersage: Tag 1 bis Tag 5.&#10;" />
         <text name="ft_auto_multiplayer" text="MULTIPLAYER" />
-        <text name="ft_auto_municipality" text="Municipality" />
-        <text name="ft_auto_must_be_run_by_the_session_host" text="must be run by the session host." />
-        <text name="ft_auto_my_farm" text="My Farm" />
-        <text name="ft_auto_n_a" text="N/A" />
+        <text name="ft_auto_municipality" text="Gemeinde" />
+        <text name="ft_auto_must_be_run_by_the_session_host" text="muss vom Session-Host gestartet werden." />
+        <text name="ft_auto_my_farm" text="Mein Hof" />
+        <text name="ft_auto_n_a" text="unbekannt" />
         <text name="ft_auto_name" text="Name" />
         <text name="ft_auto_name_2" text="name" />
-        <text name="ft_auto_name_and_estimated_weight_per_load" text="name and estimated weight per load.&#10;" />
+        <text name="ft_auto_name_and_estimated_weight_per_load" text="Name und geschätztes Gewicht der Ladung.&#10;" />
         <text name="ft_auto_ne" text="NE" />
-        <text name="ft_auto_nearby" text="NEARBY  (" />
-        <text name="ft_auto_nearby_vehicle_diagnostics" text="Fahrzeugdiagnose in der Nähe" />
+        <text name="ft_auto_nearby" text="NÄHE  (" />
+        <text name="ft_auto_nearby_vehicle_diagnostics" text="Diagnose der Fahrzeuge in der Nähe" />
         <text name="ft_auto_nearby_vehicles" text="FAHRZEUGE IN DER NÄHE" />
-        <text name="ft_auto_needs_fertilizer" text="Needs Fertilizer" />
+        <text name="ft_auto_needs_fertilizer" text="Muss gedüngt werden" />
         <text name="ft_auto_needs_fertilizer_flag" text="NEEDS FERTILIZER FLAG" />
         <text name="ft_auto_net_p_l" text="Net P/L" />
-        <text name="ft_auto_net_p_l_income_minus_expenses" text="Net P/L: income minus exStällees." />
-        <text name="ft_auto_net_p_l_income_minus_expenses_for_the_session" text="Net P/L = income minus exStällees for the session." />
+        <text name="ft_auto_net_p_l_income_minus_expenses" text="Net P/L: Einkommen abzüglich der Ausgaben." />
+        <text name="ft_auto_net_p_l_income_minus_expenses_for_the_session" text="Net P/L = Einkommen abzüglich der Ausgaben für die aktuelle Spiel-Sitzung." />
         <text name="ft_auto_net_pl" text="net_pl" />
-        <text name="ft_auto_net_savings" text="Net Savings" />
-        <text name="ft_auto_net_surcharge" text="Net Surcharge" />
+        <text name="ft_auto_net_savings" text="Netto Einsparungen" />
+        <text name="ft_auto_net_surcharge" text="Netto Kontoüberziehung" />
         <text name="ft_auto_net_worth" text="Nettovermögen" />
-        <text name="ft_auto_net_worth_balance_minus_loan_your_true_financial_positi" text="Net Worth: balance minus loan — your true financial position." />
-        <text name="ft_auto_network" text="Network" />
-        <text name="ft_auto_network_outage" text="Network outage" />
-        <text name="ft_auto_network_outage_detected_estimated_duration_approx_d_in" text="Network outage detected. Estimated duration: approx. %d in-game hours." />
-        <text name="ft_auto_network_outage_fixed_data_is_updating" text="Network outage fixed. Data is updating." />
-        <text name="ft_auto_network_outages" text="Netzstörungen" />
+        <text name="ft_auto_net_worth_balance_minus_loan_your_true_financial_positi" text="Nettovermögen: Kontostand abzüglich Kredit ergibt deine finanzielle Lage." />
+        <text name="ft_auto_network" text="Netzwerk" />
+        <text name="ft_auto_network_outage" text="Netzwerkstörung" />
+        <text name="ft_auto_network_outage_detected_estimated_duration_approx_d_in" text="Netzwerkstörung festgestellt. Vorrausichtliche Dauer: %d in-Game Stunden." />
+        <text name="ft_auto_network_outage_fixed_data_is_updating" text="Netzwerkstörung behoben. datenw erden aktualisiert." />
+        <text name="ft_auto_network_outages" text="Netzwerkstörungen" />
         <text name="ft_auto_netzst" text="netzst" />
         <text name="ft_auto_netzwerk" text="NETZWERK" />
         <text name="ft_auto_neutral" text="Neutral" />
         <text name="ft_auto_new" text="+ NEU" />
-        <text name="ft_auto_new_about_section_in_settings_with_version_links" text="Neu: About section in Einstellungen with version + links" />
-        <text name="ft_auto_new_added_ukrainian_translation" text="Neu: Added Ukrainiein translation" />
-        <text name="ft_auto_new_apps_open_full_screen_with_a_home_back_bar_redesign" text="Neu: apps oStall full-screen with a Home/Back bar; redesigned 3D frame, screen gloss + wallpaper" />
-        <text name="ft_auto_new_back_now_steps_up_one_level_leaves_a_sub_page_first" text="Neu: Back jetzt steps up one Stufe (leaves ein sub-page first) instead of always jumping straight home" />
+        <text name="ft_auto_new_about_section_in_settings_with_version_links" text="Neu: Abschnitt mit Erklärung in den Einstellungen mit Versionen" />
+        <text name="ft_auto_new_added_ukrainian_translation" text="Neu: Ukrainische Übersetzung hinzugefügt" />
+        <text name="ft_auto_new_apps_open_full_screen_with_a_home_back_bar_redesign" text="Neu: Apps öffnen sich nun im Vollbildmodus mit einer Startseiten-Leiste; Überarbeiteter 3D frame, Bildschirmglanz und Hintergrundbild" />
+        <text name="ft_auto_new_back_now_steps_up_one_level_leaves_a_sub_page_first" text="Neu: Zurück geht nun eine Seite zurück (Unterseite werden vorher verlassen) anstatt direkt auf die Startseite zurückzukehren" />
         <text name="ft_auto_new_clearer_app_bar_buttons_a_little_house_for_home_and" text="Neu: clearer app-bar buttons — a little house for Home and a real left arrow for Back" />
-        <text name="ft_auto_new_custom_home_background_drop_a_png_in_your_savegame" text="Neu: custom home background — drop a PNG in your savegame's FTHintergrund folder and pick it in Einstellungen" />
-        <text name="ft_auto_new_customise_the_app_icon_labels_in_settings_show_or_h" text="Neu: customise the app-icon labels in Einstellungen — show or hide them, and change their size and colour" />
-        <text name="ft_auto_new_farm_admin_money_time_repair_all_fill_all_fuel" text="Neu: Farm Admin — money, time, reparieren all, fill all Kraftstoff" />
-        <text name="ft_auto_new_favourites_page_tap_the_star_in_the_app_bar_or_on_t" text="Neu: Favourites page — tap the star in the app bar or on the home screen to see just your starred apps; the star glows gold when it's oStall" />
-        <text name="ft_auto_new_fully_multiplayer_actions_route_to_the_host_and_syn" text="Neu: fully multiplayer — actions route to the host and sync back to everyone" />
-        <text name="ft_auto_new_glossy_app_icons_for_every_app_built_in_integrated" text="Neu: glossy app icons for every app (built-in + integrated mods), on a paged grid with a dock" />
-        <text name="ft_auto_new_hire_tab_recruitment_pool_with_per_candidate_level" text="Neu: Hire tab — recruitment pool with per-candidate level and signing cost; reroll candidates" />
-        <text name="ft_auto_new_hotspot_manager_list_remove_map_pins_clear_all_conf" text="Neu: Hotspot Manager — list/remove map pins, clear all (confirm)" />
-        <text name="ft_auto_new_invoice" text="NEU INVOICE" />
-        <text name="ft_auto_new_invoice_2" text="Neu Invoice" />
-        <text name="ft_auto_new_invoices_app_with_in_tablet_creation_form" text="Neu: Rechnungen app with in-tablet creation form" />
-        <text name="ft_auto_new_job" text="Neu Job" />
-        <text name="ft_auto_new_market_dynamics_integration_app" text="Neu: Markt Dynamics integration app" />
-        <text name="ft_auto_new_notes_app_checkbox_todo_list_saves_per_savegame" text="Neu: Notizen app — checkbox todo list, saves per savegame" />
-        <text name="ft_auto_new_payroll_tab_wage_structure_running_estimate_and_the" text="Neu: Payroll tab — wage structure, running estimate, und Pro-Staff cost impact per Arbeiter" />
-        <text name="ft_auto_new_personnel_pro_staff_app_a_dedicated_hr_command_cent" text="Neu: Personal (Pro-Staff) app — a dedicated HR command center for Worker Costs" />
-        <text name="ft_auto_new_random_world_events_integration_app" text="Neu: Random World Events integration app" />
-        <text name="ft_auto_new_real_tablet_experience_a_lock_screen_with_slide_to" text="Neu: real tablet experience — a lock screen with slide-to-unlock, then a home springboard" />
-        <text name="ft_auto_new_roleplayphone_integration_foundation" text="Neu: RoleplayPhone integration foundation" />
-        <text name="ft_auto_new_roster_section_scrolls_multiplayer_clients_see_a_ho" text="Neu: roster section scrolls; multiplayer clients see a host-managed note until sync lands" />
-        <text name="ft_auto_new_roster_tab_sort_filter_workers_pin_to_your_vehicle" text="Neu: Roster tab — sort/filtern Arbeiter, pin zu dein Fahrzeug, fire (two-tap, severance applies)" />
-        <text name="ft_auto_new_status_bar_with_live_clock_draining_battery_and_sig" text="Neu: status bar with live clock, draining battery and signal; tap the power icon to lock" />
-        <text name="ft_auto_new_storage_app_silo_inventory_and_current_sell_prices" text="Neu: Lager app — silo inventory and current sell prices" />
-        <text name="ft_auto_new_tap_an_app_to_launch_it_with_a_zoom_open_animation" text="Neu: tap an app to launch it with a zoom-oStall animation; every icon presses in when touched" />
-        <text name="ft_auto_new_tap_edit_on_the_favourites_page_to_pick_which_apps" text="Neu: tap EDIT on the Favourites page to pick which apps you want; your picks are saved per savegame" />
-        <text name="ft_auto_new_time_controls_app_time_scale_presets_skip_to_time_o" text="Neu: Time Controls app — time scale presets + skip zu Tageszeit" />
+        <text name="ft_auto_new_custom_home_background_drop_a_png_in_your_savegame" text="Neu: benutzerdefinierter Hintergrund auf der Startseite - füge eine PNG-Datei in den Ordner FTBackground in deinem Spielstand ein und wähle es in den Einstellungen aus" />
+        <text name="ft_auto_new_customise_the_app_icon_labels_in_settings_show_or_h" text="Neu: bearbeite die App-Icon Labels in den Einstellungen - zeige oder verstecke sie und ändere ihre Größe oder Farbe" />
+        <text name="ft_auto_new_farm_admin_money_time_repair_all_fill_all_fuel" text="Neu: Farm Admin - Geld verwalten, Uhrzeit einstellen, alle Fahrzeuge reparieren, alle Fahrzeuge vollanken" />
+        <text name="ft_auto_new_favourites_page_tap_the_star_in_the_app_bar_or_on_t" text="Neu: Seite mit Favorieten: drücke auf das Stern-Symbol in der App-Leiste oder auf dem Startbildschirm um deine Favorieten zu sehen." />
+        <text name="ft_auto_new_fully_multiplayer_actions_route_to_the_host_and_syn" text="Neu: Komplett Multiplayerfähig: alle Aktionen werden dem Host mitgeteilt und werden synchronisiert" />
+        <text name="ft_auto_new_glossy_app_icons_for_every_app_built_in_integrated" text="Neu: glänzende Icons für jede App (built-in + Integrierte mods)" />
+        <text name="ft_auto_new_hire_tab_recruitment_pool_with_per_candidate_level" text="Neu: Arbeitsmarkt - Auswahl mit Arbeitskräften, die für jeden Mitarbeiter ein individuelles Erfahrungslevel und Gehaltsvorstellungen erstellt; Möglichkeit die Auswahl neuzuladen" />
+        <text name="ft_auto_new_hotspot_manager_list_remove_map_pins_clear_all_conf" text="Neu: Hotspot Manager - zeige alle Punkte auf der Karte an und entferne sie; Möglichkeit alle zu entfernen (mit Bestätigung)" />
+        <text name="ft_auto_new_invoice" text="NEUE RECHNUNG" />
+        <text name="ft_auto_new_invoice_2" text="Neue Rechnung" />
+        <text name="ft_auto_new_invoices_app_with_in_tablet_creation_form" text="Neu: Rechnungen App mit im Tablet integrierter Ausstellung" />
+        <text name="ft_auto_new_job" text="Neuer Auftrag" />
+        <text name="ft_auto_new_market_dynamics_integration_app" text="Neu: FS25_DynamicMarket App Integration" />
+        <text name="ft_auto_new_notes_app_checkbox_todo_list_saves_per_savegame" text="Neu: Notizen App - Checkbox, to-do Liste, wird pro Spielstand gespeichert" />
+        <text name="ft_auto_new_payroll_tab_wage_structure_running_estimate_and_the" text="Neu: Gehälterübersicht - Lohnstrukturen, geschätzte laufende Kosten und Pro-Staff Kosteneinfluss pro Mitarbeiter" />
+        <text name="ft_auto_new_personnel_pro_staff_app_a_dedicated_hr_command_cent" text="Neu: Personal (Pro-Staff) App - eine eigenständige App für Personalverwaltung" />
+        <text name="ft_auto_new_random_world_events_integration_app" text="Neu: Random World Events App Integration" />
+        <text name="ft_auto_new_real_tablet_experience_a_lock_screen_with_slide_to" text="Neu: Wie ein echtes Tablet: Wischen um den Bildschirm zu entsperren, dann gelangst du auf eine Startseite" />
+        <text name="ft_auto_new_roleplayphone_integration_foundation" text="Neu: RoleplayPhone Integration" />
+        <text name="ft_auto_new_roster_section_scrolls_multiplayer_clients_see_a_ho" text="Neu: Personalübersicht ist nun scrollbar: im Multiplayer wird eine durch den Host festgelegte Nachricht angezeigt, während die Daten synchronisiert werden." />
+        <text name="ft_auto_new_roster_tab_sort_filter_workers_pin_to_your_vehicle" text="Neu: Personalübersicht - sortiere und filtere deine Mitarbeiter, weise sie Fahrzeugen zu oder entlasse sie gegen eine Abfindung (Doppelklick)" />
+        <text name="ft_auto_new_status_bar_with_live_clock_draining_battery_and_sig" text="Neu: Statusleiste mit aktueller Uhrzeit, funktionierendem Akkustand und Netzwerk; Drücke das Power-Icon um das Tablet zu sperren" />
+        <text name="ft_auto_new_storage_app_silo_inventory_and_current_sell_prices" text="Neu: Lager App - alle eingelagerten Materialien und die aktuellen Preise" />
+        <text name="ft_auto_new_tap_an_app_to_launch_it_with_a_zoom_open_animation" text="Neu: Zoom-Transition und animiertes Icon beim Öffnen der App" />
+        <text name="ft_auto_new_tap_edit_on_the_favourites_page_to_pick_which_apps" text="Neu: Drücke BEARBEITEN auf der Favoriten-Seite um deine Lieblingsapps auszuwählen; die Auswahl wird pro Spielstand gespeichert" />
+        <text name="ft_auto_new_time_controls_app_time_scale_presets_skip_to_time_o" text="Neu: Zeitsteuerungsapp - Zeitskalierung und springen zu Tageszeit" />
         <text name="ft_auto_new_todo" text="NEU TODO" />
-        <text name="ft_auto_new_usedplus_integration_app" text="Neu: UsedPlus integration app" />
-        <text name="ft_auto_new_worker_costs_app_now_shows_the_pro_staff_roster_lev" text="Neu: Arbeiter Costs app jetzt shows Pro-Staff roster — Stufe, hours, jobs, und Müdigkeit per Arbeiter" />
-        <text name="ft_auto_new_worker_costs_integration_app" text="Neu: Worker Costs integration app" />
-        <text name="ft_auto_nitrogen" text="Nitrogen" />
-        <text name="ft_auto_nitrogen_phosphorus_potassium_ph_and_organic" text="nitrogen, phosphorus, potassium, pH, and organic&#10;" />
-        <text name="ft_auto_no" text="No" />
-        <text name="ft_auto_no_action_has_been_recorded_yet" text="No action has been recorded yet." />
+        <text name="ft_auto_new_usedplus_integration_app" text="Neu: UsedPlus App Integration" />
+        <text name="ft_auto_new_worker_costs_app_now_shows_the_pro_staff_roster_lev" text="Neu: WorkerCosts App zeigt jetzt Pro-Staff Personalübersicht - Erfahrungsstufe, Arbeitsstunden, Aufträge und Müdigkeit für jeden Mitarbeiter" />
+        <text name="ft_auto_new_worker_costs_integration_app" text="Neu: WorkerCosts App Integration" />
+        <text name="ft_auto_nitrogen" text="Stickstoff" />
+        <text name="ft_auto_nitrogen_phosphorus_potassium_ph_and_organic" text="Stickstoff, Phosphor, Kalium, pH-Wert und Organische Substanz&#10;" />
+        <text name="ft_auto_no" text="Nein" />
+        <text name="ft_auto_no_action_has_been_recorded_yet" text="Es wurde noch keine Aktion aufgezeichnet." />
         <text name="ft_auto_no_active_contracts" text="Keine aktiven Aufträge." />
-        <text name="ft_auto_no_active_financing_contracts" text="Keine aktiven Finanzierungsverträge." />
-        <text name="ft_auto_no_active_job" text="kein aktiver Auftrag" />
-        <text name="ft_auto_no_active_listings" text="No aktiv listings." />
-        <text name="ft_auto_no_active_market_events" text="No aktiv Markt Ereigniss." />
-        <text name="ft_auto_no_animal_pens_owned" text="No animal Ställe im Besitz." />
-        <text name="ft_auto_no_badge_parked_or_player_controlled" text="No badge = parked or player-controlled." />
-        <text name="ft_auto_no_bucket_vehicle_detected_nearby" text="Kein Schaufel-/Laderfahrzeug in der Nähe erkannt." />
-        <text name="ft_auto_no_buildings_shown" text="NO BUILDINGS SHOWN" />
-        <text name="ft_auto_no_candidates_available" text="No candidates available." />
-        <text name="ft_auto_no_completed_jobs_yet" text="No completed jobs yet." />
-        <text name="ft_auto_no_contracts_showing" text="NO AUFTRÄGE SHOWING" />
-        <text name="ft_auto_no_crop_stress_data_yet" text="No crop stress data yet." />
-        <text name="ft_auto_no_data_for_field" text="No data for Field " />
-        <text name="ft_auto_no_due_date" text="No due date" />
-        <text name="ft_auto_no_event" text="No Ereignis" />
-        <text name="ft_auto_no_event_currently_active" text="No Ereignis currently aktiv." />
-        <text name="ft_auto_no_factories_are_in_the_factoryweekschedule_hud_cache_y" text="No factories are in the FactoryWeekSchedule HUD cache yet." />
-        <text name="ft_auto_no_favourites_yet" text="No favourites yet" />
-        <text name="ft_auto_no_fields_owned" text="No Felder im Besitz" />
-        <text name="ft_auto_no_hotspots_on_the_map" text="No hotspots on the map" />
+        <text name="ft_auto_no_active_financing_contracts" text="Keine aktiven Finanzierungen." />
+        <text name="ft_auto_no_active_job" text="Kein aktiver Auftrag." />
+        <text name="ft_auto_no_active_listings" text="Kein aktives Angebot." />
+        <text name="ft_auto_no_active_market_events" text="Kein aktives Marktereignis." />
+        <text name="ft_auto_no_animal_pens_owned" text="Es befinden sich keine Ställe in deinem Besitz." />
+        <text name="ft_auto_no_badge_parked_or_player_controlled" text="Keine Plakette bedeutet, Fahrzeug ist geparkt oder wird durch einen Spieler bedient." />
+        <text name="ft_auto_no_bucket_vehicle_detected_nearby" text="Kein Fahrzeug zur Schüttgutverladung in der Nähe erkannt." />
+        <text name="ft_auto_no_buildings_shown" text="KEINE GEBÄUDE ANGEZEIGT" />
+        <text name="ft_auto_no_candidates_available" text="Keine Bewerber verfügbar." />
+        <text name="ft_auto_no_completed_jobs_yet" text="Noch keine abgeschlossene Aufträge." />
+        <text name="ft_auto_no_contracts_showing" text="KEINE AUFTRÄGE ANZEIGEN" />
+        <text name="ft_auto_no_crop_stress_data_yet" text="Keine Daten über Stresslevel der Pflanzen." />
+        <text name="ft_auto_no_data_for_field" text="Keine Daten für das Feld" />
+        <text name="ft_auto_no_due_date" text="Kein Fälligkeitsdatum" />
+        <text name="ft_auto_no_event" text="Kein Ereignis" />
+        <text name="ft_auto_no_event_currently_active" text="Derzeit kein Ereignis aktiv." />
+        <text name="ft_auto_no_factories_are_in_the_factoryweekschedule_hud_cache_y" text="Keine Fabriken sind derzeit im Produktionsplaungs-HUD gespeichert." />
+        <text name="ft_auto_no_favourites_yet" text="Keine Favoriten" />
+        <text name="ft_auto_no_fields_owned" text="Du besitzt noch keine Felder." />
+        <text name="ft_auto_no_hotspots_on_the_map" text="Es gibt keine Hotspots auf der Karte." />
         <text name="ft_auto_no_invoices_yet" text="Noch keine Rechnungen vorhanden." />
-        <text name="ft_auto_no_job_running" text="No job running." />
-        <text name="ft_auto_no_loads_recorded_yet" text="No loads recorded yet." />
-        <text name="ft_auto_no_npcs_spawned_yet" text="No NPCs spawned yet." />
-        <text name="ft_auto_no_owned_fields_found" text="No im Besitz Felder found." />
-        <text name="ft_auto_no_production_buildings_owned" text="No production buildings im Besitz." />
-        <text name="ft_auto_no_reception_at_this_location" text="No reception at this location." />
-        <text name="ft_auto_no_sell_price_data_found" text="Keine Verkaufspreisdaten gefunden" />
-        <text name="ft_auto_no_setup_needed_apps_appear_automatically_when_the" text="No setup needed — apps appear automatically when the&#10;" />
-        <text name="ft_auto_no_setup_required_just_start_working" text="No setup required — just start working." />
-        <text name="ft_auto_no_sick_animal_pens_reported" text="Keine kranken Tierställe gemeldet." />
-        <text name="ft_auto_no_signal" text="No signal" />
-        <text name="ft_auto_no_silos_owned" text="No silos im Besitz." />
-        <text name="ft_auto_no_todos_yet_add_one_above" text="Noch keine Aufgaben – oben eine hinzufügen" />
-        <text name="ft_auto_no_vehicle" text="No Fahrzeug" />
-        <text name="ft_auto_no_vehicles_owned" text="No Fahrzeuge im Besitz." />
-        <text name="ft_auto_no_vehicles_within_35_m" text="No Fahrzeuge within 35 m." />
-        <text name="ft_auto_no_workers_yet_hire_from_the_roster_panel_alt_h" text="No Arbeiter yet. Hire von roster panel (ALT+H)." />
-        <text name="ft_auto_no_workers_yet_open_the_hire_tab_to_recruit" text="No Arbeiter yet. OStall EINSTELLEN tab zu recruit." />
-        <text name="ft_auto_no_workshop_found_on_this_farm_repairs_disabled" text="No workshop found on this farm  (repairs disabled)" />
-        <text name="ft_auto_none" text="none" />
-        <text name="ft_auto_none_active" text="none aktiv" />
+        <text name="ft_auto_no_job_running" text="Es läuft kein Auftrag." />
+        <text name="ft_auto_no_loads_recorded_yet" text="Kein Ladevorgang aufgezeichnet." />
+        <text name="ft_auto_no_npcs_spawned_yet" text="Noch kein NPC gespawnt." />
+        <text name="ft_auto_no_owned_fields_found" text="Keine Felder in deinem Besitz gefunden." />
+        <text name="ft_auto_no_production_buildings_owned" text="Keine Produktionen in deinem Besitz." />
+        <text name="ft_auto_no_reception_at_this_location" text="Kein Empfang." />
+        <text name="ft_auto_no_sell_price_data_found" text="Keine Verkaufspreise gefunden" />
+        <text name="ft_auto_no_setup_needed_apps_appear_automatically_when_the" text="Kein Setup benötigt - die Apps werden automatisch geladen, wenn&#10;" />
+        <text name="ft_auto_no_setup_required_just_start_working" text="Kein Setup benötigt - fang einfach an zu arbeiten." />
+        <text name="ft_auto_no_sick_animal_pens_reported" text="Keine Ställe mit Seuchen gemeldet." />
+        <text name="ft_auto_no_signal" text="Kein Empfang" />
+        <text name="ft_auto_no_silos_owned" text="Keine Silos im Besitz." />
+        <text name="ft_auto_no_todos_yet_add_one_above" text="Noch keine Aufgaben - füge oben eine hinzu" />
+        <text name="ft_auto_no_vehicle" text="Kein Fahrzeug" />
+        <text name="ft_auto_no_vehicles_owned" text="Kein Fahrzeuge im Besitz." />
+        <text name="ft_auto_no_vehicles_within_35_m" text="Keine Fahrzeuge innerhalb von 35 m." />
+        <text name="ft_auto_no_workers_yet_hire_from_the_roster_panel_alt_h" text="Noch keine Mitarbeiter. Stelle Mitarbeiter über das Bewerberportal ein (ALT+H)." />
+        <text name="ft_auto_no_workers_yet_open_the_hire_tab_to_recruit" text="Noch keine Mitarbeiter. Öffne das Bewerberportal um Mitarbeiter einzustellen." />
+        <text name="ft_auto_no_workshop_found_on_this_farm_repairs_disabled" text="Keine Werkstatt auf deinem Hof gefunden. Reperaturen wurden deaktiviert." />
+        <text name="ft_auto_none" text="keine" />
+        <text name="ft_auto_none_active" text="keine aktiv" />
         <text name="ft_auto_normal" text="Normal" />
         <text name="ft_auto_normal_2" text="normal" />
-        <text name="ft_auto_normal_play_to_keep_the_console_clean" text="normal play to keep the console clean." />
+        <text name="ft_auto_normal_play_to_keep_the_console_clean" text="Normaler Modus um die Konsole sauber zu halten." />
         <text name="ft_auto_not_installed" text="nicht installiert" />
         <text name="ft_auto_note" text="NOTE" />
         <text name="ft_auto_notes" text="Notizen" />
         <text name="ft_auto_notes_2" text="notes" />
-        <text name="ft_auto_nothing_pinned" text="Nothing pinned." />
-        <text name="ft_auto_notices_d" text="Notices: %d" />
-        <text name="ft_auto_notifications" text="NOTIFICATIONS" />
-        <text name="ft_auto_notifications_off" text="Meldungen: Aus" />
-        <text name="ft_auto_notifications_on" text="Meldungen: An" />
-        <text name="ft_auto_notifications_s" text="Notifications %s" />
-        <text name="ft_auto_notifications_s_2" text="Notifications: %s&#10;" />
-        <text name="ft_auto_novice" text="Novice" />
-        <text name="ft_auto_novice_experienced_master_lifetime_hours" text="(Novice / Experienced / Master), lifetime hours,&#10;" />
+        <text name="ft_auto_nothing_pinned" text="Nichts angeheftet." />
+        <text name="ft_auto_notices_d" text="Mahnungen: %d" />
+        <text name="ft_auto_notifications" text="BENACHRICHTUNGEN" />
+        <text name="ft_auto_notifications_off" text="Benachrichtigungen: Aus" />
+        <text name="ft_auto_notifications_on" text="Benachrichtigungen: An" />
+        <text name="ft_auto_notifications_s" text="Benachrichtigungen %s" />
+        <text name="ft_auto_notifications_s_2" text="Benachrichtigungen: %s&#10;" />
+        <text name="ft_auto_novice" text="Auszubildender" />
+        <text name="ft_auto_novice_experienced_master_lifetime_hours" text="(Auszubildender / Facharbeiter / Meister), Arbeitserfahrung,&#10;" />
         <text name="ft_auto_now" text="jetzt" />
         <text name="ft_auto_npc" text="NPC" />
         <text name="ft_auto_npc_2" text="npc" />
-        <text name="ft_auto_npc_asleep_under_an_ai_npc_contract" text="NPC    = asleep under ein AI/NPC contract.&#10;" />
-        <text name="ft_auto_npc_favor" text="NPC Favor" />
+        <text name="ft_auto_npc_asleep_under_an_ai_npc_contract" text="NPC schläft während eines AI-NPC-Vertrags.&#10;" />
+        <text name="ft_auto_npc_favor" text="NPC Gefallen" />
         <text name="ft_auto_npc_favor_2" text="npc_favor" />
-        <text name="ft_auto_npc_favor_mod_not_detected" text="NPC Favor mod not detected." />
-        <text name="ft_auto_npc_favor_tracker" text="NPC favor tracker" />
-        <text name="ft_auto_number" text="number" />
-        <text name="ft_auto_number_and_developer_name" text="number and developer name." />
-        <text name="ft_auto_number_of_favors_currently_in_progress" text="Number of favors currently in progress.&#10;" />
-        <text name="ft_auto_nutrient_availability_increased_by_crop_rotation" text="nutrient availability. Increased by crop rotation&#10;" />
-        <text name="ft_auto_nutrient_colours" text="NUTRIENT COLOURS" />
+        <text name="ft_auto_npc_favor_mod_not_detected" text="FS25_NPCFavors nicht gefunden." />
+        <text name="ft_auto_npc_favor_tracker" text="NPC favor Übersicht" />
+        <text name="ft_auto_number" text="Zahl" />
+        <text name="ft_auto_number_and_developer_name" text="Zahl und Name des Entwickler." />
+        <text name="ft_auto_number_of_favors_currently_in_progress" text="Anzahl an offenen Gefallen..&#10;" />
+        <text name="ft_auto_nutrient_availability_increased_by_crop_rotation" text="Nährtstoffverfügbarkeit. Erhöht sich durch Fruchtfolge.&#10;" />
+        <text name="ft_auto_nutrient_colours" text="NÄHRSTOFFFARBEN" />
         <text name="ft_auto_nw" text="NW" />
-        <text name="ft_auto_occur_intensity_1_5_controls_how_severe" text="occur. Intensity (1-5) controls how severe&#10;" />
-        <text name="ft_auto_ocean_blue" text="Ocean Blue" />
+        <text name="ft_auto_occur_intensity_1_5_controls_how_severe" text="entstehen. Die Intensität (1-5) steuert wie stark&#10;" />
+        <text name="ft_auto_ocean_blue" text="Ozeanblau" />
         <text name="ft_auto_off" text="AUS" />
         <text name="ft_auto_off_2" text="Aus" />
         <text name="ft_auto_off_3" text="off" />
-        <text name="ft_auto_off_rare_normal_frequent" text="Aus / Rare / Normal / Frequent" />
-        <text name="ft_auto_off_rare_normal_frequent_default_off" text="Aus / Rare / Normal / Frequent | Standard: Aus" />
-        <text name="ft_auto_offer" text="  AUSER" />
-        <text name="ft_auto_offer_pending" text="offer_Stallding" />
+        <text name="ft_auto_off_rare_normal_frequent" text="Aus / Selten / Normal / Häufig" />
+        <text name="ft_auto_off_rare_normal_frequent_default_off" text="Aus / Selten / Normal / Häufig | Standard: Aus" />
+        <text name="ft_auto_offer" text="  AUẞER" />
+        <text name="ft_auto_offer_pending" text="offer_pending" />
         <text name="ft_auto_offline" text="offline" />
         <text name="ft_auto_ok" text="ok" />
-        <text name="ft_auto_older_entries_scroll_off_the_bottom_of_the_list" text="Older entries scroll off the bottom of the list." />
+        <text name="ft_auto_older_entries_scroll_off_the_bottom_of_the_list" text="Älltere Einträge stehen am Ende der Liste." />
         <text name="ft_auto_on" text="AN" />
         <text name="ft_auto_on_2" text="An" />
-        <text name="ft_auto_on_all_your_motorized_vehicles" text="             on all your motorized Fahrzeuge." />
-        <text name="ft_auto_on_sleeping_fields_are_skipped_to_save_performance_and" text="on. Sleeping Felder are skipped zu save performance und to&#10;" />
-        <text name="ft_auto_only_available_in_built_in_mode" text="Only available in built-in mode.&#10;" />
-        <text name="ft_auto_only_motorized_vehicles_owned_by_your_farm_appear" text="Only motorized Fahrzeuge im Besitz by your farm appear.&#10;" />
-        <text name="ft_auto_only_shown_when_2_stations_buy_that_crop" text="Only shown when 2+ stations buy that crop." />
-        <text name="ft_auto_only_shown_when_a_workshop_placeable_is_on_your_farm" text="Only shown when a workshop placeable is on your farm&#10;" />
+        <text name="ft_auto_on_all_your_motorized_vehicles" text="an all deinen motorisierten Fahrzeugen." />
+        <text name="ft_auto_on_sleeping_fields_are_skipped_to_save_performance_and" text="an. Deaktivierte Felder werden übersprungen um die Performance zu verbessern und&#10;" />
+        <text name="ft_auto_only_available_in_built_in_mode" text="Nur im built-in Modus verfügbar.&#10;" />
+        <text name="ft_auto_only_motorized_vehicles_owned_by_your_farm_appear" text="Nur Fahrzeuge im Besitz deines Hofes tauchen hier auf.&#10;" />
+        <text name="ft_auto_only_shown_when_2_stations_buy_that_crop" text="Wird nur angezeigt wenn mindestens zwei Stationen dise Kultur kaufen." />
+        <text name="ft_auto_only_shown_when_a_workshop_placeable_is_on_your_farm" text="Wird nur angezeigt, wenn sich eine platzbierbare Werkstatt auf deinem Hof befindet&#10;" />
         <text name="ft_auto_open" text="ÖFFNEN" />
         <text name="ft_auto_open_2" text="Öffnen" />
         <text name="ft_auto_open_button" text="ÖFFNEN-BUTTON" />
         <text name="ft_auto_open_key" text="Öffnen-Taste" />
-        <text name="ft_auto_open_key_s" text="OStall Key: %s&#10;" />
-        <text name="ft_auto_open_notices" text="OStall Notices" />
-        <text name="ft_auto_open_tablet" text="OStall tablet" />
-        <text name="ft_auto_open_the_contracts_app_for_details_and_deadlines" text="OStall the Aufträge app for details and deadlines." />
-        <text name="ft_auto_opens_the_large_provider_selection_window" text="OStälle the large provider selection window" />
-        <text name="ft_auto_operating_hours" text="Operating Hours" />
-        <text name="ft_auto_operating_hours_total_engine_time_in_whole_hours" text="Operating hours: total engine time in whole hours.&#10;" />
-        <text name="ft_auto_optimal_ph_range_is_6_0_to_7_5" text="Optimal pH range is 6.0 to 7.5.&#10;" />
-        <text name="ft_auto_or_reset_position_scale_to_restore_defaults" text="or POSITION &amp; SKALIERUNG ZURÜCKSETZEN to restore defaults." />
-        <text name="ft_auto_or_set_it_via_console_tabletsetstartupapp_weather" text="Or set it via console: TabletSetStartupApp weather" />
-        <text name="ft_auto_or_the_workercosts_console_commands" text="or the WorkerCosts console commands." />
-        <text name="ft_auto_orange_bar_offer_is_waiting_for_your_decision" text="Orange bar = offer is waiting for your decision." />
-        <text name="ft_auto_orange_peak_current_price_is_below_the_recorded_high" text="Orange peak = current Preis is below recorded high.&#10;" />
-        <text name="ft_auto_organic_matter" text="ORGANIC MATTER" />
-        <text name="ft_auto_organic_matter_2" text="Organic Matter" />
-        <text name="ft_auto_other" text="Other" />
-        <text name="ft_auto_outage" text="Outage" />
-        <text name="ft_auto_outage_2" text="outage" />
-        <text name="ft_auto_outages_s" text="OUTAGES: %s" />
-        <text name="ft_auto_outages_s_2" text="Outages: %s." />
-        <text name="ft_auto_outgoing" text="outgoing" />
-        <text name="ft_auto_outgoing_money_you_owe" text="OUTGOING  (money you owe)" />
+        <text name="ft_auto_open_key_s" text="Öffnen Taste: %s&#10;" />
+        <text name="ft_auto_open_notices" text="Notizen öffnen" />
+        <text name="ft_auto_open_tablet" text="Tablet öffnen" />
+        <text name="ft_auto_open_the_contracts_app_for_details_and_deadlines" text="Öffne die Auftrag-App für mehr Informationen." />
+        <text name="ft_auto_opens_the_large_provider_selection_window" text="Öffnet das Fenster für Anbieterwechsel" />
+        <text name="ft_auto_operating_hours" text="Betriebsstunden" />
+        <text name="ft_auto_operating_hours_total_engine_time_in_whole_hours" text="Betriebsstunden: gesamte Zeit die der Motor gelaufen is in Stunden.&#10;" />
+        <text name="ft_auto_optimal_ph_range_is_6_0_to_7_5" text="Der optimale pH-Wert liegt zwischen 6,0 und 7,5.&#10;" />
+        <text name="ft_auto_or_reset_position_scale_to_restore_defaults" text="oder POSITION &amp; SKALIERUNG ZURÜCKSETZEN um die Standardwerte wiederherzustellen." />
+        <text name="ft_auto_or_set_it_via_console_tabletsetstartupapp_weather" text="Oder nutze den Konsolenbefehl: TabletSetStartupApp weather" />
+        <text name="ft_auto_or_the_workercosts_console_commands" text="oder den WorkerCosts Konsolenbefehl." />
+        <text name="ft_auto_orange_bar_offer_is_waiting_for_your_decision" text="Orange Leiste = das Angebot wartet auf deine Rückmeldung." />
+        <text name="ft_auto_orange_peak_current_price_is_below_the_recorded_high" text="Oranger Ausschlag = aktueller Preis ist unterhalb des aufgezeichneten Höchstwert.&#10;" />
+        <text name="ft_auto_organic_matter" text="ORGANISCHE SUBSTANZ" />
+        <text name="ft_auto_organic_matter_2" text="Organische Substanz" />
+        <text name="ft_auto_other" text="Andere" />
+        <text name="ft_auto_outage" text="Ausfall" />
+        <text name="ft_auto_outage_2" text="Störung" />
+        <text name="ft_auto_outages_s" text="Ausfälle: %s" />
+        <text name="ft_auto_outages_s_2" text="Störungen: %s." />
+        <text name="ft_auto_outgoing" text="ausgehend" />
+        <text name="ft_auto_outgoing_money_you_owe" text="Schulden  (Geld das du schuldest)" />
         <text name="ft_auto_outputs" text="AUSGÄNGE" />
-        <text name="ft_auto_outputs_pile_up_if_the_unloading_station_is_full_check" text="Outputs pile up if the unloading station is full — check&#10;" />
-        <text name="ft_auto_outside_this_range_nutrient_uptake_is_reduced_even" text="Outside this range nutrient uptake is reduced even&#10;" />
+        <text name="ft_auto_outputs_pile_up_if_the_unloading_station_is_full_check" text="Ausgänge stapeln sich wenn der Entladebereich voll ist - überprüfe&#10;" />
+        <text name="ft_auto_outside_this_range_nutrient_uptake_is_reduced_even" text="Außerhalb dieser Spanne ist die Nährstoffaufnahme nocheinmal mehr reduziert&#10;" />
         <text name="ft_auto_ovc" text="OVC" />
-        <text name="ft_auto_overall" text="Overall" />
-        <text name="ft_auto_overall_animal_productivity_is_driven_by_food_water" text="Overall animal productivity is driven by food, water,&#10;" />
-        <text name="ft_auto_overall_standing_with_the_local_community_0_100" text="Overall standing with the local community (0-100).&#10;" />
+        <text name="ft_auto_overall" text="Gesamt" />
+        <text name="ft_auto_overall_animal_productivity_is_driven_by_food_water" text="Die gesmate Produktivität deiner Tiere ist bestimmt von Fütterung, Wasser,&#10;" />
+        <text name="ft_auto_overall_standing_with_the_local_community_0_100" text="Gesamte Beliebtheit mit der Nachbarschaft (0-100).&#10;" />
         <text name="ft_auto_overcast" text="Bedeckt" />
-        <text name="ft_auto_overcast_2" text="overcast" />
-        <text name="ft_auto_overdue" text="OVERDUE" />
-        <text name="ft_auto_overdue_2" text="Overdue" />
-        <text name="ft_auto_overdue_3" text="overdue" />
-        <text name="ft_auto_overdue_by_d_day_s" text="Overdue by %d Tag%s" />
+        <text name="ft_auto_overcast_2" text="Bewölkt" />
+        <text name="ft_auto_overdue" text="ÜBERFÄLLIG" />
+        <text name="ft_auto_overdue_2" text="Überfällig" />
+        <text name="ft_auto_overdue_3" text="überfällig" />
+        <text name="ft_auto_overdue_by_d_day_s" text="Überfällig zum %d Tag%s" />
         <text name="ft_auto_overview" text="ÜBERSICHT" />
-        <text name="ft_auto_overwrite" text="overwrite" />
-        <text name="ft_auto_owed" text="OFFEN" />
-        <text name="ft_auto_paging" text="paging" />
-        <text name="ft_auto_paid" text="PAID" />
-        <text name="ft_auto_paid_2" text="Paid" />
-        <text name="ft_auto_paid_3" text="paid" />
-        <text name="ft_auto_partly_cloudy" text="Teilweise Bewölkt" />
+        <text name="ft_auto_overwrite" text="Überschreiben" />
+        <text name="ft_auto_owed" text="geschuldet" />
+        <text name="ft_auto_paging" text="blättern" />
+        <text name="ft_auto_paid" text="BEZAHLT" />
+        <text name="ft_auto_paid_2" text="Bezahlt" />
+        <text name="ft_auto_paid_3" text="bezahlt" />
+        <text name="ft_auto_partly_cloudy" text="teilweise Bewölkt" />
         <text name="ft_auto_party" text="PARTY" />
         <text name="ft_auto_party_2" text="party" />
         <text name="ft_auto_pause" text="⏸ PAUSE" />
-        <text name="ft_auto_pause_freezes_time_active_speed_highlighted" text="⏸ PAUSE freezes time. Aktiv speed highlighted." />
-        <text name="ft_auto_pause_freezes_time_completely" text="⏸ PAUSE freezes time completely.&#10;" />
-        <text name="ft_auto_pay" text="PAY" />
-        <text name="ft_auto_payment_mode" text="PAYMENT MODE" />
-        <text name="ft_auto_payment_mode_2" text="Payment Mode" />
-        <text name="ft_auto_payroll" text="PAYROLL" />
-        <text name="ft_auto_payroll_2" text="payroll" />
-        <text name="ft_auto_payroll_tab" text="PAYROLL TAB" />
-        <text name="ft_auto_peak_price_is_tracked_and_saved_per_savegame" text="Peak Preis is tracked und saved per savegame.&#10;" />
-        <text name="ft_auto_peak_s_day_d" text="  Peak: %s  (Tag %d)" />
-        <text name="ft_auto_pen" text="Pen" />
-        <text name="ft_auto_pen_capacity_e_g_cows_12_20" text="Stall capacity (e.g. Kühe  (12 / 20)).&#10;" />
-        <text name="ft_auto_pen_cards" text="PEN CARDS" />
-        <text name="ft_auto_pending" text=" Stallding" />
-        <text name="ft_auto_pending_2" text="PENDING" />
-        <text name="ft_auto_pending_3" text="Stallding" />
-        <text name="ft_auto_pens" text=" Ställe" />
-        <text name="ft_auto_per_worker_base" text="PER WORKER  (base " />
-        <text name="ft_auto_percentage_and_hours_remaining" text="percentage, and hours remaining." />
-        <text name="ft_auto_percentage_of_sky_covered_by_clouds" text="Percentage of sky covered by clouds.&#10;" />
-        <text name="ft_auto_percentage_of_tax_paid_that_is_returned_as_a_rebate" text="Percentage of tax paid that is returned as a rebate.&#10;" />
-        <text name="ft_auto_percentage_of_the_food_trough_that_is_filled" text="Percentage of the food trough that is filled.&#10;" />
-        <text name="ft_auto_percentage_of_the_water_trough_that_is_filled" text="Percentage of the water trough that is filled.&#10;" />
+        <text name="ft_auto_pause_freezes_time_active_speed_highlighted" text="⏸ PAUSE hält die Zeit an. Aktive Geschwindigkeit hervorgehoben." />
+        <text name="ft_auto_pause_freezes_time_completely" text="⏸ PAUSE hält die Zeit komplett an.&#10;" />
+        <text name="ft_auto_pay" text="BEZAHLEN" />
+        <text name="ft_auto_payment_mode" text="BEZAHLUNG" />
+        <text name="ft_auto_payment_mode_2" text="Bezahlung" />
+        <text name="ft_auto_payroll" text="LOHN" />
+        <text name="ft_auto_payroll_2" text="Lohn" />
+        <text name="ft_auto_payroll_tab" text="LOHNABRECHNUNG" />
+        <text name="ft_auto_peak_price_is_tracked_and_saved_per_savegame" text="Höchstpreise werden pro Spielstand verfolgt und gespeichert.&#10;" />
+        <text name="ft_auto_peak_s_day_d" text="  Höchststand: %s  (Tag %d)" />
+        <text name="ft_auto_pen" text="Stall" />
+        <text name="ft_auto_pen_capacity_e_g_cows_12_20" text="Stallplätze (z.B. Kühe  (12 / 20)).&#10;" />
+        <text name="ft_auto_pen_cards" text="STALLKARTE" />
+        <text name="ft_auto_pending" text="ausstehend" />
+        <text name="ft_auto_pending_2" text="AUSSTEHEND" />
+        <text name="ft_auto_pending_3" text="Ausstehend" />
+        <text name="ft_auto_pens" text="Ställe" />
+        <text name="ft_auto_per_worker_base" text="PRO MITARBEITER  (basis " />
+        <text name="ft_auto_percentage_and_hours_remaining" text="Prozentsatz und Stunden verbleibend." />
+        <text name="ft_auto_percentage_of_sky_covered_by_clouds" text="Prozentualer Anteil des Himmels, der durch Wolken bedeckt ist.&#10;" />
+        <text name="ft_auto_percentage_of_tax_paid_that_is_returned_as_a_rebate" text="Prozentualer Anteil gezahlter Steuern der als Rabatt zurückgezahlt wird.&#10;" />
+        <text name="ft_auto_percentage_of_the_food_trough_that_is_filled" text="Füllstand des Futtertisch in Prozent.&#10;" />
+        <text name="ft_auto_percentage_of_the_water_trough_that_is_filled" text="Füllstand der Tränken mit Wasser in Prozent.&#10;" />
         <text name="ft_auto_personnel" text="Personal" />
         <text name="ft_auto_personnel_2" text="personnel" />
-        <text name="ft_auto_pest_outbreaks_temporarily_shift_crop_prices" text="pest outbreaks temporarily shift crop prices.&#10;" />
-        <text name="ft_auto_pf_dlc_active" text="PF DLC aktiv" />
+        <text name="ft_auto_pest_outbreaks_temporarily_shift_crop_prices" text="Schädlingsbefall sorgt für vorübergehenden Schwankungen der Preise für deine Erzeugnisse.&#10;" />
+        <text name="ft_auto_pf_dlc_active" text="Precision Farming DLC aktiviert" />
         <text name="ft_auto_ph" text="pH" />
-        <text name="ft_auto_phosphorus" text="Phosphorus" />
-        <text name="ft_auto_pin" text="PIN" />
-        <text name="ft_auto_pin_2" text="Pin" />
-        <text name="ft_auto_pinned_s_to_s" text="Pinned %s to %s" />
+        <text name="ft_auto_phosphorus" text="Phosphor" />
+        <text name="ft_auto_pin" text="Anheften" />
+        <text name="ft_auto_pin_2" text="Anheften" />
+        <text name="ft_auto_pinned_s_to_s" text="%s an %s angeheftet" />
         <text name="ft_auto_pins" text="PINS" />
-        <text name="ft_auto_placeable_from_the_shop_to_see_it_here" text="placeable from the shop to see it here." />
-        <text name="ft_auto_player" text="Player" />
-        <text name="ft_auto_player_etc_removing_system_hotspots_missions" text="Player, etc. Removing system hotspots (Missions,&#10;" />
-        <text name="ft_auto_player_position_unavailable" text="Player position unavailable." />
+        <text name="ft_auto_placeable_from_the_shop_to_see_it_here" text="Platzierbares aus dem Shop um es hier zu sehen." />
+        <text name="ft_auto_player" text="Spieler" />
+        <text name="ft_auto_player_etc_removing_system_hotspots_missions" text="Spieler, etc. entfernt Auftrags-HotSpots (Aufträge,&#10;" />
+        <text name="ft_auto_player_position_unavailable" text="Spielerposition nicht verfügbar." />
         <text name="ft_auto_plays_a_click_when_switching_apps_in_the_sidebar" text="Klickton beim Wechseln der Apps" />
         <text name="ft_auto_plays_a_paging_sound_when_the_in_game_help_panel_opens" text="Ton beim Öffnen/Schliessen der Hilfe" />
         <text name="ft_auto_plays_a_sound_when_you_open_or_close_the_tablet_t_key" text="Ton beim Öffnen/Schliessen mit T" />
-        <text name="ft_auto_plow_cultivate" text="Plow / cultivate" />
-        <text name="ft_auto_plowing" text="Plowing" />
-        <text name="ft_auto_plowing_cultivating" text="Plowing / Cultivating" />
-        <text name="ft_auto_poor" text="Poor" />
+        <text name="ft_auto_plow_cultivate" text="Pflüge / Grubber" />
+        <text name="ft_auto_plowing" text="Pflügen" />
+        <text name="ft_auto_plowing_cultivating" text="Pflügen / Grubbern" />
+        <text name="ft_auto_poor" text="Schlecht" />
         <text name="ft_auto_position" text="Position" />
         <text name="ft_auto_position_2" text="Position" />
-        <text name="ft_auto_potassium" text="Potassium" />
-        <text name="ft_auto_ppm" text=" ppm  (" />
-        <text name="ft_auto_precipitation" text="PRECIPITATION" />
-        <text name="ft_auto_precipitation_2" text="Precipitation" />
-        <text name="ft_auto_prepend" text="preStalld" />
-        <text name="ft_auto_present" text="Present" />
-        <text name="ft_auto_press_clear_all_once_it_turns_red_and_asks" text="Press CLEAR ALL once — it turns red and asks&#10;" />
-        <text name="ft_auto_press_s_to_open" text="Press %s to oStall" />
-        <text name="ft_auto_price_comparison" text="PRICE COMPARISON" />
-        <text name="ft_auto_price_comparison_all_stations" text="PRICE COMPARISON  (all stations)" />
-        <text name="ft_auto_price_modifiers" text="Price Modifiers" />
-        <text name="ft_auto_price_modifiers_and_event_frequency_can_be" text="Price modifiers und Ereignis frequency cein be&#10;" />
-        <text name="ft_auto_prices_are_per_1_000_litres_refreshes_every_5_seconds" text="Prices are per 1,000 litres. Refreshes every 5 seconds." />
+        <text name="ft_auto_potassium" text="Kalium" />
+        <text name="ft_auto_ppm" text=" 1 mg je kg  (" />
+        <text name="ft_auto_precipitation" text="NIEDERSCHLAG" />
+        <text name="ft_auto_precipitation_2" text="Niederschlag" />
+        <text name="ft_auto_prepend" text="voranstellen" />
+        <text name="ft_auto_present" text="vorhanden" />
+        <text name="ft_auto_press_clear_all_once_it_turns_red_and_asks" text="drücke CLEAR ALL einmal - es färbt sich rot und fragt&#10;" />
+        <text name="ft_auto_press_s_to_open" text="Drücke %s zum öffnen" />
+        <text name="ft_auto_price_comparison" text="PREISVERGLEICH" />
+        <text name="ft_auto_price_comparison_all_stations" text="PREISVERGLEICH  (alle Stationen)" />
+        <text name="ft_auto_price_modifiers" text="Preiseinfluss" />
+        <text name="ft_auto_price_modifiers_and_event_frequency_can_be" text="Preiseinfluss und Ereignishäufigkeit können&#10;" />
+        <text name="ft_auto_prices_are_per_1_000_litres_refreshes_every_5_seconds" text="Preise sind pro 1.000 Liter. Aktualsiert sich alle 5 Sekunden." />
         <text name="ft_auto_pro_staff" text="PRO-STAFF  (" />
         <text name="ft_auto_pro_staff_2" text="Pro-Staff" />
-        <text name="ft_auto_pro_staff_impact" text="PRO-STAFF IMPACT" />
-        <text name="ft_auto_pro_staff_personnel_management_hire_fire_assign_payroll" text="Pro-Staff personnel management — hire, fire, assign, payroll" />
-        <text name="ft_auto_pro_staff_roster" text="PRO-STAFF ROSTER" />
+        <text name="ft_auto_pro_staff_impact" text="PRO-STAFF EINFLUSS" />
+        <text name="ft_auto_pro_staff_personnel_management_hire_fire_assign_payroll" text="Pro-Staff Personalverwaltung - Einstellen, Entlassen, Zuweisen, Bezahlen" />
+        <text name="ft_auto_pro_staff_roster" text="PRO-STAFF BEWERBERPORTAL" />
         <text name="ft_auto_prod" text="PROD" />
         <text name="ft_auto_prod_2" text="prod_" />
         <text name="ft_auto_production" text="Produktion" />
         <text name="ft_auto_production_2" text="production" />
-        <text name="ft_auto_production_building_chains_inputs_outputs_active_status" text="Produktionsketten – Eingänge, Ausgänge, Status" />
+        <text name="ft_auto_production_building_chains_inputs_outputs_active_status" text="Produktionsketten - Eingänge, Ausgänge, Status" />
         <text name="ft_auto_production_buildings" text="production_buildings" />
-        <text name="ft_auto_production_buildings_must_be_owned_by_your_farm" text="Production Gebäudes must be im Besitz by dein farm.&#10;" />
-        <text name="ft_auto_production_lines_are_currently_active" text="production lines are currently aktiv." />
-        <text name="ft_auto_production_production_buildings_you_own" text="Production: production Gebäudes du own." />
-        <text name="ft_auto_productivity" text="PRODUCTIVITY" />
-        <text name="ft_auto_productivity_separately" text="productivity separately." />
-        <text name="ft_auto_progress_bar" text="PROGRESS BAR" />
-        <text name="ft_auto_provider" text="Provider" />
-        <text name="ft_auto_provider_2" text="provider" />
-        <text name="ft_auto_provider_changed_s" text="Provider changed: %s." />
-        <text name="ft_auto_purchase_a_cheese_factory_bakery_or_other_production" text="Purchase a cheese factory, bakery, or other production&#10;" />
-        <text name="ft_auto_purchase_a_pen_to_start_raising_animals" text="Purchase a Stall to start raising animals." />
-        <text name="ft_auto_purchase_a_production_placeable_to_track_it_here" text="Purchase a production placeable to track it here." />
-        <text name="ft_auto_purchase_a_silo_to_track_stored_crops" text="Purchase a silo to track stored crops." />
-        <text name="ft_auto_purchase_cost" text="Purchase Cost" />
-        <text name="ft_auto_purchase_land_to_start_farming" text="Purchase land to start farming." />
-        <text name="ft_auto_purchase_motorized_vehicles_to_track_them_here" text="Purchase motorized Fahrzeuge to track them here." />
-        <text name="ft_auto_quiet_if_you_already_know_the_open_key" text="quiet if you already kjetzt the oStall key." />
+        <text name="ft_auto_production_buildings_must_be_owned_by_your_farm" text="Das Produktionsgebäude muss deinem Hof gehören.&#10;" />
+        <text name="ft_auto_production_lines_are_currently_active" text="Produktionslinien sind derzeit inaktiv." />
+        <text name="ft_auto_production_production_buildings_you_own" text="Produktion: Produktionen die dir gehören." />
+        <text name="ft_auto_productivity" text="PRODUKTIVITÄT" />
+        <text name="ft_auto_productivity_separately" text="Produktivität seperat." />
+        <text name="ft_auto_progress_bar" text="FORSCHRITTSBALKEN" />
+        <text name="ft_auto_provider" text="Anbieter" />
+        <text name="ft_auto_provider_2" text="Anbieter" />
+        <text name="ft_auto_provider_changed_s" text="Anbieter zu: %s gewechselt." />
+        <text name="ft_auto_purchase_a_cheese_factory_bakery_or_other_production" text="Kaufe eine Käserei, Bäckerei oder andere Produktionen&#10;" />
+        <text name="ft_auto_purchase_a_pen_to_start_raising_animals" text="Kaufe einen Stall um Tiere großzuziehen." />
+        <text name="ft_auto_purchase_a_production_placeable_to_track_it_here" text="Kaufe eine platzierbare Produktion um sie hier zu verfolgen." />
+        <text name="ft_auto_purchase_a_silo_to_track_stored_crops" text="Kaufe ein Silo um gelagerte Kulturen zu verfolgen." />
+        <text name="ft_auto_purchase_cost" text="Kaufkosten" />
+        <text name="ft_auto_purchase_land_to_start_farming" text="Kaufe Land um mit der Landwirtschaft zu beginnen." />
+        <text name="ft_auto_purchase_motorized_vehicles_to_track_them_here" text="Kaufe Fahrzeuge um sie hier zu verfolgen." />
+        <text name="ft_auto_quiet_if_you_already_know_the_open_key" text="aus wenn du bereits die Taste zum Öffnen kennst." />
         <text name="ft_auto_rain" text=" Regen" />
         <text name="ft_auto_rain_2" text="RAIN" />
         <text name="ft_auto_rain_3" text="Regen" />
         <text name="ft_auto_rain_4" text="rain" />
-        <text name="ft_auto_rain_or_storm_intensity_shown_with_a_fill_bar" text="Regen or storm intensity shown with a fill bar.&#10;" />
-        <text name="ft_auto_rainy" text="Regeny" />
+        <text name="ft_auto_rain_or_storm_intensity_shown_with_a_fill_bar" text="Intensität des Regen oder des Sturm wird mit einer Füllanzeige dargestellt.&#10;" />
+        <text name="ft_auto_rainy" text="Regnerisch" />
         <text name="ft_auto_random_world_events" text="Random World Events" />
         <text name="ft_auto_random_world_events_2" text="random_world_events" />
-        <text name="ft_auto_random_world_events_is_not_installed" text="Random World Events is not installed." />
-        <text name="ft_auto_random_world_events_tracker" text="Random world Ereigniss tracker" />
-        <text name="ft_auto_rare" text="Rare" />
-        <text name="ft_auto_rare_2" text="rare" />
-        <text name="ft_auto_ready" text="ERNTEBEREIT" />
-        <text name="ft_auto_ready_2" text="Erntebereit" />
-        <text name="ft_auto_ready_3" text="ready" />
+        <text name="ft_auto_random_world_events_is_not_installed" text="Random World Events ist nicht installiert." />
+        <text name="ft_auto_random_world_events_tracker" text="Random world Ereignisse verfolgen" />
+        <text name="ft_auto_rare" text="Selten" />
+        <text name="ft_auto_rare_2" text="selten" />
+        <text name="ft_auto_ready" text="BEREIT" />
+        <text name="ft_auto_ready_2" text="Bereit" />
+        <text name="ft_auto_ready_3" text="bereit" />
         <text name="ft_auto_realistic_dealer" text="realistic_dealer" />
         <text name="ft_auto_realistic_farming" text="realistic_farming" />
         <text name="ft_auto_realistic_farming_mobile" text="Realistic Farming Mobile" />
         <text name="ft_auto_realisticdealer" text="RealisticDealer" />
-        <text name="ft_auto_realisticdealer_financing_installments_and_repossession" text="RealisticDealer financing, installments and repossession status" />
-        <text name="ft_auto_realisticdealer_was_not_detected" text="RealisticDealer was not detected." />
-        <text name="ft_auto_receivable" text="FORDERUNGEN" />
-        <text name="ft_auto_recent_jobs" text="Recent Jobs" />
-        <text name="ft_auto_reception" text="Reception" />
-        <text name="ft_auto_record_is_saved_to_the_history_list" text="record is saved to the History list." />
-        <text name="ft_auto_recruit" text="Recruit" />
-        <text name="ft_auto_recruit_2" text="recruit" />
-        <text name="ft_auto_recruitment_pool" text="Recruitment pool" />
-        <text name="ft_auto_recruitment_pool_rerolled" text="Recruitment pool rerolled" />
-        <text name="ft_auto_refill_before_hitting_red_to_maintain_productivity" text="Refill before hitting red to maintain productivity." />
-        <text name="ft_auto_refuel_vehicles" text="Kraftstoff Füllen Fahrzeuge" />
-        <text name="ft_auto_rejected" text="REJECTED" />
-        <text name="ft_auto_rejected_2" text="rejected" />
-        <text name="ft_auto_relationship_score_higher_scores_unlock_exclusive" text="relationship score. Higher scores unlock exclusive&#10;" />
-        <text name="ft_auto_relationships" text="RELATIONSHIPS" />
-        <text name="ft_auto_relationships_2" text="RELATIONSHIPS  (" />
-        <text name="ft_auto_remaining_debt" text="Remaining Debt" />
-        <text name="ft_auto_remaining_s" text="Remaining: %s" />
-        <text name="ft_auto_remaining_s_rate_s" text="Remaining: %s | Rate: %s" />
-        <text name="ft_auto_remove_the_task_entirely" text="✕    — remove the task entirely&#10;" />
-        <text name="ft_auto_reopen_initial_selection" text="REOPEN INITIAL SELECTION" />
-        <text name="ft_auto_repair" text="REPAIR" />
+        <text name="ft_auto_realisticdealer_financing_installments_and_repossession" text="RealisticDealer Finanzierung, Installationen und Stand der Rückabwicklung" />
+        <text name="ft_auto_realisticdealer_was_not_detected" text="RealisticDealer wurde nicht gefunden." />
+        <text name="ft_auto_receivable" text="ERHÄLTLICH" />
+        <text name="ft_auto_recent_jobs" text="Kürzliche Aufträge" />
+        <text name="ft_auto_reception" text="Erhalten" />
+        <text name="ft_auto_record_is_saved_to_the_history_list" text="Aufzeichnung wurde in der Historie gespeichert." />
+        <text name="ft_auto_recruit" text="Anheuern" />
+        <text name="ft_auto_recruit_2" text="Anheuern" />
+        <text name="ft_auto_recruitment_pool" text="BEWERBERPORTAL" />
+        <text name="ft_auto_recruitment_pool_rerolled" text="Bewerberportal neugeladen" />
+        <text name="ft_auto_refill_before_hitting_red_to_maintain_productivity" text="Auffüllen bevor es sich rot färbt um die Produktivität aufrechtzuerhalten." />
+        <text name="ft_auto_refuel_vehicles" text="Fahrzeuge tanken" />
+        <text name="ft_auto_rejected" text="ABGELEHNT" />
+        <text name="ft_auto_rejected_2" text="abgelehnt" />
+        <text name="ft_auto_relationship_score_higher_scores_unlock_exclusive" text="Verhältnis-Score. Höhere Scores schalten exklusive [X] frei&#10;" />
+        <text name="ft_auto_relationships" text="VERHÄLTNISSE" />
+        <text name="ft_auto_relationships_2" text="VERHÄLTNISSE  (" />
+        <text name="ft_auto_remaining_debt" text="Verbleibende Schulden" />
+        <text name="ft_auto_remaining_s" text="Verbleibend: %s" />
+        <text name="ft_auto_remaining_s_rate_s" text="Verbleibend: %s | Rate: %s" />
+        <text name="ft_auto_remove_the_task_entirely" text="✕    - entferne die Aufgabe komplett&#10;" />
+        <text name="ft_auto_reopen_initial_selection" text="URPSRÜNGLICHE AUSWAHL ERNEUT ÖFFNEN" />
+        <text name="ft_auto_repair" text="REPARIEREN" />
         <text name="ft_auto_repair_2" text="reparieren" />
         <text name="ft_auto_repair_all" text="ALLE REPARIEREN" />
-        <text name="ft_auto_repair_all_resets_damage_on_all_your_vehicles" text="ALLE REPARIEREN — resets damage on all your Fahrzeuge.&#10;" />
-        <text name="ft_auto_repair_button" text="REPAIR BUTTON" />
-        <text name="ft_auto_repair_completed_tablet_is_ready_to_use_again" text="Repair completed. Tablet is ready to use again." />
-        <text name="ft_auto_repair_vehicle" text="REPAIR VEHICLE" />
-        <text name="ft_auto_repair_vehicles" text="Repair Fahrzeuge" />
+        <text name="ft_auto_repair_all_resets_damage_on_all_your_vehicles" text="ALLE REPARIEREN — setzte den Schaden all deiner Fahrzeuge zurück.&#10;" />
+        <text name="ft_auto_repair_button" text="REPARATUR KNOPF" />
+        <text name="ft_auto_repair_completed_tablet_is_ready_to_use_again" text="Reperatur abgeschlossen. Dein Tablet kann wieder genutzt werden." />
+        <text name="ft_auto_repair_vehicle" text="FAHRZEUG REPARIEREN" />
+        <text name="ft_auto_repair_vehicles" text="Fahrzeuge reparieren" />
         <text name="ft_auto_repairs_available" text="REPARATUREN VERFÜGBAR" />
-        <text name="ft_auto_repossessed" text="Repossessed" />
-        <text name="ft_auto_repossessed_2" text="repossessed" />
-        <text name="ft_auto_repossession" text="repossession" />
-        <text name="ft_auto_repossession_running" text="Repossession running" />
+        <text name="ft_auto_repossessed" text="zurückgenommen" />
+        <text name="ft_auto_repossessed_2" text="Zurückgenommen" />
+        <text name="ft_auto_repossession" text="Rücknahme" />
+        <text name="ft_auto_repossession_running" text="Rücknahme läuft" />
         <text name="ft_auto_repossessions" text="Rücknahmen" />
-        <text name="ft_auto_reroll" text="REROLL" />
+        <text name="ft_auto_reroll" text="NEULADEN" />
         <text name="ft_auto_reset" text="ZURÜCKSETZEN" />
-        <text name="ft_auto_reset_all_settings_to_defaults" text="Reset all settings to defaults" />
+        <text name="ft_auto_reset_all_settings_to_defaults" text="Alle Einstellungen auf Standardwerte zurücksetzen" />
         <text name="ft_auto_reset_all_to_defaults" text="ALLES AUF STANDARD ZURÜCKSETZEN" />
         <text name="ft_auto_reset_button" text="ZURÜCKSETZEN-BUTTON" />
-        <text name="ft_auto_reset_position_scale" text="POSITION &amp; SKALIERUNG ZURÜCKSETZEN" />
-        <text name="ft_auto_reset_settings" text="Reset Einstellungen" />
-        <text name="ft_auto_resets_after_the_monthly_salary_is_paid" text="Resets after the monthly salary is paid." />
-        <text name="ft_auto_respected" text="Respected" />
-        <text name="ft_auto_respected_70_neutral_40_poor_40" text="Respected &gt;= 70  |  Neutral &gt;= 40  |  Poor &lt; 40.&#10;" />
-        <text name="ft_auto_restores_every_setting_to_its_factory_value" text="Restores every setting to its factory value,&#10;" />
-        <text name="ft_auto_return" text="RETURN %" />
-        <text name="ft_auto_return_2" text="Return %" />
-        <text name="ft_auto_right_click_or_press_esc_to_exit" text="Right-click or press Esc to exit." />
-        <text name="ft_auto_ripening" text="RiStalling" />
+        <text name="ft_auto_reset_position_scale" text="POSITION &amp; GRÖẞE ZURÜCKSETZEN" />
+        <text name="ft_auto_reset_settings" text="Einstellungen zurücksetzen" />
+        <text name="ft_auto_resets_after_the_monthly_salary_is_paid" text="Wird zurückgesetzte nachdem das Monatsgehalt gezahlt wurde." />
+        <text name="ft_auto_respected" text="Respektiert" />
+        <text name="ft_auto_respected_70_neutral_40_poor_40" text="Respektiert &gt;= 70  |  Neutral &gt;= 40  |  Schlecht &lt; 40.&#10;" />
+        <text name="ft_auto_restores_every_setting_to_its_factory_value" text="Setzt alle Einstellungen auf Werkseinstellungen zurück,&#10;" />
+        <text name="ft_auto_return" text="Rückgabe %" />
+        <text name="ft_auto_return_2" text="Rückgabe %" />
+        <text name="ft_auto_right_click_or_press_esc_to_exit" text="Rechtsklick oder ESC drücken zum verlassen." />
+        <text name="ft_auto_ripening" text="Reifen" />
         <text name="ft_auto_roleplay_phone" text="roleplay_phone" />
         <text name="ft_auto_roleplay_phone_integration" text="ROLEPLAY PHONE INTEGRATION" />
         <text name="ft_auto_roleplayphone" text="RoleplayPhone" />
         <text name="ft_auto_roleplayphone_checkinstalled" text="RoleplayPhone_checkInstalled" />
-        <text name="ft_auto_roleplayphone_getinvoices" text="RoleplayPhone_getRechnungen" />
-        <text name="ft_auto_rolling" text="Rolling" />
-        <text name="ft_auto_roster" text="ROSTER" />
-        <text name="ft_auto_roster_2" text="roster" />
-        <text name="ft_auto_roster_data_unavailable" text="Roster data unavailable." />
-        <text name="ft_auto_roster_is_host_managed_syncs_to_clients_soon" text="Roster is host-managed — syncs to clients soon." />
-        <text name="ft_auto_roster_tab" text="ROSTER TAB" />
-        <text name="ft_auto_rows_marked_fert_in_yellow_need_fertilising" text="Rows marked [FERT!] in yellow need fertilising.&#10;" />
-        <text name="ft_auto_running_costs" text="RUNNING COSTS" />
+        <text name="ft_auto_roleplayphone_getinvoices" text="RoleplayPhone_getInvoices" />
+        <text name="ft_auto_rolling" text="Walzen" />
+        <text name="ft_auto_roster" text="BEWERBERPORTAL" />
+        <text name="ft_auto_roster_2" text="Bewerberportal" />
+        <text name="ft_auto_roster_data_unavailable" text="Bewerberdaten nicht verfügbar." />
+        <text name="ft_auto_roster_is_host_managed_syncs_to_clients_soon" text="Das Bewerberportal wird durch den Host verwaltet - Synchronisation mit den Clients folgt." />
+        <text name="ft_auto_roster_tab" text="BEWERBERPORTAL" />
+        <text name="ft_auto_rows_marked_fert_in_yellow_need_fertilising" text="Zeilen markiert mit [FERT!] in Gelb müssen gedüngt werden.&#10;" />
+        <text name="ft_auto_running_costs" text="LAUFENDE KOSTEN" />
         <text name="ft_auto_rurallink" text="RuralLink" />
         <text name="ft_auto_rurallink_2" text="rurallink" />
         <text name="ft_auto_rwe" text="RWE" />
         <text name="ft_auto_s" text="^%s+" />
         <text name="ft_auto_s_0f_c" text="%s  %.0f'C" />
         <text name="ft_auto_s_d_4" text="%s  (%d/4)" />
-        <text name="ft_auto_s_d_animals_about_d_min" text="%s - %d animals - about %d min" />
-        <text name="ft_auto_s_data_frozen" text="%s - data frozen" />
+        <text name="ft_auto_s_d_animals_about_d_min" text="%s - %d Tiere - ungefähr %d min" />
+        <text name="ft_auto_s_data_frozen" text="%s - Daten eingefroren" />
         <text name="ft_auto_s_day_d" text="%s  -  Tag %d" />
-        <text name="ft_auto_s_invoice_d" text="%s.invoice(%d)" />
-        <text name="ft_auto_s_s" text="%s – %s" />
+        <text name="ft_auto_s_invoice_d" text="%s.Rechnung(%d)" />
+        <text name="ft_auto_s_s" text="%s - %s" />
         <text name="ft_auto_s_s_2" text="%s/%s" />
-        <text name="ft_auto_s_s_mo_d_mo_left" text="%s  •  %s/mo  •  %d mo left" />
-        <text name="ft_auto_same_colour_thresholds_as_food" text="Same colour thresholds as food.&#10;" />
-        <text name="ft_auto_scale" text="Skalierung" />
-        <text name="ft_auto_scale_fixes_for_ultrawide_monitors" text="Skalierung fixes for ultrawide monitors" />
+        <text name="ft_auto_s_s_mo_d_mo_left" text="%s  •  %s/Monate  •  %d Monate übrig" />
+        <text name="ft_auto_same_colour_thresholds_as_food" text="Selbe Farbwerte wie Futter.&#10;" />
+        <text name="ft_auto_scale" text="Größe" />
+        <text name="ft_auto_scale_fixes_for_ultrawide_monitors" text="Größe für Ultraweit Bildschirme gefixt" />
         <text name="ft_auto_screen_on" text="Screen-on" />
         <text name="ft_auto_scroll" text="scroll" />
-        <text name="ft_auto_scroll_down_for_the_pro_staff_roster" text="Scroll down for the Pro-Staff roster." />
+        <text name="ft_auto_scroll_down_for_the_pro_staff_roster" text="Runterscrollen für die Pro-Staff Personalübersicht." />
         <text name="ft_auto_scroll_wheel_over_this_panel_to_scroll_settings" text="Mausrad über diesem Fenster scrollt die Einstellungen." />
         <text name="ft_auto_scrolling" text="SCROLLING" />
         <text name="ft_auto_se" text="SE" />
-        <text name="ft_auto_season" text="Season" />
-        <text name="ft_auto_season_2" text="season" />
-        <text name="ft_auto_season_day_time_weather" text="SEASON / DAY / TIME / WETTER" />
+        <text name="ft_auto_season" text="Jahreszeit" />
+        <text name="ft_auto_season_2" text="Jahreszeit" />
+        <text name="ft_auto_season_day_time_weather" text="Jahreszeit / Tag / Zeit / Wetter" />
         <text name="ft_auto_season_requires_the_seasons_mod_blank_in_base_game" text="Season requires the Seasons mod — blank in base game.&#10;" />
-        <text name="ft_auto_seasonal" text="Seasonal" />
-        <text name="ft_auto_seasonal_crop_stress" text="Seasonal Frucht Stress" />
-        <text name="ft_auto_seasonal_crop_stress_monitor" text="Seasonal crop stress monitor" />
+        <text name="ft_auto_seasonal" text="Jährlich" />
+        <text name="ft_auto_seasonal_crop_stress" text="SeasonalCropStress" />
+        <text name="ft_auto_seasonal_crop_stress_monitor" text="SeasonalCropStress Bestandsmonitor" />
         <text name="ft_auto_sectionheader" text="sectionHeader" />
-        <text name="ft_auto_seeded" text="Seeded" />
+        <text name="ft_auto_seeded" text="gesät" />
         <text name="ft_auto_select" text="AUSWÄHLEN" />
-        <text name="ft_auto_select_a_field" text="SELECT A FIELD" />
-        <text name="ft_auto_select_a_field_above_for_soil_details" text="Select ein Feld above foder soil details." />
+        <text name="ft_auto_select_a_field" text="WÄHLE EIN FELD" />
+        <text name="ft_auto_select_a_field_above_for_soil_details" text="Wähle ein Feld für Bodeninformationen." />
         <text name="ft_auto_select_a_provider_then_activate_it" text="Wähle einen Anbieter und aktiviere ihn danach." />
         <text name="ft_auto_select_a_vehicle_above_to_inspect" text="Wähle oben ein Fahrzeug aus." />
-        <text name="ft_auto_select_unpin" text="SELECT / UNPIN" />
-        <text name="ft_auto_self" text="Self" />
-        <text name="ft_auto_sell_crops" text="Sell crops" />
-        <text name="ft_auto_sell_point" text="Sell Point" />
+        <text name="ft_auto_select_unpin" text="AUSWÄHLEN / LÖSEN" />
+        <text name="ft_auto_self" text="Selbst" />
+        <text name="ft_auto_sell_crops" text="Kulturen Verkaufen" />
+        <text name="ft_auto_sell_point" text="Verkaufspunkt" />
         <text name="ft_auto_sell_prices" text="sell_prices" />
         <text name="ft_auto_selten" text="selten" />
-        <text name="ft_auto_sent_to_the_host_and_the_result_syncs_back_to" text="sent to the host and the result syncs back to&#10;" />
-        <text name="ft_auto_sentry" text="SENTRY" />
-        <text name="ft_auto_service_fee" text="Service Fee" />
-        <text name="ft_auto_session_p_l" text="SESSION P&amp;L" />
+        <text name="ft_auto_sent_to_the_host_and_the_result_syncs_back_to" text="an den Host gesendet und das Ergebnis wird zurück synchronisiert nach&#10;" />
+        <text name="ft_auto_sentry" text="MONITOR" />
+        <text name="ft_auto_service_fee" text="Gebühr" />
+        <text name="ft_auto_session_p_l" text="SITZUNG P&amp;L" />
         <text name="ft_auto_set" text="SET" />
-        <text name="ft_auto_set_an_amount_greater_than_0_to_create" text="Set ein amount greater thein 0 zu create." />
+        <text name="ft_auto_set_an_amount_greater_than_0_to_create" text="Wähle zum erstellen eine Anzahl größer als 0." />
         <text name="ft_auto_set_startup_app_id" text="Set startup app ID" />
         <text name="ft_auto_set_tablet_keybind" text="Set tablet keybind" />
         <text name="ft_auto_set_time_scale_and_skip_to_a_time_of_day" text="Zeitskalierung ändern und zu Uhrzeit springen" />
-        <text name="ft_auto_sets_how_fast_game_time_passes" text="Sets how fast game time passes.&#10;" />
-        <text name="ft_auto_sets_how_fast_in_game_time_passes" text="Sets how fast in-game time passes.&#10;" />
-        <text name="ft_auto_sets_the_per_hour_wage_rate_for_hired_workers" text="Sets per-hour wage rate foder hired Arbeiter.&#10;" />
+        <text name="ft_auto_sets_how_fast_game_time_passes" text="Stellt ein wie schnell die Zeit vergeht.&#10;" />
+        <text name="ft_auto_sets_how_fast_in_game_time_passes" text="Stellt ein wie schnell die in-Game Zeit vergeht.&#10;" />
+        <text name="ft_auto_sets_the_per_hour_wage_rate_for_hired_workers" text="Legt den Stundenlohnt für Angestellte fest.&#10;" />
         <text name="ft_auto_settings" text="Einstellungen" />
         <text name="ft_auto_settings_2" text="Einstellungen" />
         <text name="ft_auto_settings_3" text="settings" />
         <text name="ft_auto_settings_changed" text="settings_changed" />
-        <text name="ft_auto_settings_integration_in_pause_menu" text="Einstellungen integration in pause menu" />
+        <text name="ft_auto_settings_integration_in_pause_menu" text="Einstellungen Integration im Pausenmenü" />
         <text name="ft_auto_shop" text="Shop" />
         <text name="ft_auto_shops" text=" shops  |  " />
-        <text name="ft_auto_shops_may_break_game_features_be_careful" text="Shops) may break game features — be careful." />
-        <text name="ft_auto_should_i_draw_my_overlay_right_now" text="should I draw my overlay right jetzt?" />
-        <text name="ft_auto_show_all_tablet_commands" text="Anzeigen all tablet commands" />
-        <text name="ft_auto_show_current_settings" text="Anzeigen current settings" />
-        <text name="ft_auto_show_or_hide_the_text_under_each_app_icon" text="Text unter App-Symbolen anzeigen oder ausblenden" />
-        <text name="ft_auto_shown_here_so_you_can_plan_your_cash_flow" text="Shown here so you can plan your cash flow." />
-        <text name="ft_auto_shown_in_orange_as_it_represents_an_ongoing_cost" text="Shown in orange as it represents an ongoing cost." />
-        <text name="ft_auto_shown_top_right_of_the_hero_card_and_in_the_detail_rows" text="Shown top-right of the hero card and in the detail rows." />
-        <text name="ft_auto_shows_a_welcome_message_in_the_top_left_corner" text="Shows a welcome message in the top-left corner&#10;" />
-        <text name="ft_auto_shows_a_welcome_notification_when_a_savegame_loads" text="Shows a welcome notification when a savegame loads" />
-        <text name="ft_auto_shows_all_active_map_hotspots_pins" text="Anzeigens all aktiv map hotspots / pins.&#10;" />
-        <text name="ft_auto_shows_all_field_contracts_your_farm_has_accepted" text="Anzeigens all Feld Aufträge dein farm has accepted&#10;" />
-        <text name="ft_auto_shows_current_fuel_level_litres_remaining_and_tank" text="Anzeigens current Kraftstoff Stufe, litres remaining, und tank&#10;" />
-        <text name="ft_auto_shows_every_motorized_vehicle_your_farm_owns" text="Shows every motorized Fahrzeug your farm owns.&#10;" />
-        <text name="ft_auto_shows_every_production_building_your_farm_owns" text="Shows every production building your farm owns.&#10;" />
-        <text name="ft_auto_shows_item_name_monthly_payment_and_remaining" text="Shows item name, monthly payment, and remaining&#10;" />
-        <text name="ft_auto_shows_the_best_available_sell_price_per_stored_crop" text="Anzeigens best available sell Preis per stored crop&#10;" />
-        <text name="ft_auto_shows_the_changelog_for_farm_tablet_what_changed" text="Shows the changelog for Farm Tablet — what changed&#10;" />
-        <text name="ft_auto_shows_the_current_tablet_position_x_y_and_scale" text="Shows the current tablet position (X/Y) and scale.&#10;" />
-        <text name="ft_auto_shows_the_current_weather_condition_with_a_colour_coded" text="Shows the current weather condition with a colour-coded&#10;" />
-        <text name="ft_auto_shows_the_vehicle_currently_being_tracked_with_its" text="Shows the Fahrzeug currently being tracked with its&#10;" />
-        <text name="ft_auto_shows_whether_seasonal_crop_stress_is_enabled_and" text="Shows whether Seasonal Frucht Stress is enabled and&#10;" />
-        <text name="ft_auto_shows_your_player_s_current_world_coordinates" text="Shows your player's current world coordinates.&#10;" />
-        <text name="ft_auto_signing_cost" text="Signing cost  " />
-        <text name="ft_auto_silo_inventory_and_current_sell_prices" text="Silo-Bestand und aktuelle Verkaufspreise" />
-        <text name="ft_auto_silos" text=" silos" />
-        <text name="ft_auto_silos_are_empty" text="Silos are empty" />
-        <text name="ft_auto_since_the_last_time_the_savegame_was_loaded" text="(since the last time the savegame was loaded).&#10;" />
-        <text name="ft_auto_single_station_no_comparison_available" text="Nur eine Station – kein Vergleich verfügbar" />
+        <text name="ft_auto_shops_may_break_game_features_be_careful" text="Shops) kann das Spiel beeinträchtigen - sei vorsichtig." />
+        <text name="ft_auto_should_i_draw_my_overlay_right_now" text="soll ich das Overlay jetzt anzeigen?" />
+        <text name="ft_auto_show_all_tablet_commands" text="Zeige alle Tablet Befehle" />
+        <text name="ft_auto_show_current_settings" text="Zeige die aktuellen Einstellungen" />
+        <text name="ft_auto_show_or_hide_the_text_under_each_app_icon" text="Text unter den App-Symbolen anzeigen oder ausblenden" />
+        <text name="ft_auto_shown_here_so_you_can_plan_your_cash_flow" text="Wird hier angezeigt, damit du deine Geldmittel planen kannst." />
+        <text name="ft_auto_shown_in_orange_as_it_represents_an_ongoing_cost" text="Wird Orange dargestellt, wenn es laufende Kosten sind." />
+        <text name="ft_auto_shown_top_right_of_the_hero_card_and_in_the_detail_rows" text="Wird oben rechts in der Übersicht angezeigt" />
+        <text name="ft_auto_shows_a_welcome_message_in_the_top_left_corner" text="Zeigt eine Willkommensnachricht in der oberen linken Ecke&#10;" />
+        <text name="ft_auto_shows_a_welcome_notification_when_a_savegame_loads" text="Zeigt eine WWillkommensnachricht, wenn der Spielstand geladen wird" />
+        <text name="ft_auto_shows_all_active_map_hotspots_pins" text="Zeigt alle aktive Hotspots auf der Karte.&#10;" />
+        <text name="ft_auto_shows_all_field_contracts_your_farm_has_accepted" text="Zeigt alle aktiven Aufträge die dein Hof angenommen hat&#10;" />
+        <text name="ft_auto_shows_current_fuel_level_litres_remaining_and_tank" text="Zeigt den aktuellen Kraftstofflevel und die verbleibenden Liter im Tank&#10;" />
+        <text name="ft_auto_shows_every_motorized_vehicle_your_farm_owns" text="Zeigt jedes Fahrzeug das deinem Hof gehört.&#10;" />
+        <text name="ft_auto_shows_every_production_building_your_farm_owns" text="Zeigt jede Produktion die deinem Hof gehört.&#10;" />
+        <text name="ft_auto_shows_item_name_monthly_payment_and_remaining" text="Zeigt den Gegenstand, die Monatsrate und den verbleibenden&#10;" />
+        <text name="ft_auto_shows_the_best_available_sell_price_per_stored_crop" text="Zeigt den Bestpreis für jede eingelagerte Kultur&#10;" />
+        <text name="ft_auto_shows_the_changelog_for_farm_tablet_what_changed" text="Zeigt den changelog für Farm Tablet&#10;" />
+        <text name="ft_auto_shows_the_current_tablet_position_x_y_and_scale" text="Zeigt die aktuelle Position und Größe des Tablets.&#10;" />
+        <text name="ft_auto_shows_the_current_weather_condition_with_a_colour_coded" text="Zeigt die aktuellen Wetterbedingungen farblich markiert an&#10;" />
+        <text name="ft_auto_shows_the_vehicle_currently_being_tracked_with_its" text="Zeigt das Fahrzeug aktuell verfolgt wird&#10;" />
+        <text name="ft_auto_shows_whether_seasonal_crop_stress_is_enabled_and" text="Zeigt ob FS25_SeasonalCropStress aktiviert ist und&#10;" />
+        <text name="ft_auto_shows_your_player_s_current_world_coordinates" text="Zeigt die aktuellen Koordinaten des Spielers an.&#10;" />
+        <text name="ft_auto_signing_cost" text="Kosten zu Unterzeichnung" />
+        <text name="ft_auto_silo_inventory_and_current_sell_prices" text="Bestand im Silo und aktuelle Verkaufspreise" />
+        <text name="ft_auto_silos" text="Silos" />
+        <text name="ft_auto_silos_are_empty" text="Silos sind leer" />
+        <text name="ft_auto_since_the_last_time_the_savegame_was_loaded" text="(seitdem der Spielstand zuletzt geladen wurde).&#10;" />
+        <text name="ft_auto_single_station_no_comparison_available" text="Nur eine Station - kein Vergleich verfügbar" />
         <text name="ft_auto_skidsteer" text="skidsteer" />
         <text name="ft_auto_skip_to" text="SKIP TO" />
-        <text name="ft_auto_slate_grey" text="Slate Grey" />
+        <text name="ft_auto_slate_grey" text="Schiefergrau" />
         <text name="ft_auto_sleep" text="SLEEP" />
         <text name="ft_auto_sleep_toggle" text="SLEEP TOGGLE" />
-        <text name="ft_auto_slide_to_unlock" text="Zum Entsperren schieben" />
-        <text name="ft_auto_small" text="SMALL" />
+        <text name="ft_auto_slide_to_unlock" text="Zum Entsperren wischen" />
+        <text name="ft_auto_small" text="Klein" />
         <text name="ft_auto_snow" text="Schnee" />
-        <text name="ft_auto_so_you_can_spot_what_needs_refuelling_at_a_glance" text="so you can spot what needs refuelling at a glance." />
+        <text name="ft_auto_so_you_can_spot_what_needs_refuelling_at_a_glance" text="damit du auf einen Blick sehen kannst, was aufgefüllt werden muss." />
         <text name="ft_auto_soil" text="SOIL" />
         <text name="ft_auto_soil_2" text="soil" />
-        <text name="ft_auto_soil_data_field" text="SOIL DATA  — Field " />
-        <text name="ft_auto_soil_fertilizer" text="Bodendünger" />
+        <text name="ft_auto_soil_data_field" text="Bodendaten - Feld " />
+        <text name="ft_auto_soil_fertilizer" text="Dünger" />
         <text name="ft_auto_soil_fertilizer_2" text="soil_fertilizer" />
-        <text name="ft_auto_soil_fertilizer_mod_not_detected" text="Soil Fertilizer mod not detected." />
-        <text name="ft_auto_soil_fertilizer_status" text="Soil fertilizer status" />
-        <text name="ft_auto_soil_moisture_and_drought_stress_per_field" text="soil moisture und drought stress per Feld.&#10;" />
-        <text name="ft_auto_soil_profile_in_the_panel_below_the_list" text="soil profile in the panel below the list.&#10;" />
-        <text name="ft_auto_soil_system_is_initializing" text="Soil system is initializing..." />
+        <text name="ft_auto_soil_fertilizer_mod_not_detected" text="FS25_SoilFertilizer mod nicht gefunden." />
+        <text name="ft_auto_soil_fertilizer_status" text="Dünger Zustand" />
+        <text name="ft_auto_soil_moisture_and_drought_stress_per_field" text="Bodenfeuchtigkeit und Dürrestress pro Feld.&#10;" />
+        <text name="ft_auto_soil_profile_in_the_panel_below_the_list" text="Bodenprofil im Bereich unter der Liste.&#10;" />
+        <text name="ft_auto_soil_system_is_initializing" text="Bodensystem wird initialisiert..." />
         <text name="ft_auto_soilconstants" text="SoilConstants" />
-        <text name="ft_auto_sort" text="SORT: " />
-        <text name="ft_auto_sorted_by_fuel_level_emptiest_machines_appear_first" text="Sortierened by Kraftstoff Stufe — emptiest machines appear first&#10;" />
+        <text name="ft_auto_sort" text="FILTERN: " />
+        <text name="ft_auto_sorted_by_fuel_level_emptiest_machines_appear_first" text="Filtern nach: Kraftstofflevel - am geringsten gefüllte Maschine erscheint zuerst&#10;" />
         <text name="ft_auto_sound" text="Ton" />
-        <text name="ft_auto_sound_effects" text="TON EFFECTS" />
-        <text name="ft_auto_sound_effects_off" text="Toneffekte: Aus" />
-        <text name="ft_auto_sound_effects_on" text="Toneffekte: An" />
-        <text name="ft_auto_sound_effects_s" text="Ton Effects: %s&#10;" />
-        <text name="ft_auto_sow_seeds" text="Sow seeds" />
-        <text name="ft_auto_sowing" text="Sowing" />
-        <text name="ft_auto_sowing_planting" text="Sowing / Planting" />
-        <text name="ft_auto_speed" text="Speed" />
-        <text name="ft_auto_speed_km_h_are_shown_here" text="speed (km/h) are shown here.&#10;" />
-        <text name="ft_auto_spray_fields" text="Spray Felder" />
-        <text name="ft_auto_spraying" text="Spraying" />
+        <text name="ft_auto_sound_effects" text="Geräusche" />
+        <text name="ft_auto_sound_effects_off" text="Geräusche: Aus" />
+        <text name="ft_auto_sound_effects_on" text="Geräusche: An" />
+        <text name="ft_auto_sound_effects_s" text="Geräusche: %s&#10;" />
+        <text name="ft_auto_sow_seeds" text="Saatgut aussäen" />
+        <text name="ft_auto_sowing" text="Säen" />
+        <text name="ft_auto_sowing_planting" text="Säen / Pflanzen" />
+        <text name="ft_auto_speed" text="Geschwindigkeit" />
+        <text name="ft_auto_speed_km_h_are_shown_here" text="Geschwindigkeit (km/h) wird hier angezeigt.&#10;" />
+        <text name="ft_auto_spray_fields" text="Felder spritzen" />
+        <text name="ft_auto_spraying" text="Spritzen" />
         <text name="ft_auto_spring" text="Frühling" />
         <text name="ft_auto_springboard" text="springboard" />
-        <text name="ft_auto_square_brackets_next_to_their_name" text="square brackets next to their name." />
-        <text name="ft_auto_staff" text="STAFF" />
-        <text name="ft_auto_stalled" text="stalled" />
-        <text name="ft_auto_stalled_no_productions_are_enabled_check_the_building" text="Stalled: no productions are enabled (check the building&#10;" />
-        <text name="ft_auto_start" text="start" />
-        <text name="ft_auto_start_job" text="START JOB" />
-        <text name="ft_auto_start_job_2" text="start job" />
-        <text name="ft_auto_start_new" text="START NEU" />
-        <text name="ft_auto_started_day" text="Started Tag " />
-        <text name="ft_auto_starting_a_job" text="STARTING A JOB" />
-        <text name="ft_auto_startup_app" text="STARTUP APP" />
+        <text name="ft_auto_square_brackets_next_to_their_name" text="eckige Klammern neben ihren Namen." />
+        <text name="ft_auto_staff" text="PERSONAL" />
+        <text name="ft_auto_stalled" text="Angehalten" />
+        <text name="ft_auto_stalled_no_productions_are_enabled_check_the_building" text="Angehalten: Keine Produktionen aktiviert (Gebäude prüfen)" />
+        <text name="ft_auto_start" text="Start" />
+        <text name="ft_auto_start_job" text="AUFTRAG STARTEN" />
+        <text name="ft_auto_start_job_2" text="Auftrag starten" />
+        <text name="ft_auto_start_new" text="NEU STARTEN" />
+        <text name="ft_auto_started_day" text="Gestartet an Tag " />
+        <text name="ft_auto_starting_a_job" text="AUFTRAG WIRD GESTARTET" />
+        <text name="ft_auto_startup_app" text="START-APP" />
         <text name="ft_auto_startup_app_2" text="Start-App: " />
-        <text name="ft_auto_startup_app_s" text="Startup App: %s&#10;" />
-        <text name="ft_auto_startup_app_set_to_s" text="Startup app set to: %s" />
-        <text name="ft_auto_stat" text="STAT" />
+        <text name="ft_auto_startup_app_s" text="Start-App: %s&#10;" />
+        <text name="ft_auto_startup_app_set_to_s" text="Start-App festgelegt auf: %s" />
+        <text name="ft_auto_stat" text="STAT." />
         <text name="ft_auto_state" text="   Status: " />
         <text name="ft_auto_state_2" text="STATUS" />
-        <text name="ft_auto_state_dot_colours" text="STATUS DOT COLOURS" />
-        <text name="ft_auto_stated_tax_rate" text="stated tax rate." />
-        <text name="ft_auto_stations_are_sorted_best_price_first" text="Stations are sorted best-Preis first.&#10;" />
-        <text name="ft_auto_stats" text="stats" />
+        <text name="ft_auto_state_dot_colours" text="STATUSPUNKT-FARBEN" />
+        <text name="ft_auto_stated_tax_rate" text="Festgelegter Steuersatz." />
+        <text name="ft_auto_stations_are_sorted_best_price_first" text="Stationen sind nach dem besten Preis sortiert.&#10;" />
+        <text name="ft_auto_stats" text="Statistiken" />
         <text name="ft_auto_status" text="STATUS" />
         <text name="ft_auto_status_2" text="Status" />
         <text name="ft_auto_status_3" text="^Status:" />
-        <text name="ft_auto_status_4" text="status" />
-        <text name="ft_auto_status_banner" text="STATUS BANNER" />
-        <text name="ft_auto_statuses_pending_paid_overdue_rejected" text="Statuses: PENDING, PAID, OVERDUE / REJECTED." />
-        <text name="ft_auto_stone_picking" text="Stone Picking" />
+        <text name="ft_auto_status_4" text="Status" />
+        <text name="ft_auto_status_banner" text="STATUSBANNER" />
+        <text name="ft_auto_statuses_pending_paid_overdue_rejected" text="Status: AUSSTEHEND, BEZAHLT, ÜBERFÄLLIG / ABGELEHNT." />
+        <text name="ft_auto_stone_picking" text="Steine sammeln" />
         <text name="ft_auto_storage" text="Lager" />
-        <text name="ft_auto_storage_2" text="storage" />
-        <text name="ft_auto_storage_historical_peak_price_tracking_saved_per_savega" text="Lager: historical peak Preis tracking — saved per savegame" />
-        <text name="ft_auto_storage_peak_shown_under_each_crop_orange_below_peak_gr" text="Lager: peak shown under each crop (orange = below peak, green = at peak)" />
-        <text name="ft_auto_storage_price_comparison_section_all_stations_sorted_be" text="Lager: Preis comparison section — all stations sorted best-first" />
-        <text name="ft_auto_storages" text="storages_" />
-        <text name="ft_auto_store" text="store" />
-        <text name="ft_auto_storm" text="STORM" />
-        <text name="ft_auto_storm_2" text="Storm" />
-        <text name="ft_auto_storm_3" text="storm" />
-        <text name="ft_auto_stormy" text="Stormy" />
+        <text name="ft_auto_storage_2" text="Lager" />
+        <text name="ft_auto_storage_historical_peak_price_tracking_saved_per_savega" text="Lager: Historische Höchstpreise werden pro Spielstand gespeichert." />
+        <text name="ft_auto_storage_peak_shown_under_each_crop_orange_below_peak_gr" text="Lager: Höchstpreis unter jeder Frucht (Orange = unter Höchstpreis, Grün = Höchstpreis)." />
+        <text name="ft_auto_storage_price_comparison_section_all_stations_sorted_be" text="Lager: Preisvergleich – alle Verkaufsstellen nach bestem Preis sortiert." />
+        <text name="ft_auto_storages" text="Lager" />
+        <text name="ft_auto_store" text="Shop" />
+        <text name="ft_auto_storm" text="STURM" />
+        <text name="ft_auto_storm_2" text="Sturm" />
+        <text name="ft_auto_storm_3" text="Sturm" />
+        <text name="ft_auto_stormy" text="Stürmisch" />
         <text name="ft_auto_str" text="STR" />
         <text name="ft_auto_straw" text="Stroh" />
         <text name="ft_auto_straw_clean_d" text="STROH/SAUBER  %d%%" />
-        <text name="ft_auto_straw_cleanliness_bar" text="STROH / SAUBERLINESS BAR" />
-        <text name="ft_auto_stress_indicator" text="STRESS INDICATOR" />
-        <text name="ft_auto_stress_the_value_row_ends_with_xx_in_red" text="stress, the value row ends with  !XX%  in red.&#10;" />
-        <text name="ft_auto_string" text="string" />
-        <text name="ft_auto_summary_badges" text="SUMMARY BADGES" />
-        <text name="ft_auto_summary_bar" text="SUMMARY BAR" />
+        <text name="ft_auto_straw_cleanliness_bar" text="STROH-/SAUBERKEITSBALKEN" />
+        <text name="ft_auto_stress_indicator" text="STRESSANZEIGE" />
+        <text name="ft_auto_stress_the_value_row_ends_with_xx_in_red" text="Bei Stress endet die Wertezeile mit !XX % in Rot.&#10;" />
+        <text name="ft_auto_string" text="Zeichenfolge" />
+        <text name="ft_auto_summary_badges" text="ÜBERSICHTSABZEICHEN" />
+        <text name="ft_auto_summary_bar" text="ÜBERSICHTSBALKEN" />
         <text name="ft_auto_summary_cards" text="ÜBERSICHTSKARTEN" />
         <text name="ft_auto_summer" text="Sommer" />
-        <text name="ft_auto_supplier" text="Supplier" />
-        <text name="ft_auto_sure" text="SURE?" />
-        <text name="ft_auto_surface_you_are_standing_negative_values_mean_you" text="surface you are standing. Negative values mean you&#10;" />
+        <text name="ft_auto_supplier" text="Lieferant" />
+        <text name="ft_auto_sure" text="SICHER?" />
+        <text name="ft_auto_surface_you_are_standing_negative_values_mean_you" text="Die Höhe der Oberfläche, auf der du stehst. Negative Werte bedeuten ...&#10;" />
         <text name="ft_auto_sw" text="SW" />
-        <text name="ft_auto_switch_to_app_by_id" text="Switch to app by ID" />
-        <text name="ft_auto_switched_to_app_s" text="Switched to app: %s" />
-        <text name="ft_auto_syncing_roster_from_host" text="Syncing roster from host..." />
-        <text name="ft_auto_system_initialized_apps_d" text="System initialized. Apps: %d" />
-        <text name="ft_auto_table" text="table" />
-        <text name="ft_auto_tablet" text="tablet" />
+        <text name="ft_auto_switch_to_app_by_id" text="Zur App per ID wechseln" />
+        <text name="ft_auto_switched_to_app_s" text="Zur App gewechselt: %s" />
+        <text name="ft_auto_syncing_roster_from_host" text="Personaldaten werden vom Host synchronisiert..." />
+        <text name="ft_auto_system_initialized_apps_d" text="System initialisiert. Apps: %d" />
+        <text name="ft_auto_table" text="Tabelle" />
+        <text name="ft_auto_tablet" text="Tablet" />
         <text name="ft_auto_tablet_battery_empty" text="Tablet-Akku leer" />
         <text name="ft_auto_tablet_charging" text="Tablet lädt..." />
-        <text name="ft_auto_tablet_closed" text="Tablet closed" />
+        <text name="ft_auto_tablet_closed" text="Tablet geschlossen" />
         <text name="ft_auto_tablet_closed_2" text="tablet_closed" />
         <text name="ft_auto_tablet_configuration" text="Tablet-Einstellungen" />
-        <text name="ft_auto_tablet_edit_mode_drag_move_corners_scale_edges_width_ri" text="TABLET EDIT MODE  |  Drag: move  |  Corners: scale  |  Edges: Breite  |  Right-click: exit" />
+        <text name="ft_auto_tablet_edit_mode_drag_move_corners_scale_edges_width_ri" text="TABLET-BEARBEITUNGSMODUS | Ziehen: verschieben | Ecken: skalieren | Kanten: Breite | Rechtsklick: beenden" />
         <text name="ft_auto_tablet_focus_changed" text="tablet_focus_changed" />
-        <text name="ft_auto_tablet_in_repair" text="Tablet in reparieren" />
+        <text name="ft_auto_tablet_in_repair" text="Tablet wird repariert" />
         <text name="ft_auto_tablet_open_close_sound_off" text="Tablet-Ton: Aus" />
         <text name="ft_auto_tablet_open_close_sound_on" text="Tablet-Ton: An" />
-        <text name="ft_auto_tablet_open_close_sound_plays_on_the_t_key" text="Tablet OStall/Schliessen Ton: plays on the T key." />
-        <text name="ft_auto_tablet_opened" text="Tablet oStalled" />
-        <text name="ft_auto_tablet_opened_2" text="tablet_oStalled" />
-        <text name="ft_auto_tablet_service" text="Tablet Service" />
-        <text name="ft_auto_tablet_show_this_help" text="tablet - Anzeigen this help&#10;" />
-        <text name="ft_auto_tablet_toggled" text="Tablet toggled" />
+        <text name="ft_auto_tablet_open_close_sound_plays_on_the_t_key" text="Tablet-Ton beim Öffnen/Schließen mit der Taste T." />
+        <text name="ft_auto_tablet_opened" text="Tablet geöffnet" />
+        <text name="ft_auto_tablet_opened_2" text="tablet_opened" />
+        <text name="ft_auto_tablet_service" text="Tablet-Service" />
+        <text name="ft_auto_tablet_show_this_help" text="Tablet – Diese Hilfe anzeigen&#10;" />
+        <text name="ft_auto_tablet_toggled" text="Tablet umgeschaltet" />
         <text name="ft_auto_tabletapp" text="TabletApp" />
-        <text name="ft_auto_tabletapp_id_switch_to_app_immediately" text="TabletApp [id] - Switch to app immediately&#10;" />
-        <text name="ft_auto_tabletclose" text="TabletSchliessen" />
-        <text name="ft_auto_tabletdisable" text="TabletDisable" />
-        <text name="ft_auto_tabletenable" text="TabletEnable" />
-        <text name="ft_auto_tabletenable_disable_toggle_mod" text="TabletEnable/Disable - Toggle mod&#10;" />
-        <text name="ft_auto_tabletkeybind" text="TabletKeybind" />
-        <text name="ft_auto_tabletkeybind_key_set_open_key" text="TabletKeybind [key] - Set oStall key&#10;" />
-        <text name="ft_auto_tabletopen" text="TabletOStall" />
-        <text name="ft_auto_tabletopen_close_open_close_tablet" text="TabletOStall/Schliessen - OStall/close tablet&#10;" />
-        <text name="ft_auto_tabletresetsettings" text="TabletResetEinstellungen" />
-        <text name="ft_auto_tabletresetsettings_reset_to_defaults" text="TabletResetEinstellungen - Reset to defaults&#10;" />
-        <text name="ft_auto_tabletsetnotifications" text="TabletSetNotifications" />
-        <text name="ft_auto_tabletsetnotifications_true_false_toggle_notifications" text="TabletSetNotifications true|false - Toggle notifications&#10;" />
-        <text name="ft_auto_tabletsetstartupapp" text="TabletSetStartupApp" />
-        <text name="ft_auto_tabletsetstartupapp_id_set_startup_app_e_g_dashboard_we" text="TabletSetStartupApp [id] - Set startup app (e.g. dashboard, weather)&#10;" />
-        <text name="ft_auto_tabletshowsettings" text="TabletShowEinstellungen" />
-        <text name="ft_auto_tabletshowsettings_show_current_settings" text="TabletAnzeigenEinstellungen - Anzeigen current settings&#10;" />
-        <text name="ft_auto_tablettoggle" text="TabletToggle" />
-        <text name="ft_auto_tablettoggle_toggle_tablet" text="TabletToggle - Toggle tablet&#10;" />
-        <text name="ft_auto_tap_an_app_to_add_or_remove_it_from_favourites" text="Tap an app to add or remove it from favourites" />
-        <text name="ft_auto_tap_edit_then_pick_your_apps" text="Tap EDIT, then pick your apps" />
+        <text name="ft_auto_tabletapp_id_switch_to_app_immediately" text="TabletApp [ID] – Sofort zur App wechseln&#10;" />
+        <text name="ft_auto_tabletclose" text="TabletSchließen" />
+        <text name="ft_auto_tabletdisable" text="TabletDeaktivieren" />
+        <text name="ft_auto_tabletenable" text="TabletAktivieren" />
+        <text name="ft_auto_tabletenable_disable_toggle_mod" text="TabletAktivieren/Deaktivieren – Mod umschalten&#10;" />
+        <text name="ft_auto_tabletkeybind" text="TabletTaste" />
+        <text name="ft_auto_tabletkeybind_key_set_open_key" text="TabletTaste [Taste] – Öffnungstaste festlegen&#10;" />
+        <text name="ft_auto_tabletopen" text="TabletÖffnen" />
+        <text name="ft_auto_tabletopen_close_open_close_tablet" text="TabletÖffnen/Schließen – Tablet öffnen oder schließen&#10;" />
+        <text name="ft_auto_tabletresetsettings" text="TabletEinstellungenZurücksetzen" />
+        <text name="ft_auto_tabletresetsettings_reset_to_defaults" text="TabletEinstellungenZurücksetzen – Standardwerte wiederherstellen&#10;" />
+        <text name="ft_auto_tabletsetnotifications" text="TabletBenachrichtigungen" />
+        <text name="ft_auto_tabletsetnotifications_true_false_toggle_notifications" text="TabletBenachrichtigungen true|false – Benachrichtigungen umschalten&#10;" />
+        <text name="ft_auto_tabletsetstartupapp" text="TabletStartApp" />
+        <text name="ft_auto_tabletsetstartupapp_id_set_startup_app_e_g_dashboard_we" text="TabletStartApp [ID] – Start-App festlegen (z. B. Dashboard, Wetter)&#10;" />
+        <text name="ft_auto_tabletshowsettings" text="TabletEinstellungenAnzeigen" />
+        <text name="ft_auto_tabletshowsettings_show_current_settings" text="TabletEinstellungenAnzeigen – Aktuelle Einstellungen anzeigen&#10;" />
+        <text name="ft_auto_tablettoggle" text="TabletUmschalten" />
+        <text name="ft_auto_tablettoggle_toggle_tablet" text="TabletUmschalten – Tablet ein-/ausblenden&#10;" />
+        <text name="ft_auto_tap_an_app_to_add_or_remove_it_from_favourites" text="Tippe auf eine App, um sie zu den Favoriten hinzuzufügen oder daraus zu entfernen." />
+        <text name="ft_auto_tap_edit_then_pick_your_apps" text="Tippe auf BEARBEITEN und wähle anschließend deine Apps aus." />
         <text name="ft_auto_tap_edit_to_add_widgets" text="Tippe auf BEARBEITEN, um Widgets hinzuzufügen." />
-        <text name="ft_auto_tap_finish_on_the_home_screen_when_you_are_done" text="Tap FINISH on the Home screen when you are done.&#10;" />
-        <text name="ft_auto_tap_fire_again_to_confirm_severance" text="Tap FIRE again to confirm — severance " />
-        <text name="ft_auto_tap_home_to_return_to_the_app_grid" text="Tap HOME to return to the app grid." />
-        <text name="ft_auto_tap_new_to_open_the_creation_form" text="Tap + NEU to oStall the creation form.&#10;" />
-        <text name="ft_auto_tap_on_off_to_show_or_hide_each_widget" text="Tap ON/AUS to show or hide each widget." />
-        <text name="ft_auto_tap_start_job_pick_a_field_your_vehicle_and_the" text="Tap START JOB, pick ein Feld, dein Fahrzeug, und the&#10;" />
-        <text name="ft_auto_tap_t_to_close_the_tablet_and_get_back_to_work" text="Tap T to close the tablet and get back to work!" />
-        <text name="ft_auto_tap_the_small_edit_button_top_right_of_the_dashboard" text="Tap the small EDIT button (top-right of the dashboard)&#10;" />
-        <text name="ft_auto_task" text="TASK" />
-        <text name="ft_auto_tax" text="TAX" />
-        <text name="ft_auto_tax_2" text="tax" />
-        <text name="ft_auto_tax_mod" text="Tax Mod" />
+        <text name="ft_auto_tap_finish_on_the_home_screen_when_you_are_done" text="Tippe auf der Startseite auf FERTIG, sobald du fertig bist.&#10;" />
+        <text name="ft_auto_tap_fire_again_to_confirm_severance" text="Tippe erneut auf ENTLASSEN, um die Entlassung zu bestätigen." />
+        <text name="ft_auto_tap_home_to_return_to_the_app_grid" text="Tippe auf HOME, um zum App-Raster zurückzukehren." />
+        <text name="ft_auto_tap_new_to_open_the_creation_form" text="Tippe auf + NEU, um das Erstellungsformular zu öffnen.&#10;" />
+        <text name="ft_auto_tap_on_off_to_show_or_hide_each_widget" text="Tippe auf EIN/AUS, um einzelne Widgets ein- oder auszublenden." />
+        <text name="ft_auto_tap_start_job_pick_a_field_your_vehicle_and_the" text="Tippe auf AUFTRAG STARTEN, wähle ein Feld, dein Fahrzeug und anschließend die gewünschte Aufgabe.&#10;" />
+        <text name="ft_auto_tap_t_to_close_the_tablet_and_get_back_to_work" text="Drücke T, um das Tablet zu schließen und weiterzuarbeiten!" />
+        <text name="ft_auto_tap_the_small_edit_button_top_right_of_the_dashboard" text="Tippe auf die kleine Schaltfläche BEARBEITEN oben rechts im Dashboard.&#10;" />
+        <text name="ft_auto_task" text="AUFGABE" />
+        <text name="ft_auto_tax" text="STEUER" />
+        <text name="ft_auto_tax_2" text="Steuer" />
+        <text name="ft_auto_tax_mod" text="Steuer-Mod" />
         <text name="ft_auto_tax_mod_2" text="tax_mod" />
-        <text name="ft_auto_tax_mod_integration_app" text="Tax Mod integration app" />
-        <text name="ft_auto_tax_mod_is_not_installed" text="Tax Mod is not installed." />
-        <text name="ft_auto_tax_mod_status_and_toggle" text="Tax Mod status and toggle" />
-        <text name="ft_auto_tax_rate" text="TAX RATE" />
-        <text name="ft_auto_tax_rate_2" text="Tax Rate" />
-        <text name="ft_auto_telehandler" text="telehandler" />
-        <text name="ft_auto_temperature" text="TEMPERATURE" />
-        <text name="ft_auto_temperature_2" text="Temperature" />
+        <text name="ft_auto_tax_mod_integration_app" text="Steuer-Mod-Integration" />
+        <text name="ft_auto_tax_mod_is_not_installed" text="Der Steuer-Mod ist nicht installiert." />
+        <text name="ft_auto_tax_mod_status_and_toggle" text="Status und Umschalter des Steuer-Mods" />
+        <text name="ft_auto_tax_rate" text="STEUERSATZ" />
+        <text name="ft_auto_tax_rate_2" text="Steuersatz" />
+        <text name="ft_auto_telehandler" text="Teleskoplader" />
+        <text name="ft_auto_temperature" text="TEMPERATUR" />
+        <text name="ft_auto_temperature_2" text="Temperatur" />
         <text name="ft_auto_terrain_at_position" text="GELÄNDE AN POSITION" />
-        <text name="ft_auto_the_active_job_badge_shows_on_the_home_screen" text="The aktiv job badge shows on Home screen." />
-        <text name="ft_auto_the_active_speed_is_highlighted" text="The aktiv speed is highlighted." />
-        <text name="ft_auto_the_app_shown_first_every_time_you_open_the_tablet" text="The app shown first every time du oStall tablet.&#10;" />
-        <text name="ft_auto_the_building_has_the_inputs_it_needs" text="the building has the inputs it needs.&#10;" />
-        <text name="ft_auto_the_current_difficulty_setting" text="the current difficulty setting." />
-        <text name="ft_auto_the_currently_active_event_frequency" text="currently aktiv Ereignis, frequency,&#10;" />
-        <text name="ft_auto_the_digging_app_refreshes_automatically_every_500ms" text="The digging app refreshes automatically every 500ms&#10;" />
-        <text name="ft_auto_the_left_sidebar_at_any_time" text="the left sidebar at any time." />
-        <text name="ft_auto_the_mod_adds_configurable_periodic_income_payments" text="The mod adds configurable periodic income payments&#10;" />
-        <text name="ft_auto_the_mod_deducts_periodic_tax_from_your_balance" text="The mod deducts periodic tax from your balance&#10;" />
-        <text name="ft_auto_the_money_added_to_your_balance_per_payment_cycle" text="The money added to your balance per payment cycle.&#10;" />
-        <text name="ft_auto_the_panel_below_pinned_vehicles_stay_visible_even" text="the panel below. Pinned Fahrzeuge stay visible even&#10;" />
-        <text name="ft_auto_the_pro_staff_impact_how_levels_cheaper_and" text="the Pro-Staff impact — how levels (cheaper) and&#10;" />
-        <text name="ft_auto_the_release_date_on_the_right" text="the release date on the right.&#10;" />
-        <text name="ft_auto_the_roster_lives_on_the_host_and_is_loading" text="The roster lives on the host and is loading." />
-        <text name="ft_auto_the_roster_lives_on_the_host_your_actions_are" text="The roster lives on the host. Your actions are&#10;" />
-        <text name="ft_auto_the_tracker_activates_automatically_when_you_drive_or" text="The tracker activates automatically when you drive or&#10;" />
-        <text name="ft_auto_the_worker_costs_mod_settings" text="the Worker Costs mod settings." />
-        <text name="ft_auto_their_effects_are" text="their effects are." />
-        <text name="ft_auto_their_role_agronomist_mechanic_etc_is_shown_in" text="Their role (Agronomist, Mechanic, etc.) is shown in&#10;" />
-        <text name="ft_auto_them_reroll_to_draw_fresh_candidates" text="them; REROLL to draw fresh candidates." />
-        <text name="ft_auto_them_tap_twice_severance_applies" text="them (tap twice — severance applies)." />
-        <text name="ft_auto_then_add_to_add_it_to_the_list" text="then + ADD to add it to the list.&#10;" />
-        <text name="ft_auto_then_click_home_background_to_cycle_through_them" text="then click STARTSEITEN-HINTERGRUND to cycle through them." />
-        <text name="ft_auto_these_controls_affect_all_players_and" text="These controls affect all players and" />
-        <text name="ft_auto_third_party_companion_apps_show_their_own_version" text="Third-party companion apps show their own version&#10;" />
-        <text name="ft_auto_this_app_is_a_favourite" text="this app is a favourite" />
-        <text name="ft_auto_this_is_a_shortcut_you_can_also_click_the_icon_in" text="This is a shortcut — you can also click the icon in&#10;" />
-        <text name="ft_auto_this_month" text="THIS MONTH" />
-        <text name="ft_auto_this_view_is_read_only_hire_fire_and_assign" text="This view is read-only — hire, fire, and assign&#10;" />
-        <text name="ft_auto_tier_and_how_far_through_the_listing_period_you_are" text="tier, and how far through the listing period you are." />
-        <text name="ft_auto_time" text="TIME" />
-        <text name="ft_auto_time_2" text="Time" />
-        <text name="ft_auto_time_3" text="time" />
+        <text name="ft_auto_the_active_job_badge_shows_on_the_home_screen" text="Das Symbol für den aktiven Auftrag wird auf der Startseite angezeigt." />
+        <text name="ft_auto_the_active_speed_is_highlighted" text="Die aktive Geschwindigkeit ist hervorgehoben." />
+        <text name="ft_auto_the_app_shown_first_every_time_you_open_the_tablet" text="Diese App wird jedes Mal zuerst angezeigt, wenn du das Tablet öffnest.&#10;" />
+        <text name="ft_auto_the_building_has_the_inputs_it_needs" text="Das Gebäude verfügt über alle benötigten Eingabematerialien.&#10;" />
+        <text name="ft_auto_the_current_difficulty_setting" text="Die aktuelle Schwierigkeitsstufe." />
+        <text name="ft_auto_the_currently_active_event_frequency" text="Aktive Ereignishäufigkeit und -dauer.&#10;" />
+        <text name="ft_auto_the_digging_app_refreshes_automatically_every_500ms" text="Die Bagger-App aktualisiert sich automatisch alle 500 ms.&#10;" />
+        <text name="ft_auto_the_left_sidebar_at_any_time" text="...die linke Seitenleiste jederzeit." />
+        <text name="ft_auto_the_mod_adds_configurable_periodic_income_payments" text="Der Mod fügt konfigurierbare regelmäßige Einnahmen hinzu.&#10;" />
+        <text name="ft_auto_the_mod_deducts_periodic_tax_from_your_balance" text="Der Mod zieht regelmäßig Steuern von deinem Kontostand ab.&#10;" />
+        <text name="ft_auto_the_money_added_to_your_balance_per_payment_cycle" text="Der Betrag, der pro Zahlungszyklus deinem Kontostand gutgeschrieben wird.&#10;" />
+        <text name="ft_auto_the_panel_below_pinned_vehicles_stay_visible_even" text="Das folgende Panel bleibt auch bei angehefteten Fahrzeugen sichtbar.&#10;" />
+        <text name="ft_auto_the_pro_staff_impact_how_levels_cheaper_and" text="Zeigt den Einfluss von Pro-Staff – wie Stufen Kosten und Effizienz beeinflussen.&#10;" />
+        <text name="ft_auto_the_release_date_on_the_right" text="...das Veröffentlichungsdatum auf der rechten Seite.&#10;" />
+        <text name="ft_auto_the_roster_lives_on_the_host_and_is_loading" text="Die Personalliste befindet sich auf dem Host und wird geladen." />
+        <text name="ft_auto_the_roster_lives_on_the_host_your_actions_are" text="Die Personalliste wird vom Host verwaltet. Deine Aktionen werden synchronisiert.&#10;" />
+        <text name="ft_auto_the_tracker_activates_automatically_when_you_drive_or" text="Der Tracker aktiviert sich automatisch, sobald du fährst oder arbeitest.&#10;" />
+        <text name="ft_auto_the_worker_costs_mod_settings" text="Die Einstellungen des Worker-Costs-Mods." />
+        <text name="ft_auto_their_effects_are" text="...deren Auswirkungen sind." />
+        <text name="ft_auto_their_role_agronomist_mechanic_etc_is_shown_in" text="Ihre Rolle (Agronom, Mechaniker usw.) wird in der Liste angezeigt.&#10;" />
+        <text name="ft_auto_them_reroll_to_draw_fresh_candidates" text="...oder auf NEU WÜRFELN, um neue Bewerber zu erhalten." />
+        <text name="ft_auto_them_tap_twice_severance_applies" text="...zweimal tippen – Abfindung wird angewendet." />
+        <text name="ft_auto_then_add_to_add_it_to_the_list" text="Anschließend auf + HINZUFÜGEN tippen, um den Eintrag zur Liste hinzuzufügen.&#10;" />
+        <text name="ft_auto_then_click_home_background_to_cycle_through_them" text="Klicke anschließend auf HOME-HINTERGRUND, um zwischen den Bildern zu wechseln." />
+        <text name="ft_auto_these_controls_affect_all_players_and" text="Diese Einstellungen wirken sich auf alle Spieler aus." />
+        <text name="ft_auto_third_party_companion_apps_show_their_own_version" text="Apps von Drittanbietern zeigen ihre eigene Versionsnummer an.&#10;" />
+        <text name="ft_auto_this_app_is_a_favourite" text="Diese App ist ein Favorit." />
+        <text name="ft_auto_this_is_a_shortcut_you_can_also_click_the_icon_in" text="Dies ist eine Verknüpfung – alternativ kannst du das Symbol im Dock verwenden.&#10;" />
+        <text name="ft_auto_this_month" text="DIESER MONAT" />
+        <text name="ft_auto_this_view_is_read_only_hire_fire_and_assign" text="Diese Ansicht ist schreibgeschützt – Einstellungen, Entlassungen und Zuweisungen erfolgen an anderer Stelle.&#10;" />
+        <text name="ft_auto_tier_and_how_far_through_the_listing_period_you_are" text="Stufe sowie Fortschritt des Angebotszeitraums." />
+        <text name="ft_auto_time" text="ZEIT" />
+        <text name="ft_auto_time_2" text="Zeit" />
+        <text name="ft_auto_time_3" text="Zeit" />
         <text name="ft_auto_time_controls" text="Zeitsteuerung" />
         <text name="ft_auto_time_controls_2" text="time_controls" />
-        <text name="ft_auto_time_controls_affect_all_players_and" text="Time controls affect all players and" />
-        <text name="ft_auto_time_remaining" text="TIME REMAINING" />
+        <text name="ft_auto_time_controls_affect_all_players_and" text="Die Zeitsteuerung wirkt sich auf alle Spieler aus." />
+        <text name="ft_auto_time_remaining" text="VERBLEIBENDE ZEIT" />
         <text name="ft_auto_time_scale" text="ZEITSKALIERUNG" />
-        <text name="ft_auto_time_scale_now" text="ZEITSKALIERUNG  ·  jetzt: " />
-        <text name="ft_auto_time_shown_is_in_game_time_not_real_world_time" text="Time shown is in-game time, not real-world time.&#10;" />
+        <text name="ft_auto_time_scale_now" text="ZEITSKALIERUNG · Aktuell: " />
+        <text name="ft_auto_time_shown_is_in_game_time_not_real_world_time" text="Es wird die Ingame-Zeit angezeigt, nicht die reale Uhrzeit.&#10;" />
         <text name="ft_auto_tisonk" text="TisonK" />
-        <text name="ft_auto_to_collect" text=" to collect" />
-        <text name="ft_auto_to_enable" text=" to enable" />
-        <text name="ft_auto_to_remove_every_hotspot_from_the_map" text="to remove every hotspot from the map." />
-        <text name="ft_auto_to_show_or_hide_individual_data_rows" text="to show or hide individual data rows.&#10;" />
-        <text name="ft_auto_to_supplement_your_farm_earnings" text="to supplement your farm earnings." />
-        <text name="ft_auto_to_zero_use_at_the_start_of_a_new_job_to_track" text="zu zero. Use at start of ein new job zu track&#10;" />
-        <text name="ft_auto_todo_list" text="TODO LIST" />
-        <text name="ft_auto_todo_list_d_pending_d_done" text="TODO LIST  (%d Stallding · %d done)" />
-        <text name="ft_auto_todos_are_saved_automatically_per_savegame" text="Todos are saved automatically per savegame." />
-        <text name="ft_auto_toggle_tablet" text="Toggle tablet" />
-        <text name="ft_auto_toggles_are_admin_only_and_validated_by_the_host_client" text="Toggles are admin-only and validated by the host. Clients&#10;" />
-        <text name="ft_auto_toggles_the_mod_on_or_off_without_uninstalling_it" text="Toggles the mod on or off without uninstalling it.&#10;" />
-        <text name="ft_auto_tool" text="Tool" />
-        <text name="ft_auto_top_of_the_app_shows_total_receivable_green" text="Top of the app shows total receivable (green)&#10;" />
-        <text name="ft_auto_top_of_the_screen_shows_totals_ready_fields_that_can_be" text="Top of screen shows totals: ERNTEBEREIT Felder that can&#10;be Ernteed, GROW Felder mit crops growing, und LEER&#10;Felder mit no aktiv crop." />
-        <text name="ft_auto_total" text=" total" />
-        <text name="ft_auto_total_earned" text="Total Earned" />
-        <text name="ft_auto_total_paid" text="TOTAL PAID" />
-        <text name="ft_auto_total_paid_2" text="Total Paid" />
-        <text name="ft_auto_total_wages_accumulated_this_month" text="Total wages accumulated this month.&#10;" />
+        <text name="ft_auto_to_collect" text=" zum Abholen" />
+        <text name="ft_auto_to_enable" text=" zum Aktivieren" />
+        <text name="ft_auto_to_remove_every_hotspot_from_the_map" text="...um alle Hotspots von der Karte zu entfernen." />
+        <text name="ft_auto_to_show_or_hide_individual_data_rows" text="...um einzelne Datenzeilen ein- oder auszublenden.&#10;" />
+        <text name="ft_auto_to_supplement_your_farm_earnings" text="...um deine Hofeinnahmen zu ergänzen." />
+        <text name="ft_auto_to_zero_use_at_the_start_of_a_new_job_to_track" text="Auf Null zurücksetzen. Zu Beginn eines neuen Auftrags verwenden, um die Arbeit zu erfassen.&#10;" />
+        <text name="ft_auto_todo_list" text="AUFGABENLISTE" />
+        <text name="ft_auto_todo_list_d_pending_d_done" text="AUFGABENLISTE (%d offen · %d erledigt)" />
+        <text name="ft_auto_todos_are_saved_automatically_per_savegame" text="Aufgaben werden automatisch pro Spielstand gespeichert." />
+        <text name="ft_auto_toggle_tablet" text="Tablet umschalten" />
+        <text name="ft_auto_toggles_are_admin_only_and_validated_by_the_host_client" text="Diese Schalter können nur vom Administrator geändert werden und werden vom Host überprüft.&#10;" />
+        <text name="ft_auto_toggles_the_mod_on_or_off_without_uninstalling_it" text="Schaltet den Mod ein oder aus, ohne ihn zu deinstallieren.&#10;" />
+        <text name="ft_auto_tool" text="Werkzeug" />
+        <text name="ft_auto_top_of_the_app_shows_total_receivable_green" text="Oben in der App wird der gesamte Forderungsbetrag (grün) angezeigt.&#10;" />
+        <text name="ft_auto_top_of_the_screen_shows_totals_ready_fields_that_can_be" text="Oben werden die Gesamtzahlen angezeigt: ERNTEBEREITE Felder, WACHSENDE Felder und LEERE Felder ohne Frucht.&#10;" />
+        <text name="ft_auto_total" text="Gesamt" />
+        <text name="ft_auto_total_earned" text="Gesamte Einnahmen" />
+        <text name="ft_auto_total_paid" text="GESAMT BEZAHLT" />
+        <text name="ft_auto_total_paid_2" text="Gesamt bezahlt" />
+        <text name="ft_auto_total_wages_accumulated_this_month" text="In diesem Monat aufgelaufene Lohnkosten.&#10;" />
         <text name="ft_auto_tour" text="Tour" />
-        <text name="ft_auto_town_reputation" text="TOWN REPUTATION" />
-        <text name="ft_auto_town_reputation_2" text="Town Reputation: " />
-        <text name="ft_auto_tracked_from_the_current_session_since_load" text="Tracked from the current session (since load).&#10;" />
-        <text name="ft_auto_tracks_money_you_owe_others_outgoing_and" text="Tracks money you owe others (OUTGOING) and&#10;" />
-        <text name="ft_auto_trailer" text="Trailer" />
+        <text name="ft_auto_town_reputation" text="RUF DER STADT" />
+        <text name="ft_auto_town_reputation_2" text="Ruf der Stadt: " />
+        <text name="ft_auto_tracked_from_the_current_session_since_load" text="Erfasst seit der aktuellen Spielsitzung (seit dem Laden).&#10;" />
+        <text name="ft_auto_tracks_money_you_owe_others_outgoing_and" text="Erfasst ausgehende Zahlungen sowie Geld, das dir andere schulden.&#10;" />
+        <text name="ft_auto_trailer" text="Anhänger" />
         <text name="ft_auto_transport" text="Transport" />
-        <text name="ft_auto_tree_planting" text="Tree Planting" />
-        <text name="ft_auto_true" text="true" />
-        <text name="ft_auto_type" text="Type " />
-        <text name="ft_auto_type_of_work_hit_confirm_to_begin_timing" text="type of work. Hit Confirm to begin timing.&#10;" />
-        <text name="ft_auto_type_tablet_in_console_for_all_commands" text="Befehl „tablet“ zeigt Konsolenbefehle." />
-        <text name="ft_auto_unavailable" text="unavailable" />
-        <text name="ft_auto_undo" text="UNDO" />
-        <text name="ft_auto_undo_mark_it_pending_again" text="UNDO — mark it Stallding again (□)&#10;" />
-        <text name="ft_auto_unknown" text="Unkjetztn" />
-        <text name="ft_auto_unknown_field" text="Unkjetztn Field" />
-        <text name="ft_auto_unloading" text="Unloading" />
-        <text name="ft_auto_unlock" text="unlock" />
-        <text name="ft_auto_unnamed" text="(unnamed)" />
-        <text name="ft_auto_unpin" text="UNPIN" />
-        <text name="ft_auto_unpinned" text="Unpinned " />
-        <text name="ft_auto_up_to_30_completed_jobs_are_stored_per_savegame" text="Up to 30 completed jobs are stored per savegame.&#10;" />
-        <text name="ft_auto_up_to_6_vehicles_are_shown_at_a_time" text="Up to 6 Fahrzeuge are shown at a time." />
-        <text name="ft_auto_upd" text="UPD" />
-        <text name="ft_auto_update_fs25_soilfertilizer_to_a_build_that_ships_the_br" text="Update FS25_SoilFertilizer to a build that ships the bridge." />
-        <text name="ft_auto_updates" text="Updates" />
-        <text name="ft_auto_updates_2" text="updates" />
-        <text name="ft_auto_updates_live_while_you_work" text="Updates live while you work." />
-        <text name="ft_auto_usage_tabletapp_app_id_e_g_dashboard_weather_animals" text="Usage: TabletApp [app_id] (e.g., dashboard, weather, animals)" />
-        <text name="ft_auto_usage_tabletsetnotifications_true_false" text="Usage: TabletSetNotifications true|false" />
-        <text name="ft_auto_usage_tabletsetstartupapp_app_id_e_g_dashboard_weather" text="Usage: TabletSetStartupApp [app_id] (e.g., dashboard, weather, animals)" />
-        <text name="ft_auto_use_enter_edit_mode_for_visual_drag_and_resize" text="Use BEARBEITUNGSMODUS STARTEN foder visual drag-and-resize,&#10;" />
-        <text name="ft_auto_use_it_to_monitor_depth_while_operating_an_excavator" text="Use it zu Überwachung depth while operating ein excavator." />
+        <text name="ft_auto_tree_planting" text="Bäume pflanzen" />
+        <text name="ft_auto_true" text="Wahr" />
+        <text name="ft_auto_type" text="Typ " />
+        <text name="ft_auto_type_of_work_hit_confirm_to_begin_timing" text="Arbeitsart. Mit BESTÄTIGEN beginnt die Zeiterfassung.&#10;" />
+        <text name="ft_auto_type_tablet_in_console_for_all_commands" text="Gib „tablet“ in der Konsole ein, um alle Befehle anzuzeigen." />
+        <text name="ft_auto_unavailable" text="Nicht verfügbar" />
+        <text name="ft_auto_undo" text="RÜCKGÄNGIG" />
+        <text name="ft_auto_undo_mark_it_pending_again" text="RÜCKGÄNGIG – Aufgabe wieder als offen markieren (□).&#10;" />
+        <text name="ft_auto_unknown" text="Unbekannt" />
+        <text name="ft_auto_unknown_field" text="Unbekanntes Feld" />
+        <text name="ft_auto_unloading" text="Entladen" />
+        <text name="ft_auto_unlock" text="Entsperren" />
+        <text name="ft_auto_unnamed" text="(Unbenannt)" />
+        <text name="ft_auto_unpin" text="LÖSEN" />
+        <text name="ft_auto_unpinned" text="Gelöst" />
+        <text name="ft_auto_up_to_30_completed_jobs_are_stored_per_savegame" text="Bis zu 30 abgeschlossene Aufträge werden pro Spielstand gespeichert.&#10;" />
+        <text name="ft_auto_up_to_6_vehicles_are_shown_at_a_time" text="Es werden maximal sechs Fahrzeuge gleichzeitig angezeigt." />
+        <text name="ft_auto_upd" text="AKT" />
+        <text name="ft_auto_update_fs25_soilfertilizer_to_a_build_that_ships_the_br" text="Aktualisiere FS25_SoilFertilizer auf eine Version mit integrierter Bridge-Unterstützung." />
+        <text name="ft_auto_updates" text="Aktualisierungen" />
+        <text name="ft_auto_updates_2" text="Aktualisierungen" />
+        <text name="ft_auto_updates_live_while_you_work" text="Aktualisiert sich automatisch während der Arbeit." />
+        <text name="ft_auto_usage_tabletapp_app_id_e_g_dashboard_weather_animals" text="Verwendung: TabletApp [App-ID] (z. B. dashboard, weather, animals)" />
+        <text name="ft_auto_usage_tabletsetnotifications_true_false" text="Verwendung: TabletSetNotifications true|false" />
+        <text name="ft_auto_usage_tabletsetstartupapp_app_id_e_g_dashboard_weather" text="Verwendung: TabletSetStartupApp [App-ID] (z. B. dashboard, weather, animals)" />
+        <text name="ft_auto_use_enter_edit_mode_for_visual_drag_and_resize" text="Nutze BEARBEITUNGSMODUS STARTEN, um das Tablet per Ziehen zu verschieben und zu skalieren.&#10;" />
+        <text name="ft_auto_use_it_to_monitor_depth_while_operating_an_excavator" text="Nutze diese Anzeige, um beim Arbeiten mit dem Bagger die Grabtiefe zu überwachen." />
         <text name="ft_auto_use_new_to_create_your_first_invoice" text="Mit + NEU die erste Rechnung erstellen." />
-        <text name="ft_auto_use_the_roleplayphone_app_to_create_invoices" text="Use RoleplayPhone app zu create invoices&#10;" />
-        <text name="ft_auto_use_to_select_a_task_template_and_field" text="Use &lt; / &gt; zu select ein task template und Feld,&#10;" />
-        <text name="ft_auto_use_your_own_image_behind_the_home_and_lock_screens" text="Use dein own image behind home und lock screens.&#10;" />
-        <text name="ft_auto_used" text="USED" />
+        <text name="ft_auto_use_the_roleplayphone_app_to_create_invoices" text="Nutze die RoleplayPhone-App, um Rechnungen zu erstellen.&#10;" />
+        <text name="ft_auto_use_to_select_a_task_template_and_field" text="Mit &lt; / &gt; Aufgabenvorlage und Feld auswählen.&#10;" />
+        <text name="ft_auto_use_your_own_image_behind_the_home_and_lock_screens" text="Verwende eigene Bilder für den Home- und Sperrbildschirm.&#10;" />
+        <text name="ft_auto_used" text="GEBRAUCHT" />
         <text name="ft_auto_used_plus" text="used_plus" />
         <text name="ft_auto_usedplus" text="UsedPlus" />
-        <text name="ft_auto_usedplus_active_sale_listings_and_finance_deals" text="UsedPlus — aktiv Verkaufsangebote und finance deals" />
-        <text name="ft_auto_usedplus_is_not_installed" text="UsedPlus is not installed." />
-        <text name="ft_auto_v2" text="v2" />
-        <text name="ft_auto_values_update_live_as_you_walk_around" text="Values update live as you walk around." />
+        <text name="ft_auto_usedplus_active_sale_listings_and_finance_deals" text="UsedPlus – aktive Verkaufsangebote und Finanzierungsangebote" />
+        <text name="ft_auto_usedplus_is_not_installed" text="UsedPlus ist nicht installiert." />
+        <text name="ft_auto_v2" text="V2" />
+        <text name="ft_auto_values_update_live_as_you_walk_around" text="Die Werte werden beim Herumlaufen laufend aktualisiert." />
         <text name="ft_auto_vehcount" text="vehcount_" />
-        <text name="ft_auto_vehicle" text="VEHICLE" />
-        <text name="ft_auto_vehicle_2" text="Vehicle" />
-        <text name="ft_auto_vehicle_3" text="Vehicle: " />
+        <text name="ft_auto_vehicle" text="FAHRZEUG" />
+        <text name="ft_auto_vehicle_2" text="Fahrzeug" />
+        <text name="ft_auto_vehicle_3" text="Fahrzeug: " />
         <text name="ft_auto_vehicle_4" text="Fahrzeug" />
-        <text name="ft_auto_vehicle_has_no_stable_id_save_once_then_pin" text="Vehicle has no stable id — save once, then PIN" />
-        <text name="ft_auto_vehicle_list" text="VEHICLE LIST" />
-        <text name="ft_auto_vehicle_repossessions_still_run_through_realisticdealer" text="Vehicle repossessions still run through RealisticDealer server-side." />
-        <text name="ft_auto_vehicles" text=" Fahrzeuge" />
+        <text name="ft_auto_vehicle_has_no_stable_id_save_once_then_pin" text="Das Fahrzeug besitzt noch keine dauerhafte ID. Speichere den Spielstand einmal und hefte es anschließend an." />
+        <text name="ft_auto_vehicle_list" text="FAHRZEUGLISTE" />
+        <text name="ft_auto_vehicle_repossessions_still_run_through_realisticdealer" text="Fahrzeugrücknahmen werden weiterhin serverseitig über RealisticDealer abgewickelt." />
+        <text name="ft_auto_vehicles" text="Fahrzeuge" />
         <text name="ft_auto_vehicles_2" text="FAHRZEUGE" />
         <text name="ft_auto_vehicles_3" text="Fahrzeuge" />
         <text name="ft_auto_vehicles_4" text="Fahrzeuge" />
-        <text name="ft_auto_vehicles_d_owned" text="FAHRZEUGE  ·  %d im Besitz" />
-        <text name="ft_auto_vehicles_motorised_vehicles_owned_by_your_farm" text="Fahrzeuge: motorised Fahrzeuge im Besitz by your farm." />
-        <text name="ft_auto_vehicles_motorized_vehicles_owned_by_your_farm" text="Fahrzeuge: motorized Fahrzeuge im Besitz by your farm.&#10;" />
-        <text name="ft_auto_vehicles_nearby" text=" Fahrzeuge nearby" />
-        <text name="ft_auto_vehicles_you_have_listed_for_sale_through_a_usedplus" text="Fahrzeuge you have listed for sale through a UsedPlus&#10;" />
+        <text name="ft_auto_vehicles_d_owned" text="FAHRZEUGE · %d im Besitz" />
+        <text name="ft_auto_vehicles_motorised_vehicles_owned_by_your_farm" text="Motorisierte Fahrzeuge im Besitz deines Hofes." />
+        <text name="ft_auto_vehicles_motorized_vehicles_owned_by_your_farm" text="Motorisierte Fahrzeuge im Besitz deines Hofes.&#10;" />
+        <text name="ft_auto_vehicles_nearby" text="Fahrzeuge in der Nähe" />
+        <text name="ft_auto_vehicles_you_have_listed_for_sale_through_a_usedplus" text="Fahrzeuge, die über UsedPlus zum Verkauf angeboten werden.&#10;" />
         <text name="ft_auto_version" text="Version" />
-        <text name="ft_auto_version_developer" text="VERSION / DEVELOPER" />
-        <text name="ft_auto_version_entries" text="VERSION ENTRIES" />
-        <text name="ft_auto_vet" text="VET" />
-        <text name="ft_auto_vet_2" text="Vet" />
-        <text name="ft_auto_veterinarian" text="Veterinarian" />
+        <text name="ft_auto_version_developer" text="VERSION / ENTWICKLER" />
+        <text name="ft_auto_version_entries" text="VERSIONSEINTRÄGE" />
+        <text name="ft_auto_vet" text="TIERARZT" />
+        <text name="ft_auto_vet_2" text="Tierarzt" />
+        <text name="ft_auto_veterinarian" text="Tierarzt" />
         <text name="ft_auto_view_and_remove_map_hotspots" text="Karten-Hotspots anzeigen und entfernen" />
-        <text name="ft_auto_view_only_admin_needed" text="View only (admin needed)" />
-        <text name="ft_auto_visible" text="Visible" />
-        <text name="ft_auto_visible_2" text="visible" />
-        <text name="ft_auto_visit_npc_on_map_to_collect_reward" text="Visit NPC on map to collect reward" />
-        <text name="ft_auto_visit_shop" text="Visit shop" />
-        <text name="ft_auto_visit_the_npc_on_the_map_to_dismiss_and_collect" text="Visit the NPC on the map to dismiss and collect&#10;" />
-        <text name="ft_auto_visual_fill_bar_below_each_row" text="Visual fill bar below each row.&#10;" />
+        <text name="ft_auto_view_only_admin_needed" text="Nur Ansicht (Administrator erforderlich)" />
+        <text name="ft_auto_visible" text="Sichtbar" />
+        <text name="ft_auto_visible_2" text="sichtbar" />
+        <text name="ft_auto_visit_npc_on_map_to_collect_reward" text="Besuche den NPC auf der Karte, um deine Belohnung abzuholen." />
+        <text name="ft_auto_visit_shop" text="Shop besuchen" />
+        <text name="ft_auto_visit_the_npc_on_the_map_to_dismiss_and_collect" text="Besuche den NPC auf der Karte, um den Auftrag abzuschließen und die Belohnung abzuholen.&#10;" />
+        <text name="ft_auto_visual_fill_bar_below_each_row" text="Unter jeder Zeile wird ein grafischer Füllbalken angezeigt.&#10;" />
         <text name="ft_auto_w" text="%W" />
-        <text name="ft_auto_wage_level" text="WAGE LEVEL" />
-        <text name="ft_auto_wage_level_2" text="Wage Level" />
-        <text name="ft_auto_wage_structure" text="WAGE STRUCTURE" />
-        <text name="ft_auto_wage_structure_the_running_cost_estimate_and" text="Wage structure, the running cost estimate, and&#10;" />
-        <text name="ft_auto_wages_accrued" text="Wages Accrued" />
-        <text name="ft_auto_wait_for_fields_to_initialize" text="Wait foder Felder zu initialize." />
-        <text name="ft_auto_wake" text="WAKE" />
-        <text name="ft_auto_wake_2" text="wake" />
-        <text name="ft_auto_walk_closer_to_a_machine_to_see_it_in_the_list" text="Walk closer to a machine to see it in the list.&#10;" />
-        <text name="ft_auto_walk_closer_to_a_vehicle_to_inspect_it" text="Walk closer to a Fahrzeug to inspect it." />
-        <text name="ft_auto_walk_to_scan_terrain_elevation" text="Gehe zum Scannen der Geländehöhe." />
-        <text name="ft_auto_wall" text="wall" />
+        <text name="ft_auto_wage_level" text="LOHNSTUFE" />
+        <text name="ft_auto_wage_level_2" text="Lohnstufe" />
+        <text name="ft_auto_wage_structure" text="LOHNSTRUKTUR" />
+        <text name="ft_auto_wage_structure_the_running_cost_estimate_and" text="Lohnstruktur, geschätzte laufende Kosten und weitere Informationen.&#10;" />
+        <text name="ft_auto_wages_accrued" text="Aufgelaufene Lohnkosten" />
+        <text name="ft_auto_wait_for_fields_to_initialize" text="Warte, bis die Felder initialisiert wurden." />
+        <text name="ft_auto_wake" text="AKTIV" />
+        <text name="ft_auto_wake_2" text="Aktiv" />
+        <text name="ft_auto_walk_closer_to_a_machine_to_see_it_in_the_list" text="Gehe näher an eine Maschine heran, damit sie in der Liste erscheint.&#10;" />
+        <text name="ft_auto_walk_closer_to_a_vehicle_to_inspect_it" text="Gehe näher an ein Fahrzeug heran, um es zu untersuchen." />
+        <text name="ft_auto_walk_to_scan_terrain_elevation" text="Gehe umher, um die Geländehöhe zu erfassen." />
+        <text name="ft_auto_wall" text="Wand" />
         <text name="ft_auto_warm" text="Warm" />
-        <text name="ft_auto_warm_32_hot_32" text="Warm (&lt;32)  Hot (32+)." />
-        <text name="ft_auto_warm_dark" text="Warm Dark" />
+        <text name="ft_auto_warm_32_hot_32" text="Warm (&lt;32) · Heiß (32+)." />
+        <text name="ft_auto_warm_dark" text="Warm dunkel" />
         <text name="ft_auto_water" text="WASSER" />
-        <text name="ft_auto_water_bar" text="WASSER BAR" />
-        <text name="ft_auto_water_crops" text="Wasser crops" />
+        <text name="ft_auto_water_bar" text="WASSERBALKEN" />
+        <text name="ft_auto_water_crops" text="Feldfrüchte bewässern" />
         <text name="ft_auto_water_d" text="WASSER  %d%%" />
-        <text name="ft_auto_we_will_notify_you_when_the_repair_is_finished" text="We will notify du when reparieren is finished." />
-        <text name="ft_auto_weak" text="Weak" />
-        <text name="ft_auto_weak_2" text="weak" />
-        <text name="ft_auto_weak_reception" text="Weak reception." />
-        <text name="ft_auto_weak_signal" text="Weak signal" />
-        <text name="ft_auto_wear" text="WEAR" />
-        <text name="ft_auto_wear_2" text="Wear" />
-        <text name="ft_auto_wear_bar" text="WEAR BAR" />
+        <text name="ft_auto_we_will_notify_you_when_the_repair_is_finished" text="Du wirst benachrichtigt, sobald die Reparatur abgeschlossen ist." />
+        <text name="ft_auto_weak" text="Schwach" />
+        <text name="ft_auto_weak_2" text="schwach" />
+        <text name="ft_auto_weak_reception" text="Schwacher Empfang." />
+        <text name="ft_auto_weak_signal" text="Schwaches Signal" />
+        <text name="ft_auto_wear" text="VERSCHLEISS" />
+        <text name="ft_auto_wear_2" text="Verschleiß" />
+        <text name="ft_auto_wear_bar" text="VERSCHLEISSBALKEN" />
         <text name="ft_auto_weather" text="Wetter" />
-        <text name="ft_auto_weather_2" text="weather" />
-        <text name="ft_auto_weather_data_unavailable" text="Wetter data unavailable." />
-        <text name="ft_auto_weather_hero_card_with_condition_icon" text="Wetter hero card with condition icon" />
-        <text name="ft_auto_weeding" text="Weeding" />
-        <text name="ft_auto_weekly_once_per_in_game_week" text="Weekly = once per in-game week." />
-        <text name="ft_auto_weight" text="WEIGHT" />
-        <text name="ft_auto_weight_total_material_moved_in_tonnes" text="WEIGHT = total material moved in tonnes.&#10;" />
-        <text name="ft_auto_welcome_tap_an_app_to_begin" text="Welcome! Tap an app to begin." />
-        <text name="ft_auto_what_counts_as_a_silo" text="WHAT COUNTS AS A SILO?" />
-        <text name="ft_auto_what_is_the_app_store" text="WHAT IS THE APP STORE" />
-        <text name="ft_auto_what_is_this" text="WHAT IS THIS?" />
-        <text name="ft_auto_what_is_this_app" text="WHAT IS THIS APP" />
-        <text name="ft_auto_what_this_app_does" text="WHAT THIS APP DOES" />
-        <text name="ft_auto_what_this_app_shows" text="WHAT THIS APP SHOWS" />
-        <text name="ft_auto_what_this_is" text="WHAT THIS IS" />
+        <text name="ft_auto_weather_2" text="Wetter" />
+        <text name="ft_auto_weather_data_unavailable" text="Wetterdaten nicht verfügbar." />
+        <text name="ft_auto_weather_hero_card_with_condition_icon" text="Wetterkarte mit Wettersymbol" />
+        <text name="ft_auto_weeding" text="Unkrautbekämpfung" />
+        <text name="ft_auto_weekly_once_per_in_game_week" text="Wöchentlich = einmal pro Ingame-Woche." />
+        <text name="ft_auto_weight" text="GEWICHT" />
+        <text name="ft_auto_weight_total_material_moved_in_tonnes" text="GEWICHT = insgesamt bewegtes Material in Tonnen.&#10;" />
+        <text name="ft_auto_welcome_tap_an_app_to_begin" text="Willkommen! Tippe auf eine App, um zu beginnen." />
+        <text name="ft_auto_what_counts_as_a_silo" text="WAS ZÄHLT ALS SILO?" />
+        <text name="ft_auto_what_is_the_app_store" text="WAS IST DER APP STORE?" />
+        <text name="ft_auto_what_is_this" text="WAS IST DAS?" />
+        <text name="ft_auto_what_is_this_app" text="WAS IST DIESE APP?" />
+        <text name="ft_auto_what_this_app_does" text="WAS DIESE APP MACHT" />
+        <text name="ft_auto_what_this_app_shows" text="WAS DIESE APP ANZEIGT" />
+        <text name="ft_auto_what_this_is" text="WAS DAS IST" />
         <text name="ft_auto_wheat" text="WEIZEN" />
-        <text name="ft_auto_wheelloader" text="wheelloader" />
-        <text name="ft_auto_when_an_event_is_running_fire_flood_drought" text="When ein Ereignis is running (fire, flood, drought,&#10;" />
-        <text name="ft_auto_when_off_all_sub_toggles_are_also_silenced" text="When off all sub-toggles are also silenced.&#10;" />
-        <text name="ft_auto_when_that_mod_is_installed" text="when that mod is installed." />
-        <text name="ft_auto_when_you_are_driving_a_vehicle_its_name_and_current" text="When you are driving a Fahrzeug its name and current&#10;" />
-        <text name="ft_auto_when_you_walk_away_click_unpin_to_release_it" text="when du walk away. Klicken UNANHEFTEN zu release it." />
-        <text name="ft_auto_whenever_a_savegame_loads_turn_off_to_keep_things" text="whenever a savegame loads. Turn off to keep things&#10;" />
-        <text name="ft_auto_while_it_is_open_no_need_to_reopen_it" text="while it is oStall — no need to reoStall it.&#10;" />
-        <text name="ft_auto_white" text="Weiss" />
-        <text name="ft_auto_white_clear_dark_fog" text="white = clear, dark = fog." />
+        <text name="ft_auto_wheelloader" text="Radlader" />
+        <text name="ft_auto_when_an_event_is_running_fire_flood_drought" text="Wenn ein Ereignis läuft (Feuer, Überschwemmung, Dürre,&#10;" />
+        <text name="ft_auto_when_off_all_sub_toggles_are_also_silenced" text="Wenn deaktiviert, werden auch alle Unteroptionen stummgeschaltet.&#10;" />
+        <text name="ft_auto_when_that_mod_is_installed" text="wenn dieser Mod installiert ist." />
+        <text name="ft_auto_when_you_are_driving_a_vehicle_its_name_and_current" text="Wenn du ein Fahrzeug fährst, werden dessen Name und aktuelle&#10;" />
+        <text name="ft_auto_when_you_walk_away_click_unpin_to_release_it" text="Wenn du weggehst, klicke auf ENTFERNEN, um es zu lösen." />
+        <text name="ft_auto_whenever_a_savegame_loads_turn_off_to_keep_things" text="bei jedem Laden eines Spielstands. Deaktiviere es, um Dinge&#10;" />
+        <text name="ft_auto_while_it_is_open_no_need_to_reopen_it" text="solange es geöffnet ist – kein erneutes Öffnen erforderlich.&#10;" />
+        <text name="ft_auto_white" text="Weiß" />
+        <text name="ft_auto_white_clear_dark_fog" text="Weiß = klar, dunkel = Nebel." />
         <text name="ft_auto_wiederhergestellt" text="wiederhergestellt" />
         <text name="ft_auto_wind" text="WIND" />
-        <text name="ft_auto_wind_speed" text="Wind Speed" />
-        <text name="ft_auto_wind_speed_in_km_h_and_compass_direction" text="Wind speed in km/h and compass direction.&#10;" />
+        <text name="ft_auto_wind_speed" text="Windgeschwindigkeit" />
+        <text name="ft_auto_wind_speed_in_km_h_and_compass_direction" text="Windgeschwindigkeit in km/h und Himmelsrichtung.&#10;" />
         <text name="ft_auto_winter" text="Winter" />
-        <text name="ft_auto_withered" text="Withered" />
-        <text name="ft_auto_withered_2" text="withered" />
-        <text name="ft_auto_without_admin_see_the_list_read_only" text="without admin see the list read-only." />
-        <text name="ft_auto_without_it_use_the_built_in_invoice_system" text="Without it, use built-in invoice system." />
-        <text name="ft_auto_worker" text="Worker" />
+        <text name="ft_auto_withered" text="Verwelkt" />
+        <text name="ft_auto_withered_2" text="verwelkt" />
+        <text name="ft_auto_without_admin_see_the_list_read_only" text="Ohne Administratorrechte kann die Liste nur gelesen werden." />
+        <text name="ft_auto_without_it_use_the_built_in_invoice_system" text="Ohne dies nutze das integrierte Rechnungssystem." />
+        <text name="ft_auto_worker" text="Arbeiter" />
         <text name="ft_auto_worker_2" text="Arbeiter" />
         <text name="ft_auto_worker_costs" text="Arbeiterkosten" />
-        <text name="ft_auto_worker_costs_2" text="worker_costs" />
-        <text name="ft_auto_worker_costs_is_not_installed" text="Worker Costs is not installed." />
-        <text name="ft_auto_worker_to_the_vehicle_you_re_driving_or_fire" text="Arbeiter zu Fahrzeug you're driving, oder FIRE&#10;" />
-        <text name="ft_auto_worker_wages_and_cost_breakdown" text="Worker wages and cost breakdown" />
-        <text name="ft_auto_workers" text="Workers" />
-        <text name="ft_auto_workers_and_month_to_date_costs" text="Arbeiter, und month-to-date costs.&#10;" />
-        <text name="ft_auto_workers_from_the_in_game_roster_panel_alt_h" text="Arbeiter von in-game roster panel (ALT+H)&#10;" />
-        <text name="ft_auto_working" text="Working" />
-        <text name="ft_auto_working_2" text="working" />
-        <text name="ft_auto_working_now" text="Working Now" />
+        <text name="ft_auto_worker_costs_2" text="arbeiterkosten" />
+        <text name="ft_auto_worker_costs_is_not_installed" text="Worker Costs ist nicht installiert." />
+        <text name="ft_auto_worker_to_the_vehicle_you_re_driving_or_fire" text="Arbeiter zum Fahrzeug, das du fährst, oder FEUER&#10;" />
+        <text name="ft_auto_worker_wages_and_cost_breakdown" text="Löhne und Kostenaufstellung der Arbeiter" />
+        <text name="ft_auto_workers" text="Arbeiter" />
+        <text name="ft_auto_workers_and_month_to_date_costs" text="Arbeiter und bisherige Monatskosten.&#10;" />
+        <text name="ft_auto_workers_from_the_in_game_roster_panel_alt_h" text="Arbeiter aus der Ingame-Personalübersicht (ALT+H)&#10;" />
+        <text name="ft_auto_working" text="Arbeitet" />
+        <text name="ft_auto_working_2" text="arbeitet" />
+        <text name="ft_auto_working_now" text="Aktuell aktiv" />
         <text name="ft_auto_workshop" text="Werkstatt" />
-        <text name="ft_auto_workshop_2" text="workshop" />
-        <text name="ft_auto_workshop_vehicle_selection_with_diagnostics" text="Werkstatt: Fahrzeug selection with diagnostics" />
-        <text name="ft_auto_world" text="WORLD" />
-        <text name="ft_auto_world_2" text="world" />
-        <text name="ft_auto_world_data" text="World data" />
-        <text name="ft_auto_world_events" text="WORLD EVENTS" />
-        <text name="ft_auto_world_events_2" text="World Events" />
-        <text name="ft_auto_writes_verbose_diagnostic_messages_to_the_developer" text="Writes verbose diagnostic messages to the developer&#10;" />
+        <text name="ft_auto_workshop_2" text="werkstatt" />
+        <text name="ft_auto_workshop_vehicle_selection_with_diagnostics" text="Werkstatt: Fahrzeugauswahl mit Diagnose" />
+        <text name="ft_auto_world" text="WELT" />
+        <text name="ft_auto_world_2" text="Welt" />
+        <text name="ft_auto_world_data" text="Weltdaten" />
+        <text name="ft_auto_world_events" text="WELTEREIGNISSE" />
+        <text name="ft_auto_world_events_2" text="Weltereignisse" />
+        <text name="ft_auto_writes_verbose_diagnostic_messages_to_the_developer" text="Schreibt ausführliche Diagnosemeldungen für den Entwickler.&#10;" />
         <text name="ft_auto_wrk" text="WRK" />
         <text name="ft_auto_wth" text="WTH" />
         <text name="ft_auto_x_2f_y_2f" text="X: %.2f  Y: %.2f" />
-        <text name="ft_auto_x_east_west_y_elevation_z_north_south" text="X = east-west  |  Y = elevation  |  Z = north-south.&#10;" />
-        <text name="ft_auto_yes" text="YES" />
-        <text name="ft_auto_yes_2" text="Yes" />
-        <text name="ft_auto_you_can_remove_individual_entries_or_clear_all" text="You can remove individual entries or clear all.&#10;&#10;" />
-        <text name="ft_auto_you_don_t_own_any_fields" text="You don't own any Felder." />
-        <text name="ft_auto_you_don_t_own_any_fields_yet" text="You don't own any Felder yet." />
-        <text name="ft_auto_your_farm_in_the_vehicle_settings" text="your farm in the Fahrzeug settings." />
-        <text name="ft_auto_your_farm_s_total_available_money" text="Your farm's total available money.&#10;" />
-        <text name="ft_auto_your_farm_s_usedplus_credit_rating" text="Your farm's UsedPlus credit rating.&#10;" />
-        <text name="ft_auto_your_hired_workers_with_their_level" text="Your hired Arbeiter mit their Stufe&#10;" />
-        <text name="ft_auto_your_reward" text="your reward." />
-        <text name="ft_auto_your_silo_capacity" text="your silo capacity." />
+        <text name="ft_auto_x_east_west_y_elevation_z_north_south" text="X = Ost-West  |  Y = Höhe  |  Z = Nord-Süd.&#10;" />
+        <text name="ft_auto_yes" text="JA" />
+        <text name="ft_auto_yes_2" text="Ja" />
+        <text name="ft_auto_you_can_remove_individual_entries_or_clear_all" text="Du kannst einzelne Einträge entfernen oder alle löschen.&#10;&#10;" />
+        <text name="ft_auto_you_don_t_own_any_fields" text="Du besitzt keine Felder." />
+        <text name="ft_auto_you_don_t_own_any_fields_yet" text="Du besitzt noch keine Felder." />
+        <text name="ft_auto_your_farm_in_the_vehicle_settings" text="dein Hof in den Fahrzeugeinstellungen." />
+        <text name="ft_auto_your_farm_s_total_available_money" text="Das insgesamt verfügbare Geld deines Hofes.&#10;" />
+        <text name="ft_auto_your_farm_s_usedplus_credit_rating" text="Die UsedPlus-Kreditbewertung deines Hofes.&#10;" />
+        <text name="ft_auto_your_hired_workers_with_their_level" text="Deine angestellten Arbeiter mit ihrer Stufe.&#10;" />
+        <text name="ft_auto_your_reward" text="deine Belohnung." />
+        <text name="ft_auto_your_silo_capacity" text="deine Silokapazität." />
         <text name="ft_lockscreen_date_day" text="%s  -  Tag %d" />
         <text name="ft_dynamic_day" text="Tag %d" />
-        <text name="ft_dynamic_started_day_at" text="Gestartet Tag %d um %s" />
+        <text name="ft_dynamic_started_day_at" text="Gestartet: Tag %d um %s" />
         <text name="ft_count_pen" text="%d Stall" />
         <text name="ft_count_pens" text="%d Ställe" />
         <text name="ft_count_field" text="%d Feld" />
@@ -2253,12 +2253,12 @@
         <text name="ft_count_job" text="%d Auftrag" />
         <text name="ft_count_jobs" text="%d Aufträge" />
         <text name="ft_auto_straw_clean" text="STROH/SAUBER" />
-        <text name="ft_auto_animal_cow" text="Kühe" />
+        <text name="ft_auto_animal_cow" text="Kuh" />
         <text name="ft_auto_animal_cows" text="Kühe" />
         <text name="ft_auto_animal_pig" text="Schwein" />
         <text name="ft_auto_animal_pigs" text="Schweine" />
-        <text name="ft_auto_animal_sheep" text="Schafe" />
-        <text name="ft_auto_animal_chicken" text="Hühner" />
+        <text name="ft_auto_animal_sheep" text="Schaf" />
+        <text name="ft_auto_animal_chicken" text="Huhn" />
         <text name="ft_auto_animal_chickens" text="Hühner" />
         <text name="ft_auto_animal_horse" text="Pferd" />
         <text name="ft_auto_animal_horses" text="Pferde" />
@@ -2270,22 +2270,22 @@
         <text name="ft_auto_sugarbeet" text="ZUCKERRÜBEN" />
         <text name="ft_auto_cotton" text="BAUMWOLLE" />
         <text name="ft_animals_help_pen_cards_title" text="STALL-KARTEN" />
-        <text name="ft_animals_help_pen_cards_body" text="Jede Karte zeigt Tierart, aktuelle Anzahl und&#10;Stallkapazität (z. B. Kühe  (12 / 20)).&#10;Leere Ställe werden abgedunkelt angezeigt." />
+        <text name="ft_animals_help_pen_cards_body" text="Jede Karte zeigt Tierart, aktuelle Anzahl und&#10;Stallkapazität (z. B. Kühe (12 / 20)).&#10;Leere Ställe werden abgedunkelt dargestellt." />
         <text name="ft_animals_help_food_title" text="FUTTERBALKEN" />
-        <text name="ft_animals_help_food_body" text="Prozentualer Füllstand des Futtertrogs.&#10;Grün &gt;= 60%  |  Gelb &gt;= 25%  |  Rot &lt; 25%.&#10;Vor dem roten Bereich nachfüllen, damit die Produktivität erhalten bleibt." />
+        <text name="ft_animals_help_food_body" text="Prozentualer Füllstand des Futtertrogs.&#10;Grün &gt;= 60%  |  Gelb &gt;= 25%  |  Rot &lt; 25%.&#10;Vor Erreichen des roten Bereichs nachfüllen, damit die Produktivität erhalten bleibt." />
         <text name="ft_animals_help_water_title" text="WASSERBALKEN" />
         <text name="ft_animals_help_water_body" text="Prozentualer Füllstand des Wassertrogs.&#10;Gleiche Farbschwellen wie beim Futter.&#10;Tiere ohne Wasser verlieren schnell Produktivität." />
         <text name="ft_animals_help_straw_title" text="STROH-/SAUBERKEITSBALKEN" />
-        <text name="ft_animals_help_straw_body" text="Zeigt die Sauberkeit des Stalls — Strohstand bei Schweinen und Kühen,&#10;Sauberkeit bei Hühnern und Schafen.&#10;Niedrige Sauberkeit reduziert Ertrag und Tierwohl." />
+        <text name="ft_animals_help_straw_body" text="Zeigt die Sauberkeit des Stalls — Strohstand bei Schweinen und Kühen,&#10;Sauberkeit bei Hühnern und Schafen.&#10;Geringe Sauberkeit reduziert Ertrag und Tierwohl." />
         <text name="ft_animals_help_productivity_title" text="PRODUKTIVITÄT" />
-        <text name="ft_animals_help_productivity_body" text="Die gesamte Tierproduktivität hängt von Futter, Wasser&#10;und Sauberkeit zusammen ab. Halte alle drei Balken grün,&#10;um Milch, Eier, Wolle und Mist zu maximieren." />
+        <text name="ft_animals_help_productivity_body" text="Die gesamte Tierproduktivität hängt von Futter, Wasser&#10;und Sauberkeit ab. Halte alle drei Balken grün,&#10;um Milch, Eier, Wolle und Mist zu maximieren." />
         <text name="ft_animals_no_pens" text="Keine Tierställe im Besitz." />
         <text name="ft_animals_purchase_pen" text="Kaufe einen Stall, um Tiere zu halten." />
         <text name="ft_common_empty_lower" text="leer" />
         <text name="ft_animals_food_pct" text="FUTTER  %d%%" />
         <text name="ft_animals_water_pct" text="WASSER  %d%%" />
         <text name="ft_animals_straw_clean_pct" text="STROH/SAUBER  %d%%" />
-        <text name="ft_editmode_hint" text="Tablet-Bearbeitungsmodus: mit linker Maustaste ziehen, mit ENTER speichern, mit ESC abbrechen" />
+        <text name="ft_editmode_hint" text="Tablet-Bearbeitungsmodus: Mit linker Maustaste ziehen, mit ENTER speichern, mit ESC abbrechen" />
         <text name="ft_animals_clean_pct" text="SAUBERKEIT  %d%%" />
         <text name="ft_count_building" text="%d Gebäude" />
         <text name="ft_count_buildings" text="%d Gebäude" />
@@ -2298,9 +2298,9 @@
         <text name="ft_help_settings_display_title" text="ANZEIGE - POSITION &amp; GRÖSSE" />
         <text name="ft_help_settings_display_body" text="Zeigt Position und Größe des Tablets. Im Bearbeitungsmodus kannst du es verschieben oder skalieren." />
         <text name="ft_help_settings_edit_title" text="BEARBEITUNGSMODUS" />
-        <text name="ft_help_settings_edit_body" text="Tablet verschieben und skalieren. Rechtsklick oder Esc beendet den Modus." />
+        <text name="ft_help_settings_edit_body" text="Verschieben und Skalieren des Tablets. Rechtsklick oder ESC beendet den Modus." />
         <text name="ft_help_settings_bg_title" text="HINTERGRUNDFARBE" />
-        <text name="ft_help_settings_bg_body" text="Ändert die Bildschirmfarbe des Tablets. Klicken wechselt die Vorlagen." />
+        <text name="ft_help_settings_bg_body" text="Ändert die Bildschirmfarbe des Tablets. Klicken: Vorlage wechseln." />
         <text name="ft_help_settings_homebg_title" text="HOME-HINTERGRUND" />
         <text name="ft_help_settings_homebg_body" text="Nutzt PNG-Bilder aus savegame/FTBackground als Hintergrund." />
         <text name="ft_help_settings_sound_title" text="TONEFFEKTE" />
@@ -2308,11 +2308,11 @@
         <text name="ft_help_settings_start_title" text="START-APP" />
         <text name="ft_help_settings_start_body" text="Legt fest, welche App beim Öffnen zuerst angezeigt wird." />
         <text name="ft_help_settings_notif_title" text="MELDUNGEN" />
-        <text name="ft_help_settings_notif_body" text="Zeigt oder versteckt Tablet-Meldungen beim Laden des Savegames." />
+        <text name="ft_help_settings_notif_body" text="Zeigt oder versteckt Tablet-Meldungen beim Laden des Spielstands." />
         <text name="ft_help_settings_debug_title" text="DEBUG-MODUS" />
         <text name="ft_help_settings_debug_body" text="Schreibt zusätzliche Diagnosemeldungen in Log und Konsole." />
         <text name="ft_help_settings_reset_title" text="WERKSEINSTELLUNGEN" />
-        <text name="ft_help_settings_reset_body" text="Setzt alle Tablet-Einstellungen auf Standardwerte zurück." />
+        <text name="ft_help_settings_reset_body" text="Setzt alle Tablet-Einstellungen auf die Standardwerte zurück." />
         <text name="ft_settings_edit_stop" text="Bearbeitung beenden" />
         <text name="ft_settings_edit_position" text="Position bearbeiten" />
         <text name="ft_settings_reset_position" text="Position zurücksetzen" />
@@ -2334,7 +2334,7 @@
         <text name="ft_settings_text_size" text="Textgröße: %s" />
         <text name="ft_settings_hint_text_size" text="Klicken: Textgröße wechseln" />
         <text name="ft_settings_text_color" text="Textfarbe: %s" />
-        <text name="ft_settings_hint_text_color" text="Klicken: Weiß, Gold oder App-Farbe" />
+        <text name="ft_settings_hint_text_color" text="Klicken: Weiß, Gold oder App-Farbe auswählen" />
         <text name="ft_settings_sound_effects_on" text="Töne: An" />
         <text name="ft_settings_sound_effects_off" text="Töne: Aus" />
         <text name="ft_settings_app_sound_on" text="App-Ton: An" />
@@ -2348,7 +2348,7 @@
         <text name="ft_settings_hint_tablet_sound" text="Ton beim Öffnen/Schließen mit T" />
         <text name="ft_settings_notifications_on" text="Meldungen: An" />
         <text name="ft_settings_notifications_off" text="Meldungen: Aus" />
-        <text name="ft_settings_hint_notifications" text="Meldung beim Laden eines Savegames" />
+        <text name="ft_settings_hint_notifications" text="Meldung beim Laden eines Spielstands" />
         <text name="ft_settings_start_app" text="Start-App: %s" />
         <text name="ft_settings_hint_start_app" text="Klicken: Start-App wechseln" />
         <text name="ft_settings_debug_on" text="Debug: An" />
@@ -2367,11 +2367,11 @@
         <text name="ft_settings_help_display_title" text="ANZEIGE" />
         <text name="ft_settings_help_display_body" text="Tablet-Position, Größe, Hintergrund und App-Beschriftungen." />
         <text name="ft_settings_help_sound_title" text="TON" />
-        <text name="ft_settings_help_sound_body2" text="Schaltet Tablet-Töne einzeln oder komplett ein und aus." />
+        <text name="ft_settings_help_sound_body2" text="Schaltet Tablet-Töne einzeln oder vollständig ein und aus." />
         <text name="ft_settings_help_network_title" text="NETZWERK" />
-        <text name="ft_settings_help_network_body" text="Anbieter, Empfang, Netzstörungen und Displayreparaturen." />
+        <text name="ft_settings_help_network_body" text="Anbieter, Empfang, Netzstörungen und Display-Reparaturen." />
         <text name="ft_settings_help_scroll_title" text="SCROLLEN" />
-        <text name="ft_settings_help_scroll_body" text="Mausrad über dem Tablet-Fenster benutzen, um die Einstellungen zu scrollen." />
+        <text name="ft_settings_help_scroll_body" text="Mausrad über dem Tablet-Fenster verwenden, um durch die Einstellungen zu scrollen." />
         <text name="ft_common_active" text="Aktiv" />
         <text name="ft_common_reset" text="Zurücksetzen" />
         <text name="ft_common_change" text="Ändern" />
@@ -2388,7 +2388,7 @@
         <text name="ft_settings_background_color" text="Hintergrundfarbe" />
         <text name="ft_settings_hint_screen_color2" text="Wechselt die Bildschirmfarbe des Tablets." />
         <text name="ft_settings_home_image_title" text="Home-Bild" />
-        <text name="ft_settings_hint_home_image" text="Eigene PNG-Dateien aus dem Ordner FTBackground nutzen." />
+        <text name="ft_settings_hint_home_image" text="Eigene PNG-Dateien aus dem Ordner FTBackground verwenden." />
         <text name="ft_settings_app_labels" text="App-Beschriftungen" />
         <text name="ft_settings_text_size_title" text="Textgröße" />
         <text name="ft_settings_content_font_title" text="App-Textgröße" />
@@ -2410,9 +2410,9 @@
         <text name="ft_settings_general" text="Allgemein" />
         <text name="ft_settings_notifications" text="Meldungen" />
         <text name="ft_settings_start_app_title" text="Start-App" />
-        <text name="ft_settings_hint_start_app2" text="Diese App öffnet zuerst nach dem Entsperren." />
+        <text name="ft_settings_hint_start_app2" text="Diese App öffnet sich zuerst nach dem Entsperren." />
         <text name="ft_settings_debug_mode" text="Debug-Modus" />
-        <text name="ft_settings_hint_debug2" text="Schreibt zusätzliche Diagnosemeldungen in die Log." />
+        <text name="ft_settings_hint_debug2" text="Schreibt zusätzliche Diagnosemeldungen in das Log." />
         <text name="ft_settings_network_repair" text="Netzwerk und Reparatur" />
         <text name="ft_settings_outage" text="Störung" />
         <text name="ft_settings_daily_fee" text="Grundgebühr" />
@@ -2424,49 +2424,49 @@
         <text name="ft_settings_provider_selection" text="Anbieterauswahl" />
         <text name="ft_settings_apps_loaded" text="Apps geladen" />
         <text name="ft_settings_open_key" text="Öffnen-Taste" />
-        <text name="ft_settings_scroll_help" text="Mausrad über diesem Fenster scrollt die Einstellungen." />
-        <text name="ft_settings_console_help" text="Befehl „tablet“ zeigt Konsolenbefehle." />
+        <text name="ft_settings_scroll_help" text="Mausrad über diesem Fenster verwenden, um durch die Einstellungen zu scrollen." />
+        <text name="ft_settings_console_help" text="Der Befehl „tablet“ zeigt die Konsolenbefehle." />
         <text name="ft_settings_reset_section" text="Zurücksetzen" />
         <text name="ft_settings_all_settings" text="Alle Einstellungen" />
         <text name="ft_settings_default_values" text="Standardwerte" />
         <text name="ft_settings_hint_reset_all" text="Setzt alle Tablet-Einstellungen zurück." />
         <text name="ft_updates_help_history_title" text="VERSIONSVERLAUF" />
-        <text name="ft_updates_help_history_body" text="Zeigt die Änderungen des FarmTablets nach Versionen sortiert." />
+        <text name="ft_updates_help_history_body" text="Zeigt die Änderungen des FarmTablets nach Versionen sortiert an." />
         <text name="ft_updates_help_structure_title" text="AUFBAU" />
-        <text name="ft_updates_help_structure_body" text="Jede Version ist in Neu, Verbessert und Behoben aufgeteilt." />
+        <text name="ft_updates_help_structure_body" text="Jede Version ist in Neu, Verbessert und Behoben unterteilt." />
         <text name="ft_updates_version_history" text="Versionsverlauf" />
         <text name="ft_updates_version" text="Version" />
         <text name="ft_updates_new" text="Neu" />
         <text name="ft_updates_improved" text="Verbessert" />
         <text name="ft_updates_fixed" text="Behoben" />
         <text name="ft_changelog_251_new_1" text="Favoriten-Seite für häufig genutzte Apps" />
-        <text name="ft_changelog_251_new_2" text="App-Auswahl für Favoriten wird pro Spielstand gespeichert" />
-        <text name="ft_changelog_251_new_3" text="klarere Home- und Zurück-Schaltflächen" />
+        <text name="ft_changelog_251_new_2" text="Die App-Auswahl für Favoriten wird pro Spielstand gespeichert" />
+        <text name="ft_changelog_251_new_3" text="Klarere Home- und Zurück-Schaltflächen" />
         <text name="ft_changelog_251_new_4" text="App-Beschriftungen können in den Einstellungen angepasst werden" />
         <text name="ft_changelog_251_imp_1" text="Statusleiste mit Akku, Signal und Uhrzeit überarbeitet" />
-        <text name="ft_changelog_251_imp_2" text="App-Icons optimiert und sauberer geladen" />
-        <text name="ft_changelog_251_imp_3" text="Worker-Liste lässt sich vollständig scrollen" />
-        <text name="ft_changelog_250_new_1" text="neuer Tablet-Startbildschirm mit Sperrbildschirm" />
-        <text name="ft_changelog_250_new_2" text="neues App-Raster mit Dock und Seitenanzeige" />
-        <text name="ft_changelog_250_new_3" text="Apps öffnen mit sauberer Tablet-Animation" />
-        <text name="ft_changelog_250_new_4" text="eigener Hintergrund über FTBackground möglich" />
+        <text name="ft_changelog_251_imp_2" text="App-Symbole optimiert und sauberer geladen" />
+        <text name="ft_changelog_251_imp_3" text="Arbeiterliste lässt sich vollständig scrollen" />
+        <text name="ft_changelog_250_new_1" text="Neuer Tablet-Startbildschirm mit Sperrbildschirm" />
+        <text name="ft_changelog_250_new_2" text="Neues App-Raster mit Dock und Seitenanzeige" />
+        <text name="ft_changelog_250_new_3" text="Apps öffnen mit einer flüssigen Tablet-Animation" />
+        <text name="ft_changelog_250_new_4" text="Eigener Hintergrund über FTBackground möglich" />
         <text name="ft_changelog_250_imp_1" text="3D-Rahmen, Bildschirmglanz und Oberfläche überarbeitet" />
         <text name="ft_changelog_250_imp_2" text="Vollbild-Apps mit Home- und Zurück-Leiste" />
-        <text name="ft_changelog_240_new_1" text="Personal-App für Pro-Staff / Worker Costs" />
+        <text name="ft_changelog_240_new_1" text="Personal-App für Personalverwaltung und Arbeitskosten" />
         <text name="ft_changelog_240_new_2" text="Arbeiterliste mit Sortierung und Filter" />
         <text name="ft_changelog_240_new_3" text="Einstellung, Entlassung und Lohnübersicht für Personal" />
         <text name="ft_changelog_240_imp_1" text="Mehrspieler-Aktionen werden sauber über den Host synchronisiert" />
-        <text name="ft_changelog_2324_new_1" text="Worker-Costs-App zeigt jetzt Personal, Stunden, Jobs und Ermüdung" />
+        <text name="ft_changelog_2324_new_1" text="Arbeitskosten-App zeigt jetzt Personal, Stunden, Aufträge und Ermüdung" />
         <text name="ft_changelog_2324_imp_1" text="Personalbereich lässt sich scrollen" />
         <text name="ft_changelog_2323_fix_1" text="Pfeile und Umschalter reagieren sofort" />
         <text name="ft_changelog_2323_fix_2" text="Produktion zeigt laufende Prozesse korrekt an" />
-        <text name="ft_changelog_2323_fix_3" text="Fahrzeugkamera zoomt nicht mehr beim Scrollen im Tablet" />
-        <text name="ft_changelog_2323_imp_1" text="Soil-Werte werden passend zum HUD angezeigt" />
-        <text name="ft_changelog_220_new_1" text="ukrainische Übersetzung hinzugefügt" />
+        <text name="ft_changelog_2323_fix_3" text="Fahrzeugkamera zoomt beim Scrollen im Tablet nicht mehr" />
+        <text name="ft_changelog_2323_imp_1" text="Bodenwerte werden passend zum HUD angezeigt" />
+        <text name="ft_changelog_220_new_1" text="Ukrainische Übersetzung hinzugefügt" />
         <text name="ft_changelog_220_imp_1" text="Scroll-Hilfe für lange App-Inhalte eingebaut" />
         <text name="ft_changelog_219_new_1" text="Lager-App speichert historische Höchstpreise pro Spielstand" />
         <text name="ft_changelog_219_imp_1" text="Preisvergleich sortiert Verkaufsstellen nach bestem Preis" />
-        <text name="ft_changelog_218_new_1" text="Zeitsteuerung mit Zeit-Sprüngen" />
+        <text name="ft_changelog_218_new_1" text="Zeitsteuerung mit Zeitsprüngen" />
         <text name="ft_changelog_218_new_2" text="Hotspot-Manager für Kartenmarkierungen" />
         <text name="ft_changelog_218_new_3" text="Notizen-App mit Aufgabenliste" />
         <text name="ft_changelog_218_new_4" text="Hof-Admin für Geld, Zeit, Reparatur und Tanken" />
@@ -2474,27 +2474,27 @@
         <text name="ft_changelog_217_new_1" text="Lager-App" />
         <text name="ft_changelog_217_new_2" text="Rechnungs-App" />
         <text name="ft_changelog_217_new_3" text="UsedPlus-Integration" />
-        <text name="ft_changelog_217_new_4" text="RoleplayPhone-Grundlage" />
+        <text name="ft_changelog_217_new_4" text="Grundlage für RoleplayPhone" />
         <text name="ft_changelog_217_fix_1" text="Kamera und Maus bleiben beim geöffneten Tablet korrekt gesperrt" />
         <text name="ft_changelog_215_new_1" text="Info-Bereich in den Einstellungen" />
-        <text name="ft_changelog_215_fix_1" text="App Store und Aktualisierungen lassen sich vollständig scrollen" />
+        <text name="ft_changelog_215_fix_1" text="App Store und Aktualisierungen können vollständig gescrollt werden" />
         <text name="ft_changelog_214_new_1" text="Market-Dynamics-App" />
         <text name="ft_changelog_214_new_2" text="Worker-Costs-App" />
         <text name="ft_changelog_214_new_3" text="Random-World-Events-App" />
         <text name="ft_changelog_214_fix_1" text="Erkennung anderer Mods verbessert" />
         <text name="ft_changelog_213_new_1" text="Farbauswahl für Hintergründe" />
-        <text name="ft_changelog_213_fix_1" text="fehlende Übersetzungen im ZIP-Paket" />
-        <text name="ft_changelog_213_fix_2" text="Ausrichtung der Einstellungsschlüssel" />
+        <text name="ft_changelog_213_fix_1" text="Fehlende Übersetzungen im ZIP-Paket behoben" />
+        <text name="ft_changelog_213_fix_2" text="Ausrichtung der Einstellungsschlüssel korrigiert" />
         <text name="ft_changelog_212_new_1" text="26 Sprachen" />
-        <text name="ft_changelog_212_new_2" text="Info-Symbol pro App" />
+        <text name="ft_changelog_212_new_2" text="Info-Symbol für jede App" />
         <text name="ft_changelog_212_new_3" text="Mehrspieler- und Dedicated-Server-Unterstützung" />
-        <text name="ft_changelog_210_new_1" text="kompletter V2-Umbau" />
-        <text name="ft_changelog_210_new_2" text="neue Oberfläche" />
-        <text name="ft_changelog_210_new_3" text="zentrale Zeichenfunktionen" />
-        <text name="ft_changelog_210_new_4" text="alle Apps überarbeitet" />
-        <text name="ft_changelog_112_new_1" text="Soil-Fertilizer-, Seasonal-Crop-Stress- und NPC-Favor-Integration" />
-        <text name="ft_changelog_112_fix_1" text="Navigationsschaltflächen laufen nicht mehr über" />
-        <text name="ft_changelog_100_new_1" text="erste Veröffentlichung mit Übersicht, Wetter, Feldern, Tieren und Werkstatt" />
+        <text name="ft_changelog_210_new_1" text="Kompletter V2-Umbau" />
+        <text name="ft_changelog_210_new_2" text="Neue Oberfläche" />
+        <text name="ft_changelog_210_new_3" text="Zentrale Zeichenfunktionen" />
+        <text name="ft_changelog_210_new_4" text="Alle Apps überarbeitet" />
+        <text name="ft_changelog_112_new_1" text="Integration von Soil-Fertilizer, Seasonal-Crop-Stress und NPC-Favor" />
+        <text name="ft_changelog_112_fix_1" text="Navigationsschaltflächen überlappen nicht mehr" />
+        <text name="ft_changelog_100_new_1" text="Erste Veröffentlichung mit Übersicht, Wetter, Feldern, Tieren und Werkstatt" />
         <text name="ft_settings_scale_format" text="%.0f%% / Breite %.0f%%" />
         <text name="ft_signal_very_good" text="Sehr gut" />
         <text name="ft_signal_good" text="Gut" />
@@ -2511,32 +2511,32 @@
         <text name="ft_fleet_no_vehicles_hint" text="Kaufe motorisierte Fahrzeuge, um sie hier zu überwachen." />
         <text name="ft_ai_active_short" text="HELFER" />
         <text name="ft_settings_battery_drain" text="Akkuverbrauch" />
-        <text name="ft_settings_hint_battery_drain" text="Legt fest, ob der Tablet-Akku mit der Zeit leer wird." />
-    <text name="ft_notes_template_harvest" text="Ernte einfahren" /><text name="ft_notes_template_sow" text="Aussäen" /><text name="ft_notes_template_fertilize" text="Düngen" /><text name="ft_notes_template_plow" text="Pflügen / Grubbern" /><text name="ft_notes_template_spray" text="Felder spritzen" /><text name="ft_notes_template_sell" text="Ernte verkaufen" /><text name="ft_notes_template_refuel" text="Fahrzeuge tanken" /><text name="ft_notes_template_repair" text="Fahrzeuge reparieren" /><text name="ft_notes_template_feed" text="Tiere füttern" /><text name="ft_notes_template_clean" text="Ställe reinigen" /><text name="ft_notes_template_mow" text="Gras mähen" /><text name="ft_notes_template_bale" text="Heu / Stroh pressen" /><text name="ft_notes_template_collect_bales" text="Ballen sammeln" /><text name="ft_notes_template_contracts" text="Aufträge prüfen" /><text name="ft_notes_template_shop" text="Shop besuchen" /><text name="ft_notes_template_collect_prod" text="Produktionen abholen" /><text name="ft_notes_template_buy" text="Gerät kaufen" /><text name="ft_notes_template_water" text="Felder bewässern" /><text name="ft_notes_template_weather" text="Wetter prüfen" /><text name="ft_notes_template_field_maint" text="Feldpflege" /><text name="ft_app_notes" text="Notizen" /><text name="ft_notes_todo_list" text="Aufgabenliste" /><text name="ft_notes_actions" text="Aktionen" /><text name="ft_notes_all_done" text="Alles erledigt!" /><text name="ft_notes_pending_fmt" text="%d offen" /><text name="ft_notes_new_task" text="Neue Aufgabe" /><text name="ft_notes_no_fields" text="Keine Felder im Besitz" /><text name="ft_notes_any_field" text="Alle Felder" /><text name="ft_common_field" text="Feld" /><text name="ft_notes_add" text="+ Aufgabe hinzufügen" /><text name="ft_notes_list_count_fmt" text="Aufgabenliste (%d offen - %d erledigt)" /><text name="ft_notes_empty" text="Noch keine Aufgaben - oben eine hinzufügen" /><text name="ft_common_undo" text="Zurück" /><text name="ft_common_done" text="Erledigt" /><text name="ft_notes_clear_completed_fmt" text="%d erledigte löschen" /><text name="ft_fieldjobs_no_job" text="Kein Auftrag aktiv." /><text name="ft_fieldjobs_start_job" text="Arbeit starten" /><text name="ft_fieldjobs_recent_jobs" text="Letzte Arbeiten" /><text name="ft_fieldjobs_no_completed" text="Noch keine abgeschlossenen Arbeiten." /><text name="ft_fieldjobs_no_job_short" text="kein aktiver Auftrag" /><text name="ft_common_history" text="Verlauf" /><text name="ft_app_production" text="Produktion" /><text name="ft_production_one_building" text="1 Gebäude" /><text name="ft_production_buildings_fmt" text="%d Gebäude" /><text name="ft_production_none" text="Keine Produktionsgebäude im Besitz." /><text name="ft_production_buy_hint" text="Kaufe eine Produktion, um sie hier zu verfolgen." /><text name="ft_production_active_fmt" text="%d/%d aktiv" /><text name="ft_production_stalled" text="steht" /><text name="ft_production_inputs" text="EINGÄNGE" /><text name="ft_production_outputs" text="AUSGÄNGE" />        <text name="ft_battery_mode_off" text="Aus" />
-        <text name="ft_battery_mode_open" text="Nur wenn geöffnet" />
-        <text name="ft_battery_mode_standby" text="Immer inkl. Standby" />
+        <text name="ft_settings_hint_battery_drain" text="Legt fest, ob der Tablet-Akku mit der Zeit entladen wird." />
+    <text name="ft_notes_template_harvest" text="Ernte einfahren" /><text name="ft_notes_template_sow" text="Aussäen" /><text name="ft_notes_template_fertilize" text="Düngen" /><text name="ft_notes_template_plow" text="Pflügen / Grubbern" /><text name="ft_notes_template_spray" text="Felder spritzen" /><text name="ft_notes_template_sell" text="Ernte verkaufen" /><text name="ft_notes_template_refuel" text="Fahrzeuge tanken" /><text name="ft_notes_template_repair" text="Fahrzeuge reparieren" /><text name="ft_notes_template_feed" text="Tiere füttern" /><text name="ft_notes_template_clean" text="Ställe reinigen" /><text name="ft_notes_template_mow" text="Gras mähen" /><text name="ft_notes_template_bale" text="Heu / Stroh pressen" /><text name="ft_notes_template_collect_bales" text="Ballen sammeln" /><text name="ft_notes_template_contracts" text="Aufträge prüfen" /><text name="ft_notes_template_shop" text="Shop besuchen" /><text name="ft_notes_template_collect_prod" text="Produktionen abholen" /><text name="ft_notes_template_buy" text="Gerät kaufen" /><text name="ft_notes_template_water" text="Felder bewässern" /><text name="ft_notes_template_weather" text="Wetter prüfen" /><text name="ft_notes_template_field_maint" text="Feldpflege" /><text name="ft_app_notes" text="Notizen" /><text name="ft_notes_todo_list" text="Aufgabenliste" /><text name="ft_notes_actions" text="Aktionen" /><text name="ft_notes_all_done" text="Alles erledigt!" /><text name="ft_notes_pending_fmt" text="%d offen" /><text name="ft_notes_new_task" text="Neue Aufgabe" /><text name="ft_notes_no_fields" text="Keine Felder im Besitz" /><text name="ft_notes_any_field" text="Alle Felder" /><text name="ft_common_field" text="Feld" /><text name="ft_notes_add" text="+ Aufgabe hinzufügen" /><text name="ft_notes_list_count_fmt" text="Aufgabenliste (%d offen - %d erledigt)" /><text name="ft_notes_empty" text="Noch keine Aufgaben – oben eine hinzufügen" /><text name="ft_common_undo" text="Rückgängig" /><text name="ft_common_done" text="Erledigt" /><text name="ft_notes_clear_completed_fmt" text="%d erledigte Aufgaben löschen" /><text name="ft_fieldjobs_no_job" text="Kein Auftrag aktiv." /><text name="ft_fieldjobs_start_job" text="Arbeit starten" /><text name="ft_fieldjobs_recent_jobs" text="Letzte Arbeiten" /><text name="ft_fieldjobs_no_completed" text="Noch keine abgeschlossenen Arbeiten." /><text name="ft_fieldjobs_no_job_short" text="Kein aktiver Auftrag" /><text name="ft_common_history" text="Verlauf" /><text name="ft_app_production" text="Produktion" /><text name="ft_production_one_building" text="1 Gebäude" /><text name="ft_production_buildings_fmt" text="%d Gebäude" /><text name="ft_production_none" text="Keine Produktionsgebäude im Besitz." /><text name="ft_production_buy_hint" text="Kaufe eine Produktion, um sie hier zu überwachen." /><text name="ft_production_active_fmt" text="%d/%d aktiv" /><text name="ft_production_stalled" text="Pausiert" /><text name="ft_production_inputs" text="EINGÄNGE" /><text name="ft_production_outputs" text="AUSGÄNGE" />        <text name="ft_battery_mode_off" text="Aus" />
+        <text name="ft_battery_mode_open" text="Nur bei geöffnetem Tablet" />
+        <text name="ft_battery_mode_standby" text="Immer inklusive Standby" />
         <text name="ft_settings_hint_battery_drain_mode" text="Legt fest, wann der Tablet-Akku verbraucht wird." />
         <text name="ft_settings_battery_profile" text="Akku-Profil" />
-        <text name="ft_settings_hint_battery_profile" text="Niedrig, normal, hoch oder eigene Verbrauchswerte." />
+        <text name="ft_settings_hint_battery_profile" text="Niedriger, normaler, hoher oder eigener Verbrauchswert." />
         <text name="ft_battery_profile_low" text="Niedrig" />
         <text name="ft_battery_profile_normal" text="Normal" />
         <text name="ft_battery_profile_high" text="Hoch" />
         <text name="ft_battery_profile_custom" text="Benutzerdefiniert" />
         <text name="ft_settings_battery_open_rate" text="Verbrauch geöffnet" />
-        <text name="ft_settings_hint_battery_open_rate" text="Akkuverbrauch, wenn das Tablet geöffnet ist." />
+        <text name="ft_settings_hint_battery_open_rate" text="Akkuverbrauch bei geöffnetem Tablet." />
         <text name="ft_settings_battery_standby_rate" text="Verbrauch Standby" />
-        <text name="ft_settings_hint_battery_standby_rate" text="Akkuverbrauch, wenn das Tablet geschlossen ist." />
+        <text name="ft_settings_hint_battery_standby_rate" text="Akkuverbrauch bei geschlossenem Tablet." />
         <text name="ft_battery_rate_minutes" text="1 %% / %d Min." />
         <text name="ft_battery_service_title" text="Tablet-Akku" />
-        <text name="ft_battery_empty_auto_charge" text="Tablet-Akku leer. Tablet ist am Ladegerät." />
-        <text name="ft_battery_charging_locked" text="Tablet am Ladegerät. Einschalten ab 15% möglich." />
+        <text name="ft_battery_empty_auto_charge" text="Tablet-Akku leer. Tablet wird geladen." />
+        <text name="ft_battery_charging_locked" text="Tablet wird geladen. Einschalten ab 15%% möglich." />
         <text name="ft_battery_charged_usable" text="Tablet ausreichend geladen. Mit T wieder einschalten." />
-        <text name="ft_battery_charged_full" text="Tablet voll geladen." />
-        <text name="ft_weather_mode_real" text="Real" />
-        <text name="ft_weather_mode_arid" text="Arid" />
+        <text name="ft_battery_charged_full" text="Tablet vollständig geladen." />
+        <text name="ft_weather_mode_real" text="Realistisch" />
+        <text name="ft_weather_mode_arid" text="Trocken" />
         <text name="ft_weather_mode_normal" text="Normal" />
-        <text name="ft_weather_mode_wet" text="Wet" />
-        <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
-        <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_weather_mode_wet" text="Feucht" />
+        <text name="ft_fc_history_no_clock" text="Time Guard benötigt" />
+        <text name="ft_fc_history_no_clock_detail" text="Installiere Time Guard, um die monatliche Historie aufzuzeichnen. Die aktuellen Werte bleiben verfügbar." />
     </texts>
 </l10n>


### PR DESCRIPTION
Merges @warriordeere's improved German translation from #120. Posted on 26 July, acknowledged twice with a promise to review, then never merged.

## What was merged

Key by key rather than as a file swap, so nothing newer is lost:

- **1595 strings** taken from the contribution
- 991 already identical
- `ft_ui_app_prostaff` preserved as-is, added after the contribution was posted for the ProStaff app
- **0** `[EN]` placeholders remain

## Correcting a number from the issue thread

The improvement was reported there as **909** strings. That count came from a line-based diff, which misses any entry whose text spans lines. A proper parse puts it at **1595**. The issue comment was wrong and is corrected here.

## What it actually changes

A native speaker pass: missing lines filled, grammar corrected, and a good deal rewritten to read naturally rather than literally. Spot checking, `Behandeln` over `Jetzt versorgen`, and `Noch keine Behandlung eingetragen.` over the flatter `Noch keine Aktion vorhanden.`

## Verification

File parses as well-formed XML. Not yet loaded in game.
