### PR TITLE
feat: SCS-009 ProStaff irrigation advisory (level-gated)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ tools/_contact_sheet.png
 gui/icons/*.png
 gui/tablet_frame.png
 gui/wallpaper.png
+
+# Pre-commit gate deps (tools/test/ - installed by npm, never shipped)
+node_modules/

--- a/src/apps/IrrigationSuiteApp.lua
+++ b/src/apps/IrrigationSuiteApp.lua
@@ -14,6 +14,13 @@ local MODE_LABEL = {
     usage      = "Usage",
 }
 
+local function _T(key, fallback)
+    if g_i18n and key and g_i18n:hasText(key) then
+        return g_i18n:getText(key)
+    end
+    return fallback or key
+end
+
 local function _scs()
     return g_currentMission and g_currentMission.cropStressManager or nil
 end
@@ -195,6 +202,31 @@ local function _moistureSplit(scs, fieldId)
     local irrShare = math.max(0, math.min(moisture, rate))
     local rainShare = math.max(0, moisture - irrShare)
     return moisture, irrShare, rainShare
+end
+
+--- SCS-009: per-field water need, the pure ranking figure.
+--- Monotone in moisture deficit and dry stress; active irrigation (rate > 0)
+--- reduces need. Returns nil when moisture is unreadable (the field does not
+--- rank). Display-only: feeds the advisory sort, never any economic hook.
+local function _waterNeed(moisture, stress, rate)
+    if moisture == nil then return nil end
+    local deficit = math.max(0, 1 - moisture)          -- 0 wet .. 1 dry
+    local stressT = math.max(0, math.min(1, stress or 0))
+    local need    = deficit * 0.65 + stressT * 0.35
+    if (rate or 0) > 0 then
+        need = need * 0.6    -- already being watered: the edge is covered
+    end
+    return need
+end
+
+--- SCS-009: the plain call for a need value.
+--- Thresholds are display-only (no economic effect); they pick the words.
+---@param need number 0..1
+---@return string key, string fallback
+local function _waterCall(need)
+    if need >= 0.75 then return "ft_irr_call_water_today", "water today" end
+    if need >= 0.45 then return "ft_irr_call_watch", "watch" end
+    return "ft_irr_call_can_hold", "can hold"
 end
 
 FarmTabletUI:registerDrawer(FT.APP.IRRIGATION_SUITE, function(self)
@@ -440,6 +472,150 @@ FarmTabletUI:registerDrawer(FT.APP.IRRIGATION_SUITE, function(self)
                     y = y - FT.py(16)
                     break
                 end
+            end
+        end
+
+        -- ══════════════════════════════════════════════════════
+        -- SCS-009: ProStaff irrigation advisory (level-gated)
+        -- ══════════════════════════════════════════════════════
+        -- Read-only, display-only, no economic effect (the standing cert gate).
+        -- Everything feeds no cost / yield / price / efficiency hook. Data is all
+        -- shipped SCS getters, nil-safe, neutral-absent; SCS absent means the whole
+        -- app already returned above. ProStaff absent: the gated sections stay
+        -- honest-locked (header + the one-liner naming the unlocking level).
+        -- Local farm only: getPlayerFarmId + getOwnedFields, no cross-farm read.
+        local psm = g_currentMission and g_currentMission.proStaffManager
+        local hasForecastAccess = false
+        local hasPredictiveControl = false
+        if psm ~= nil then
+            pcall(function() hasForecastAccess = psm:hasForecastAccess(farmId) end)
+            pcall(function() hasPredictiveControl = psm:hasPredictiveControl(farmId) end)
+        end
+
+        -- Shared advisory data, computed once for both gated sections. All shipped
+        -- SCS reads, nil-safe, neutral-absent; display-only, no economic effect.
+        -- The urgency modifier (R1-A: never per-field) scales the WHOLE list but
+        -- reorders nothing - the per-field need figure stays the sort key.
+        local urgency = 1.0
+        do
+            local evap = _pcall(function() return scs:getEvaporativeDemand() end)
+            local temp = _pcall(function() return scs:getTemperature() end)
+            if evap ~= nil and temp ~= nil then
+                urgency = math.max(0.5, evap * (0.8 + math.max(0, temp - 10) * 0.02))
+            elseif evap ~= nil then
+                urgency = math.max(0.5, evap)
+            end
+        end
+        local ranked = {}
+        for _, f in ipairs(fields) do
+            local need = _waterNeed(
+                _pcall(function() return scs:getMoisture(f.id) end),
+                _pcall(function() return scs:getStress(f.id) end),
+                _pcall(function() return scs:getIrrigationRate(f.id) end))
+            if need ~= nil then
+                ranked[#ranked + 1] = { id = f.id, need = need }
+            end
+        end
+        table.sort(ranked, function(a, b) return a.need > b.need end)
+
+        y = self:drawRule(y, 0.3)
+
+        -- L7 WATER NEED -------------------------------------------------------
+        self.r:appText(x, y - FT.py(2), FT.FONT.SMALL,
+            _T("ft_irr_advisory_water_need", "WATER NEED (advisory)"),
+            RenderText.ALIGN_LEFT, AC)
+        y = y - FT.py(14)
+        if not hasForecastAccess then
+            self.r:appText(x, y - FT.py(1), FT.FONT.SMALL,
+                _T("ft_irr_advisory_locked_l7", "Unlocks at co-op level 7"),
+                RenderText.ALIGN_LEFT, FT.C.MUTED)
+            y = y - FT.py(16)
+        else
+            local hint = _pcall(function() return scs:getCriticalAlertHint() end)
+            if hint ~= nil and hint ~= "" then
+                self.r:appText(x, y - FT.py(1), FT.FONT.SMALL, tostring(hint),
+                    RenderText.ALIGN_LEFT, FT.C.WARN)
+                y = y - FT.py(14)
+            end
+
+            local shownNeed = 0
+            for _, r in ipairs(ranked) do
+                if shownNeed >= 8 then
+                    self.r:appText(x, y - FT.py(1), FT.FONT.SMALL,
+                        "… more fields omitted", RenderText.ALIGN_LEFT, FT.C.MUTED)
+                    y = y - FT.py(14)
+                    break
+                end
+                local effNeed = math.min(1, r.need * urgency)
+                local callKey, callFallback = _waterCall(effNeed)
+                local callCol = effNeed >= 0.75 and FT.C.WARN
+                    or (effNeed >= 0.45 and FT.C.TEXT_DIM or FT.C.MUTED)
+                self.r:appText(x, y - FT.py(1), FT.FONT.BODY,
+                    string.format("Field #%s", tostring(r.id)),
+                    RenderText.ALIGN_LEFT, FT.C.TEXT)
+                self.r:appText(x + cw, y - FT.py(1), FT.FONT.SMALL,
+                    _T(callKey, callFallback), RenderText.ALIGN_RIGHT, callCol)
+                y = y - FT.py(14)
+                shownNeed = shownNeed + 1
+            end
+            if shownNeed == 0 then
+                self.r:appText(x, y - FT.py(1), FT.FONT.SMALL,
+                    _T("ft_irr_advisory_no_reads", "No owned fields with water reads yet."),
+                    RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
+                y = y - FT.py(14)
+            end
+        end
+
+        y = self:drawRule(y, 0.3)
+
+        -- L18 FORWARD CALL -----------------------------------------------------
+        self.r:appText(x, y - FT.py(2), FT.FONT.SMALL,
+            _T("ft_irr_advisory_forward_call", "FORWARD CALL (advisory)"),
+            RenderText.ALIGN_LEFT, AC)
+        y = y - FT.py(14)
+        if not hasPredictiveControl then
+            self.r:appText(x, y - FT.py(1), FT.FONT.SMALL,
+                _T("ft_irr_advisory_locked_l18", "Unlocks at co-op level 18"),
+                RenderText.ALIGN_LEFT, FT.C.MUTED)
+            y = y - FT.py(16)
+        else
+            -- The hold-or-water call extended across the schedule read: which
+            -- fields' schedules cover the coming need and which gap. Still from
+            -- shipped reads only (getIrrigationSchedule); still display-only.
+            local covered, gap = 0, 0
+            local shownFwd = 0
+            for _, r in ipairs(ranked) do
+                if shownFwd >= 6 then break end
+                local sched = _pcall(function() return scs:getIrrigationSchedule(r.id) end)
+                local hasSched = type(sched) == "table"
+                    and tonumber(sched.startHour) ~= nil
+                    and tonumber(sched.endHour) ~= nil
+                local effNeed = math.min(1, r.need * urgency)
+                local callK, callF = _waterCall(effNeed)
+                if hasSched then covered = covered + 1 else gap = gap + 1 end
+                local fwdKey = hasSched and "ft_irr_advisory_schedule_covers"
+                    or "ft_irr_advisory_schedule_gap"
+                local fwdTxt = hasSched and "schedule covers" or "schedule gap"
+                local fwdCol = hasSched and FT.C.POSITIVE or FT.C.WARN
+                self.r:appText(x, y - FT.py(1), FT.FONT.BODY,
+                    string.format("Field #%s  %s", tostring(r.id),
+                        _T(callK, callF)),
+                    RenderText.ALIGN_LEFT, FT.C.TEXT)
+                self.r:appText(x + cw, y - FT.py(1), FT.FONT.SMALL,
+                    _T(fwdKey, fwdTxt), RenderText.ALIGN_RIGHT, fwdCol)
+                y = y - FT.py(14)
+                shownFwd = shownFwd + 1
+            end
+            if shownFwd == 0 then
+                self.r:appText(x, y - FT.py(1), FT.FONT.SMALL,
+                    _T("ft_irr_advisory_no_reads", "No owned fields with water reads yet."),
+                    RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
+                y = y - FT.py(14)
+            else
+                self.r:appText(x, y - FT.py(1), FT.FONT.SMALL,
+                    string.format("%d covered  ·  %d gap", covered, gap),
+                    RenderText.ALIGN_LEFT, FT.C.MUTED)
+                y = y - FT.py(14)
             end
         end
 

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Lua 5.1 syntax (+ repo lint where present) pre-commit gate.
+#
+# WHY THIS EXISTS: a Lua parse error does not stop FS25 loading the mod. The mod
+# loads, the game runs, and the offending FILE is silently dropped, so one feature
+# is simply absent with nothing but a single compiler line nobody reads. Two such
+# errors sat unnoticed in this suite until 2026-07-30 (FarmTablet's ProStaffApp and
+# WorkplaceTriggers' WTNetworkSyncBridge), each dead in EVERY session since it
+# shipped. Sub-second here beats a deploy plus a multi-minute load, and beats never
+# noticing at all.
+#
+# Install:   bash tools/test/install-hooks.sh
+# Skip once: git commit --no-verify
+# Remove:    rm "$(git rev-parse --git-path hooks)/pre-commit"
+set -e
+
+staged_lua="$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.lua$' || true)"
+[ -z "$staged_lua" ] && exit 0
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root/tools/test"
+[ -d node_modules ] || npm install --silent
+
+echo "pre-commit: Lua 5.1 syntax (staged)…"
+# Absolute paths, NUL-safe against spaces in the repo path.
+printf '%s\n' "$staged_lua" | while IFS= read -r f; do
+  [ -n "$f" ] && printf '%s\0' "$repo_root/$f"
+done | xargs -0 node ./check-staged.mjs
+
+# Repo-wide lint pass on top, when the repo has one. Non-fatal to keep the gate's
+# job crisp: syntax blocks, style advises.
+if node -e "process.exit(require('./package.json').scripts.lint ? 0 : 1)" 2>/dev/null; then
+  npm run --silent lint || echo "  (lint reported findings; not blocking the commit)"
+fi

--- a/tools/test/check-staged.mjs
+++ b/tools/test/check-staged.mjs
@@ -1,0 +1,52 @@
+// Parse the exact files git is about to commit, with luaparse pinned to Lua 5.1.
+//
+// WHY NOT REUSE tools/test/syntax-check.mjs: its findLuaFiles() defaults to SRC_DIR,
+// so it never sees main.lua at the repo root - the entry point of several mods in this
+// suite. A gate that misses the entry file is worse than no gate, because it grants
+// false confidence. This checks the STAGED set instead, which is by definition exactly
+// what is shipping, wherever it lives in the tree.
+//
+// Lives in tools/test/ (not tools/git-hooks/) because node resolves bare imports from
+// the SCRIPT's directory upward - from tools/git-hooks it never sees tools/test/node_modules.
+// Usage: node check-staged.mjs <abs-path>...
+import { readFileSync } from "node:fs";
+import luaparse from "luaparse";
+
+const files = process.argv.slice(2);
+let bad = 0;
+for (const f of files) {
+  let code;
+  try {
+    code = readFileSync(f, "utf8");
+  } catch {
+    continue; // deleted or moved between staging and now; nothing to parse
+  }
+
+  // A UTF-8 BOM is caught by the parse below, but only as
+  // "Cannot read properties of undefined (reading 'range')", which tells you
+  // nothing. Name it explicitly instead. Lua does not skip a byte order mark
+  // the way it skips a shebang, so U+FEFF is read as part of the first token.
+  // Seven files across four repos hit this on 2026-08-05, all from an editor
+  // saving as "UTF-8 with BOM".
+  if (code.charCodeAt(0) === 0xfeff) {
+    bad++;
+    console.error(`  \u2717 ${f}`);
+    console.error("      Starts with a UTF-8 BOM (EF BB BF). Lua 5.1 cannot parse it.");
+    console.error("      Fix: re-save as UTF-8 WITHOUT BOM, or strip the 3 leading bytes.");
+    continue;
+  }
+
+  try {
+    luaparse.parse(code, { luaVersion: "5.1", comments: false, locations: true });
+  } catch (e) {
+    bad++;
+    console.error(`  \u2717 ${f}\n      ${e.message}`);
+  }
+}
+if (bad > 0) {
+  console.error(`\n  ${bad} staged Lua file(s) will NOT compile in FS25. Commit blocked.`);
+  console.error("  FS25 drops the whole file at load with no useful message, so this");
+  console.error("  would ship as a silently missing feature. Fix, or --no-verify.");
+  process.exit(1);
+}
+console.log(`  \u2713 Lua 5.1 syntax OK - ${files.length} staged file(s)`);

--- a/tools/test/package.json
+++ b/tools/test/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "fs25_farmtablet-checks",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Lua 5.1 pre-commit gate. Excluded from the mod zip with the rest of tools/.",
+  "devDependencies": {
+    "luaparse": "^0.3.1"
+  }
+}

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="NECESSIDADE DE ÁGUA (conselho)" />
+        <text name="ft_irr_advisory_locked_l7" text="Desbloqueado no nível cooperativa 7" />
+        <text name="ft_irr_advisory_forward_call" text="PREVISAO (conselho)" />
+        <text name="ft_irr_advisory_locked_l18" text="Desbloqueado no nível cooperativa 18" />
+        <text name="ft_irr_advisory_no_reads" text="Ainda sem campos com leitura de água." />
+        <text name="ft_irr_call_water_today" text="irrigar hoje" />
+        <text name="ft_irr_call_watch" text="observar" />
+        <text name="ft_irr_call_can_hold" text="pode aguardar" />
+        <text name="ft_irr_advisory_schedule_covers" text="programa cobre" />
+        <text name="ft_irr_advisory_schedule_gap" text="falha no programa" />
     </texts>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="需水量（建議）" />
+        <text name="ft_irr_advisory_locked_l7" text="合作社等級7解鎖" />
+        <text name="ft_irr_advisory_forward_call" text="預測（建議）" />
+        <text name="ft_irr_advisory_locked_l18" text="合作社等級18解鎖" />
+        <text name="ft_irr_advisory_no_reads" text="尚無有水分讀數的田地。" />
+        <text name="ft_irr_call_water_today" text="今天澆水" />
+        <text name="ft_irr_call_watch" text="觀察" />
+        <text name="ft_irr_call_can_hold" text="可等待" />
+        <text name="ft_irr_advisory_schedule_covers" text="計畫涵蓋" />
+        <text name="ft_irr_advisory_schedule_gap" text="計畫缺口" />
     </texts>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="POTŘEBA VODY (poradenství)" />
+        <text name="ft_irr_advisory_locked_l7" text="Odemčeno na úrovni družstva 7" />
+        <text name="ft_irr_advisory_forward_call" text="PŘEDPOVĚĎ (poradenství)" />
+        <text name="ft_irr_advisory_locked_l18" text="Odemčeno na úrovni družstva 18" />
+        <text name="ft_irr_advisory_no_reads" text="Zatím žádná pole s údaji o vodě." />
+        <text name="ft_irr_call_water_today" text="zavlažit dnes" />
+        <text name="ft_irr_call_watch" text="sledovat" />
+        <text name="ft_irr_call_can_hold" text="může počkat" />
+        <text name="ft_irr_advisory_schedule_covers" text="plán pokrývá" />
+        <text name="ft_irr_advisory_schedule_gap" text="mezera v plánu" />
     </texts>
 </l10n>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="VANDBEHOV (rådgivning)" />
+        <text name="ft_irr_advisory_locked_l7" text="Låses op på kooperativt niveau 7" />
+        <text name="ft_irr_advisory_forward_call" text="FORUDSIGELSE (rådgivning)" />
+        <text name="ft_irr_advisory_locked_l18" text="Låses op på kooperativt niveau 18" />
+        <text name="ft_irr_advisory_no_reads" text="Endnu ingen marker med vandmålinger." />
+        <text name="ft_irr_call_water_today" text="vand i dag" />
+        <text name="ft_irr_call_watch" text="hold øje" />
+        <text name="ft_irr_call_can_hold" text="kan vente" />
+        <text name="ft_irr_advisory_schedule_covers" text="plan dækker" />
+        <text name="ft_irr_advisory_schedule_gap" text="planhul" />
     </texts>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -2538,5 +2538,15 @@
         <text name="ft_weather_mode_wet" text="Feucht" />
         <text name="ft_fc_history_no_clock" text="Time Guard benötigt" />
         <text name="ft_fc_history_no_clock_detail" text="Installiere Time Guard, um die monatliche Historie aufzuzeichnen. Die aktuellen Werte bleiben verfügbar." />
+        <text name="ft_irr_advisory_water_need" text="BEWAESSERUNGSBEDARF (Beratung)" />
+        <text name="ft_irr_advisory_locked_l7" text="Freigeschaltet ab Koop-Level 7" />
+        <text name="ft_irr_advisory_forward_call" text="VORHERSAGE (Beratung)" />
+        <text name="ft_irr_advisory_locked_l18" text="Freigeschaltet ab Koop-Level 18" />
+        <text name="ft_irr_advisory_no_reads" text="Noch keine Felder mit Wasserwerten." />
+        <text name="ft_irr_call_water_today" text="heute wässern" />
+        <text name="ft_irr_call_watch" text="beobachten" />
+        <text name="ft_irr_call_can_hold" text="kann halten" />
+        <text name="ft_irr_advisory_schedule_covers" text="Plan abgedeckt" />
+        <text name="ft_irr_advisory_schedule_gap" text="Planlücke" />
     </texts>
 </l10n>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="NECESIDAD DE AGUA (asesoría)" />
+        <text name="ft_irr_advisory_locked_l7" text="Se desbloquea en el nivel de cooperativa 7" />
+        <text name="ft_irr_advisory_forward_call" text="PREVISION (asesoría)" />
+        <text name="ft_irr_advisory_locked_l18" text="Se desbloquea en el nivel de cooperativa 18" />
+        <text name="ft_irr_advisory_no_reads" text="Aún no hay campos con lecturas de agua." />
+        <text name="ft_irr_call_water_today" text="regar hoy" />
+        <text name="ft_irr_call_watch" text="vigilar" />
+        <text name="ft_irr_call_can_hold" text="puede esperar" />
+        <text name="ft_irr_advisory_schedule_covers" text="el plan cubre" />
+        <text name="ft_irr_advisory_schedule_gap" text="hueco de plan" />
     </texts>
 </l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -2538,5 +2538,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="WATER NEED (advisory)" />
+        <text name="ft_irr_advisory_locked_l7" text="Unlocks at co-op level 7" />
+        <text name="ft_irr_advisory_forward_call" text="FORWARD CALL (advisory)" />
+        <text name="ft_irr_advisory_locked_l18" text="Unlocks at co-op level 18" />
+        <text name="ft_irr_advisory_no_reads" text="No owned fields with water reads yet." />
+        <text name="ft_irr_call_water_today" text="water today" />
+        <text name="ft_irr_call_watch" text="watch" />
+        <text name="ft_irr_call_can_hold" text="can hold" />
+        <text name="ft_irr_advisory_schedule_covers" text="schedule covers" />
+        <text name="ft_irr_advisory_schedule_gap" text="schedule gap" />
     </texts>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="NECESIDAD DE AGUA (asesoría)" />
+        <text name="ft_irr_advisory_locked_l7" text="Se desbloquea en el nivel de cooperativa 7" />
+        <text name="ft_irr_advisory_forward_call" text="PREVISION (asesoría)" />
+        <text name="ft_irr_advisory_locked_l18" text="Se desbloquea en el nivel de cooperativa 18" />
+        <text name="ft_irr_advisory_no_reads" text="Aún no hay campos con lecturas de agua." />
+        <text name="ft_irr_call_water_today" text="regar hoy" />
+        <text name="ft_irr_call_watch" text="vigilar" />
+        <text name="ft_irr_call_can_hold" text="puede esperar" />
+        <text name="ft_irr_advisory_schedule_covers" text="el plan cubre" />
+        <text name="ft_irr_advisory_schedule_gap" text="hueco de plan" />
     </texts>
 </l10n>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="需水量（建议）" />
+        <text name="ft_irr_advisory_locked_l7" text="合作社等级7解锁" />
+        <text name="ft_irr_advisory_forward_call" text="预测（建议）" />
+        <text name="ft_irr_advisory_locked_l18" text="合作社等级18解锁" />
+        <text name="ft_irr_advisory_no_reads" text="尚无有水分读数的田地。" />
+        <text name="ft_irr_call_water_today" text="今天浇水" />
+        <text name="ft_irr_call_watch" text="观察" />
+        <text name="ft_irr_call_can_hold" text="可等待" />
+        <text name="ft_irr_advisory_schedule_covers" text="计划涵盖" />
+        <text name="ft_irr_advisory_schedule_gap" text="计划缺口" />
     </texts>
 </l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="VEDENTARVE (neuvonta)" />
+        <text name="ft_irr_advisory_locked_l7" text="Avautuu osuuskunnan tasolla 7" />
+        <text name="ft_irr_advisory_forward_call" text="ENNUSTE (neuvonta)" />
+        <text name="ft_irr_advisory_locked_l18" text="Avautuu osuuskunnan tasolla 18" />
+        <text name="ft_irr_advisory_no_reads" text="Ei vielä peltoja vesilukemin." />
+        <text name="ft_irr_call_water_today" text="kastele tänään" />
+        <text name="ft_irr_call_watch" text="tarkkaile" />
+        <text name="ft_irr_call_can_hold" text="voi odottaa" />
+        <text name="ft_irr_advisory_schedule_covers" text="aikataulu kattaa" />
+        <text name="ft_irr_advisory_schedule_gap" text="aikataulun aukko" />
     </texts>
 </l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="BESOIN EN EAU (conseil)" />
+        <text name="ft_irr_advisory_locked_l7" text="Débloqué au niveau coopératif 7" />
+        <text name="ft_irr_advisory_forward_call" text="PREVISION (conseil)" />
+        <text name="ft_irr_advisory_locked_l18" text="Débloqué au niveau coopératif 18" />
+        <text name="ft_irr_advisory_no_reads" text="Aucune parcelle avec relevé d'eau pour l'instant." />
+        <text name="ft_irr_call_water_today" text="irriguer aujourd'hui" />
+        <text name="ft_irr_call_watch" text="surveiller" />
+        <text name="ft_irr_call_can_hold" text="peut attendre" />
+        <text name="ft_irr_advisory_schedule_covers" text="plan couvre" />
+        <text name="ft_irr_advisory_schedule_gap" text="trou de plan" />
     </texts>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="VÍZSZÜKSÉGLET (tanácsadás)" />
+        <text name="ft_irr_advisory_locked_l7" text="A szövetkezet 7. szintjén nyílik meg" />
+        <text name="ft_irr_advisory_forward_call" text="ELŐREJELZÉS (tanácsadás)" />
+        <text name="ft_irr_advisory_locked_l18" text="A szövetkezet 18. szintjén nyílik meg" />
+        <text name="ft_irr_advisory_no_reads" text="Még nincsenek vízmérési adattal rendelkező táblák." />
+        <text name="ft_irr_call_water_today" text="öntözés ma" />
+        <text name="ft_irr_call_watch" text="figyelés" />
+        <text name="ft_irr_call_can_hold" text="várhat" />
+        <text name="ft_irr_advisory_schedule_covers" text="a terv lefedi" />
+        <text name="ft_irr_advisory_schedule_gap" text="tervhézag" />
     </texts>
 </l10n>

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="KEBUTUHAN AIR (saran)" />
+        <text name="ft_irr_advisory_locked_l7" text="Terbuka di level koperasi 7" />
+        <text name="ft_irr_advisory_forward_call" text="PERKIRAAN (saran)" />
+        <text name="ft_irr_advisory_locked_l18" text="Terbuka di level koperasi 18" />
+        <text name="ft_irr_advisory_no_reads" text="Belum ada lahan dengan pembacaan air." />
+        <text name="ft_irr_call_water_today" text="siram hari ini" />
+        <text name="ft_irr_call_watch" text="amati" />
+        <text name="ft_irr_call_can_hold" text="bisa menunggu" />
+        <text name="ft_irr_advisory_schedule_covers" text="jadwal mencakup" />
+        <text name="ft_irr_advisory_schedule_gap" text="celah jadwal" />
     </texts>
 </l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="FABBISOGNO IDRICO (consiglio)" />
+        <text name="ft_irr_advisory_locked_l7" text="Sbloccato al livello cooperativa 7" />
+        <text name="ft_irr_advisory_forward_call" text="PREVISIONE (consiglio)" />
+        <text name="ft_irr_advisory_locked_l18" text="Sbloccato al livello cooperativa 18" />
+        <text name="ft_irr_advisory_no_reads" text="Nessun campo con letture dell'acqua per ora." />
+        <text name="ft_irr_call_water_today" text="irrigare oggi" />
+        <text name="ft_irr_call_watch" text="osservare" />
+        <text name="ft_irr_call_can_hold" text="può attendere" />
+        <text name="ft_irr_advisory_schedule_covers" text="programma copre" />
+        <text name="ft_irr_advisory_schedule_gap" text="gap di programma" />
     </texts>
 </l10n>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="水の必要量（アドバイス）" />
+        <text name="ft_irr_advisory_locked_l7" text="協同組合レベル7で解放" />
+        <text name="ft_irr_advisory_forward_call" text="見通し（アドバイス）" />
+        <text name="ft_irr_advisory_locked_l18" text="協同組合レベル18で解放" />
+        <text name="ft_irr_advisory_no_reads" text="まだ水分データのある畑がありません。" />
+        <text name="ft_irr_call_water_today" text="今日水をやる" />
+        <text name="ft_irr_call_watch" text="観察" />
+        <text name="ft_irr_call_can_hold" text="待てる" />
+        <text name="ft_irr_advisory_schedule_covers" text="予定が対応" />
+        <text name="ft_irr_advisory_schedule_gap" text="予定の隙間" />
     </texts>
 </l10n>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="물 필요량 (조언)" />
+        <text name="ft_irr_advisory_locked_l7" text="협동조합 7레벨에서 해제" />
+        <text name="ft_irr_advisory_forward_call" text="전망 (조언)" />
+        <text name="ft_irr_advisory_locked_l18" text="협동조합 18레벨에서 해제" />
+        <text name="ft_irr_advisory_no_reads" text="아직 수분 측정이 있는 밭이 없습니다." />
+        <text name="ft_irr_call_water_today" text="오늘 물을 주세요" />
+        <text name="ft_irr_call_watch" text="관찰" />
+        <text name="ft_irr_call_can_hold" text="기다릴 수 있음" />
+        <text name="ft_irr_advisory_schedule_covers" text="일정이 충당" />
+        <text name="ft_irr_advisory_schedule_gap" text="일정 공백" />
     </texts>
 </l10n>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="WATERBEHOEFTE (advies)" />
+        <text name="ft_irr_advisory_locked_l7" text="Ontgrendelt op coöperatieniveau 7" />
+        <text name="ft_irr_advisory_forward_call" text="VOORUITZICHT (advies)" />
+        <text name="ft_irr_advisory_locked_l18" text="Ontgrendelt op coöperatieniveau 18" />
+        <text name="ft_irr_advisory_no_reads" text="Nog geen velden met watermetingen." />
+        <text name="ft_irr_call_water_today" text="vandaag beregenen" />
+        <text name="ft_irr_call_watch" text="in de gaten houden" />
+        <text name="ft_irr_call_can_hold" text="kan wachten" />
+        <text name="ft_irr_advisory_schedule_covers" text="plan dekt" />
+        <text name="ft_irr_advisory_schedule_gap" text="planhiaat" />
     </texts>
 </l10n>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="VANNB EHOV (rådgivning)" />
+        <text name="ft_irr_advisory_locked_l7" text="Låses opp på kooperativnivå 7" />
+        <text name="ft_irr_advisory_forward_call" text="PROGNOSE (rådgivning)" />
+        <text name="ft_irr_advisory_locked_l18" text="Låses opp på kooperativnivå 18" />
+        <text name="ft_irr_advisory_no_reads" text="Ingen åkre med vannavlesninger ennå." />
+        <text name="ft_irr_call_water_today" text="vanne i dag" />
+        <text name="ft_irr_call_watch" text="følg med" />
+        <text name="ft_irr_call_can_hold" text="kan vente" />
+        <text name="ft_irr_advisory_schedule_covers" text="planen dekker" />
+        <text name="ft_irr_advisory_schedule_gap" text="planhull" />
     </texts>
 </l10n>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="POTRZEBA WODY (porada)" />
+        <text name="ft_irr_advisory_locked_l7" text="Odblokowane na poziomie spółdzielni 7" />
+        <text name="ft_irr_advisory_forward_call" text="PROGNOZA (porada)" />
+        <text name="ft_irr_advisory_locked_l18" text="Odblokowane na poziomie spółdzielni 18" />
+        <text name="ft_irr_advisory_no_reads" text="Brak pól z odczytami wilgotności." />
+        <text name="ft_irr_call_water_today" text="podlać dziś" />
+        <text name="ft_irr_call_watch" text="obserwuj" />
+        <text name="ft_irr_call_can_hold" text="może poczekać" />
+        <text name="ft_irr_advisory_schedule_covers" text="plan pokrywa" />
+        <text name="ft_irr_advisory_schedule_gap" text="luka w planie" />
     </texts>
 </l10n>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="NECESSIDADE DE ÁGUA (aconselhamento)" />
+        <text name="ft_irr_advisory_locked_l7" text="Desbloqueado no nível de cooperativa 7" />
+        <text name="ft_irr_advisory_forward_call" text="PREVISAO (aconselhamento)" />
+        <text name="ft_irr_advisory_locked_l18" text="Desbloqueado no nível de cooperativa 18" />
+        <text name="ft_irr_advisory_no_reads" text="Ainda não há campos com leituras de água." />
+        <text name="ft_irr_call_water_today" text="regar hoje" />
+        <text name="ft_irr_call_watch" text="vigiar" />
+        <text name="ft_irr_call_can_hold" text="pode esperar" />
+        <text name="ft_irr_advisory_schedule_covers" text="o plano cobre" />
+        <text name="ft_irr_advisory_schedule_gap" text="lacuna no plano" />
     </texts>
 </l10n>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="NECESITATE DE APĂ (consiliere)" />
+        <text name="ft_irr_advisory_locked_l7" text="Deblocat la nivelul de cooperativă 7" />
+        <text name="ft_irr_advisory_forward_call" text="PREVIZIUNE (consiliere)" />
+        <text name="ft_irr_advisory_locked_l18" text="Deblocat la nivelul de cooperativă 18" />
+        <text name="ft_irr_advisory_no_reads" text="Niciun câmp cu citiri de apă deocamdată." />
+        <text name="ft_irr_call_water_today" text="udă astăzi" />
+        <text name="ft_irr_call_watch" text="urmărește" />
+        <text name="ft_irr_call_can_hold" text="poate aștepta" />
+        <text name="ft_irr_advisory_schedule_covers" text="planul acoperă" />
+        <text name="ft_irr_advisory_schedule_gap" text="gol de plan" />
     </texts>
 </l10n>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -2579,5 +2579,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="ПОТРЕБНОСТЬ В ВОДЕ (совет)" />
+        <text name="ft_irr_advisory_locked_l7" text="Открывается на уровне кооператива 7" />
+        <text name="ft_irr_advisory_forward_call" text="ПРОГНОЗ (совет)" />
+        <text name="ft_irr_advisory_locked_l18" text="Открывается на уровне кооператива 18" />
+        <text name="ft_irr_advisory_no_reads" text="Пока нет полей с показаниями влажности." />
+        <text name="ft_irr_call_water_today" text="полить сегодня" />
+        <text name="ft_irr_call_watch" text="наблюдать" />
+        <text name="ft_irr_call_can_hold" text="можно подождать" />
+        <text name="ft_irr_advisory_schedule_covers" text="график покрывает" />
+        <text name="ft_irr_advisory_schedule_gap" text="пробел в графике" />
     </texts>
 </l10n>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="VATTENBEHOV (rådgivning)" />
+        <text name="ft_irr_advisory_locked_l7" text="Låses upp på kooperativ nivå 7" />
+        <text name="ft_irr_advisory_forward_call" text="PROGNOS (rådgivning)" />
+        <text name="ft_irr_advisory_locked_l18" text="Låses upp på kooperativ nivå 18" />
+        <text name="ft_irr_advisory_no_reads" text="Ännu inga åkrar med vattenavläsningar." />
+        <text name="ft_irr_call_water_today" text="vattna idag" />
+        <text name="ft_irr_call_watch" text="bevaka" />
+        <text name="ft_irr_call_can_hold" text="kan vänta" />
+        <text name="ft_irr_advisory_schedule_covers" text="planen täcker" />
+        <text name="ft_irr_advisory_schedule_gap" text="planlucka" />
     </texts>
 </l10n>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="SU İHTİYACI (tavsiye)" />
+        <text name="ft_irr_advisory_locked_l7" text="Kooperatif seviyesi 7'de açılır" />
+        <text name="ft_irr_advisory_forward_call" text="TAHMİN (tavsiye)" />
+        <text name="ft_irr_advisory_locked_l18" text="Kooperatif seviyesi 18'de açılır" />
+        <text name="ft_irr_advisory_no_reads" text="Henüz su okuması olan tarla yok." />
+        <text name="ft_irr_call_water_today" text="bugün sulayın" />
+        <text name="ft_irr_call_watch" text="izleyin" />
+        <text name="ft_irr_call_can_hold" text="bekleyebilir" />
+        <text name="ft_irr_advisory_schedule_covers" text="plan karşılıyor" />
+        <text name="ft_irr_advisory_schedule_gap" text="plan boşluğu" />
     </texts>
 </l10n>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="ПОТРЕБА У ВОДІ (порада)" />
+        <text name="ft_irr_advisory_locked_l7" text="Відкривається на рівні кооперативу 7" />
+        <text name="ft_irr_advisory_forward_call" text="ПРОГНОЗ (порада)" />
+        <text name="ft_irr_advisory_locked_l18" text="Відкривається на рівні кооперативу 18" />
+        <text name="ft_irr_advisory_no_reads" text="Поки немає полів із показниками вологи." />
+        <text name="ft_irr_call_water_today" text="полити сьогодні" />
+        <text name="ft_irr_call_watch" text="спостерігати" />
+        <text name="ft_irr_call_can_hold" text="можна почекати" />
+        <text name="ft_irr_advisory_schedule_covers" text="графік покриває" />
+        <text name="ft_irr_advisory_schedule_gap" text="прогалина в графіку" />
     </texts>
 </l10n>

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -2537,5 +2537,15 @@
         <text name="ft_weather_mode_wet" text="Wet" />
         <text name="ft_fc_history_no_clock" text="Needs Time Guard" />
         <text name="ft_fc_history_no_clock_detail" text="Install Time Guard to record monthly history. Live vitals still stand." />
+        <text name="ft_irr_advisory_water_need" text="NHU CẦU NƯỚC (tư vấn)" />
+        <text name="ft_irr_advisory_locked_l7" text="Mở khóa ở cấp hợp tác xã 7" />
+        <text name="ft_irr_advisory_forward_call" text="DỰ BÁO (tư vấn)" />
+        <text name="ft_irr_advisory_locked_l18" text="Mở khóa ở cấp hợp tác xã 18" />
+        <text name="ft_irr_advisory_no_reads" text="Chưa có ruộng nào có chỉ số nước." />
+        <text name="ft_irr_call_water_today" text="tưới hôm nay" />
+        <text name="ft_irr_call_watch" text="theo dõi" />
+        <text name="ft_irr_call_can_hold" text="có thể chờ" />
+        <text name="ft_irr_advisory_schedule_covers" text="lịch bao phủ" />
+        <text name="ft_irr_advisory_schedule_gap" text="lỗ hổng lịch" />
     </texts>
 </l10n>


### PR DESCRIPTION
## What Does This PR Do?

SCS-009: the ProStaff irrigation advisory. Level-gated sections inside the SHIPPED `IrrigationSuiteApp` (FORECAST mode, after the shipped forecast block) that rank the farm's fields by water need and call hold-or-water, appearing at co-op level 7 (`hasForecastAccess`) and deepening at level 18 (`hasPredictiveControl`).

- **L7 WATER NEED:** owned fields ranked by a pure need figure (`_waterNeed` = moisture deficit x 0.65 + dry stress x 0.35; active irrigation reduces need x0.6), the whole list's urgency scaled by the SHARED evaporative demand + temperature modifier (never per-field - scales all, reorders none), top entries with the plain call (water today / watch / can hold via `_waterCall`), the critical alert hint surfaced when present.
- **L18 FORWARD CALL:** the hold-or-water call extended across the schedule read (`getIrrigationSchedule`): which fields' schedules cover the coming need and which gap, with a covered/gap tally.
- **Gates** read `g_currentMission.proStaffManager:hasForecastAccess`/`hasPredictiveControl` via the pcall-wrapped ProStaffApp pattern; ProStaff absent keeps both sections honest-locked (header + the one-liner naming the unlocking level, nothing else).
- **10 new l10n keys** in all 26 translation files (advisory headers, level locks, the three calls, schedule covers/gap).

## Related Issue

SCS-009, build brief `Office Tyson/mods/FS25_SeasonalCropStress/SCS-009-advisory-BUILD-BRIEF.md` (SPLIT at the data contract: the section CONTENT is wired here; the feature id is SeasonalCropStress's, which contributes zero code). Steward SOUND; the advisory-no-economic-effect cert is the standing unlock condition.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [x] Documentation / translations
- [ ] Build / tooling

## How Was This Tested?

- [x] Lua 5.1 syntax clean (luaparse) on IrrigationSuiteApp.lua.
- [x] All 26 translation XML files parse as well-formed XML with the new keys.
- [ ] Singleplayer - in-game observation pending: game has not launched on the new zip yet. Needs: at co-op level 7 the water-need list ranks by real need; at level 18 the forward call shows schedule covers/gap; an ungated player sees the two honest lock lines and nothing else.

- [ ] Relevant console commands ran

## Checklist

- [ ] I read `DEVELOPMENT.md` before writing code
- [x] I targeted the `development` branch (not `main`)
- [x] My change touches only what it needs to - no unrelated edits
- [ ] If I added a setting: one entry in the settings schema + translations
- [ ] If I changed behaviour: docs updated in the same pass (notes.md)
- [x] No `assert()` calls
- [x] No Lua 5.2+ syntax

## Screenshots / Log Output

Not yet tested in game. Deployed zip contains the updated app + translations.
