### PR TITLE
feat: the tablet claims the whole screen while open (MasterHUD isFullscreen)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK, Akita83</author>
-    <version>2.5.3.2</version>
+    <version>2.6.0.0</version>
     <modName>FS25_FarmTablet</modName>
     <title>
         <en>Farm Tablet</en>

--- a/src/FarmTabletUI.lua
+++ b/src/FarmTabletUI.lua
@@ -520,7 +520,12 @@ function FarmTabletUI:openTablet()
     end
 
     if g_currentMission then
-        g_currentMission:addDrawable(self)
+        -- MasterHUD present -> it draws us through the subscribe claim, so adding a
+        -- second drawable would render the tablet twice. Standalone, the drawable is
+        -- the only path.
+        if FTMasterHUDBridge == nil or not FTMasterHUDBridge.active then
+            g_currentMission:addDrawable(self)
+        end
     end
 
     if g_inputBinding then
@@ -568,7 +573,9 @@ function FarmTabletUI:closeTablet()
     end
 
     if g_currentMission then
-        g_currentMission:removeDrawable(self)
+        if FTMasterHUDBridge == nil or not FTMasterHUDBridge.active then
+            g_currentMission:removeDrawable(self)
+        end
         if self._mouseListener then
             removeModEventListener(self._mouseListener)
             self._mouseListener = nil

--- a/src/integrations/FTMasterHUDBridge.lua
+++ b/src/integrations/FTMasterHUDBridge.lua
@@ -1,0 +1,56 @@
+-- =========================================================
+-- FS25_FarmTablet - MasterHUD bridge
+-- =========================================================
+-- Optional bridge to FS25_MasterHUD. FarmTablet ships standalone (it renders as an
+-- engine drawable), so this is delegate-when-present:
+--
+--   * MasterHUD installed -> FarmTablet subscribes as a self-draw with an
+--     `isFullscreen` claim. While the tablet is open it owns the WHOLE screen, so
+--     MasterHUD stands every other companion's HUD down (Income, Tax, RWE, Soil,
+--     ...). A panel background is an overlay, and an overlay does not cover text
+--     that was already rendered underneath it, so the others have to not draw.
+--     This is the same contract SoilFertilizer's settings panel declared (its
+--     `isFullscreen`), applied to the tablet's full-screen surface.
+--   * MasterHUD absent -> FarmTablet keeps its engine drawable, exactly as before.
+--
+-- While MasterHUD is active the tablet does NOT add itself as an engine drawable
+-- (see FarmTabletUI:openTablet/closeTablet): MasterHUD's loop draws it when it
+-- claims the screen, so the tablet renders once, not twice.
+-- =========================================================
+
+FTMasterHUDBridge = {}
+
+FTMasterHUDBridge.active = false   -- MasterHUD present and we subscribed
+
+--- Register the tablet with MasterHUD. Called once at loadMission00Finished, after
+--- the UI instance exists. Idempotent.
+---@param ui table the FarmTabletUI instance (farmTabletManager.ui)
+function FTMasterHUDBridge.register(ui)
+    if ui == nil or FTMasterHUDBridge.active then return end
+    local hud = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+    if hud == nil or hud.subscribe == nil then return end
+
+    local ok, err = pcall(function()
+        hud:subscribe("FarmTablet_UI", {
+            -- MasterHUD calls this every frame; draw only while the tablet is open.
+            -- When the tablet claims the screen, MasterHUD's loop calls ONLY this
+            -- draw, so the tablet renders once in the right layer.
+            draw = function()
+                if ui.isOpen then ui:draw() end
+            end,
+            -- Declares that the tablet owns the whole screen while open, so every
+            -- other companion HUD stands down. Optional on MasterHUD's side, so an
+            -- older MasterHUD simply ignores it and behaves exactly as before.
+            isFullscreen = function()
+                return ui.isOpen == true
+            end,
+        })
+    end)
+
+    if ok then
+        FTMasterHUDBridge.active = true
+        Logging.info("[FarmTablet] registered with MasterHUD (fullscreen claim while open)")
+    else
+        Logging.warning("[FarmTablet] MasterHUD registration failed: %s (using own drawable)", tostring(err))
+    end
+end

--- a/src/main.lua
+++ b/src/main.lua
@@ -35,6 +35,7 @@ source(modDirectory .. "src/ui/HomeScreen.lua")
 source(modDirectory .. "src/ui/LockScreen.lua")
 source(modDirectory .. "src/FarmTabletUIEditMode.lua")
 source(modDirectory .. "src/FarmTabletManager.lua")
+source(modDirectory .. "src/integrations/FTMasterHUDBridge.lua")
 
 -- Built-in Apps
 source(modDirectory .. "src/apps/DashboardApp.lua")
@@ -90,6 +91,11 @@ local function loadedMission(mission, node)
     if not isEnabled() then return end
     if mission.cancelLoading then return end
     farmTabletManager:onMissionLoaded()
+    -- MasterHUD claim (delegate-when-present): while the tablet is open it owns the
+    -- whole screen, so every other companion HUD stands down.
+    if FTMasterHUDBridge ~= nil then
+        FTMasterHUDBridge.register(farmTabletManager.ui)
+    end
 end
 
 local function load(mission)


### PR DESCRIPTION
feat: the tablet claims the whole screen while open (MasterHUD isFullscreen)

The same cross-mod bleed-through fix SoilFertilizer's settings panel got today, applied to FarmTablet. While the tablet is open, every other companion HUD (Income, Tax, RWE, Soil, and so on) stood down so it no longer reads through the tablet's full-screen surface.

A panel background is an overlay, and an overlay does not cover text that was already rendered underneath it. The others have to not draw, and MasterHUD is what owns that cross-mod ordering.

- New `src/integrations/FTMasterHUDBridge.lua`: delegate-when-present. When MasterHUD is installed, FarmTablet subscribes with an `isFullscreen` claim (true while the tablet is open) and draws through MasterHUD's loop. When MasterHUD is absent, the tablet keeps its engine drawable, exactly as before.
- `FarmTabletUI.lua`: when the bridge is active the tablet no longer adds itself as an engine drawable, so it renders once instead of twice.

Optional on MasterHUD's side, so an older MasterHUD simply ignores it and behaves as before. Works with MasterHUD installed; standalone each mod draws its own stack.

Verified: Lua 5.1 gate clean, staged-set check clean. Not verified in game yet: open the tablet over an Income/Tax/RWE HUD and confirm they hide while it is open and return when it closes.
