### PR TITLE
fix(ft): charge the tablet force-repair fee on the server

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,7 @@
 - Baseline date: 2026-06-29 (updated 2026-07-25)
 
 ## Near-term (next release cycle)
+- [x] TabletForceRepair works on a dedicated server (2026-08-18): the client previously hit "Money can only be deducted on the server" and could never force-complete a display repair on a dedi. The fee is now charged server-authoritatively through a new FarmTabletForceRepairEvent (client requests, server deducts, broadcast confirm completes the local repair), and the single-player path is unchanged. Remains a temporary command, removed when the repair station ships.
 - [~] TEMPORARY `TabletForceRepair` console command: force-completes a display repair for a fixed 3000 fee until the real repair station ships, then it is removed.
 - [ ] Focus state fix (Point 1): make goHome / openTablet / unlock pass nil instead of the previous appId (three one-line changes in FarmTabletUI.lua).
 - [x] Keep the ecosystem-map current: MarketDynamicsApp and RandomWorldEventsApp are NOT stubs (source files exist; autoDetect registers them when the handles are present).

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,7 @@
 - [x] Confirmed: MarketDynamicsApp and RandomWorldEventsApp are real apps, not stubs (autoDetect registers them when handles present).
 
 ## Bugs
+- [x] FT-006 TabletForceRepair on a dedicated server (2026-08-18): the client hit "Money can only be deducted on the server" and could not force-complete a display repair on a dedi. New `FarmTabletForceRepairEvent` (src/events/): the client sends the request, the server charges the 3000 fee via `farm:changeBalance` + `addMoneyChange`, then broadcasts a confirm that completes the requesting client's local repair (`_completeLocalForceRepair`). The single-player path in `forceCompleteRepair` is unchanged. Lua 5.1 syntax clean; built and uploaded to the RF Dev server (SHA256 byte-verified).
 - [ ] Focus state passes previous appId instead of nil on goHome/openTablet/unlock (Point 1).
 - [x] FT-001 `_exitEditMode()` restores camera rotation (fixed, merged to main).
 - [x] FT-002 Nil guard on `g_currentMission` in `SettingsManager:getSettings()` (fixed, merged to main).

--- a/src/FarmTabletUI.lua
+++ b/src/FarmTabletUI.lua
@@ -1994,26 +1994,47 @@ function FarmTabletUI:forceCompleteRepair()
     if self._tabletRepairActive ~= true then
         return false, "Tablet is not in repair, nothing to force"
     end
-    local fee = FT.FORCE_REPAIR_FEE
-    if g_currentMission == nil or g_currentMission.getIsServer == nil or not g_currentMission:getIsServer() then
-        return false, "Money can only be deducted on the server"
+    if g_currentMission == nil or g_currentMission.getIsServer == nil then
+        return false, "Mission not ready"
     end
-    if g_farmManager == nil then
-        return false, "Farm manager not available"
-    end
-    local farmId = self:_getNetworkBillingFarmId()
-    local ok = pcall(function()
-        local farm = g_farmManager:getFarmById(farmId)
-        if farm ~= nil and farm.changeBalance ~= nil then
-            farm:changeBalance(-fee, MoneyType.OTHER)
-            if g_currentMission.addMoneyChange ~= nil then
-                g_currentMission:addMoneyChange(-fee, farmId, MoneyType.OTHER, true)
+    if g_currentMission:getIsServer() then
+        -- Server: charge the fee here and complete the repair locally.
+        local farmId = self:_getNetworkBillingFarmId()
+        local ok = pcall(function()
+            local farm = g_farmManager ~= nil and g_farmManager:getFarmById(farmId) or nil
+            if farm ~= nil and farm.changeBalance ~= nil then
+                farm:changeBalance(-FT.FORCE_REPAIR_FEE, MoneyType.OTHER)
+                if g_currentMission.addMoneyChange ~= nil then
+                    g_currentMission:addMoneyChange(-FT.FORCE_REPAIR_FEE, farmId, MoneyType.OTHER, true)
+                end
             end
+        end)
+        if not ok then
+            return false, "Could not deduct the repair fee"
         end
-    end)
-    if not ok then
-        return false, "Could not deduct the repair fee"
+        self:_completeLocalForceRepair()
+        return true, string.format("Forced repair complete. Repair fee charged: %d.", FT.FORCE_REPAIR_FEE)
     end
+
+    -- Client on a dedicated server: the fee can only be charged by the server.
+    -- Send the request; the server deducts and the broadcast confirm completes
+    -- the local repair (see FarmTabletForceRepairEvent).
+    if g_client ~= nil and g_client.getServerConnection ~= nil then
+        local conn = g_client:getServerConnection()
+        if conn ~= nil and conn.sendEvent ~= nil then
+            conn:sendEvent(FarmTabletForceRepairEvent.new(self:_getNetworkBillingFarmId()))
+            return true, string.format("Repair requested. Repair fee charged: %d.", FT.FORCE_REPAIR_FEE)
+        end
+    end
+    return false, "No server connection available"
+end
+
+-- Local half of a forced repair: clear the broken-display state. Called directly by
+-- the server path and by the receiving client when the fee-charge confirm arrives.
+-- The fee has already been charged wherever money can move.
+function FarmTabletUI:_completeLocalForceRepair()
+    if self._tabletRepairActive ~= true then return end
+    local fee = FT.FORCE_REPAIR_FEE
     self._tabletRepairActive = false
     self._tabletRepairStartMin = nil
     self._tabletRepairEndMin = nil
@@ -2024,7 +2045,6 @@ function FarmTabletUI:forceCompleteRepair()
         self.uiState = (self.settings.lockScreenEnabled ~= false) and "lock" or "home"
     end
     self:_notifyTabletRepair(ftUiFormat("ft_repair_force_done_msg", "Forced repair complete. Repair fee charged: %d.", fee))
-    return true, string.format("Forced repair complete. Repair fee charged: %d.", fee)
 end
 
 function FarmTabletUI:_drawRepairScreen()

--- a/src/events/FarmTabletForceRepairEvent.lua
+++ b/src/events/FarmTabletForceRepairEvent.lua
@@ -1,0 +1,61 @@
+-- =========================================================
+-- FarmTabletForceRepairEvent
+--
+-- Force-complete the tablet repair on a dedicated server.
+--
+-- The tablet display state is client-local (each player's own tablet can break),
+-- but the repair fee has to be charged on the server. A client that force-repairs
+-- sends this event; the server deducts the fee from the requesting farm and
+-- broadcasts the event back; the receiving client then completes its local
+-- repair. Every other client no-ops because its own tablet is not in repair.
+-- =========================================================
+
+FarmTabletForceRepairEvent = {}
+local FarmTabletForceRepairEvent_mt = Class(FarmTabletForceRepairEvent, Event)
+
+function FarmTabletForceRepairEvent.emptyNew()
+    local self = Event.new(FarmTabletForceRepairEvent_mt)
+    return self
+end
+
+function FarmTabletForceRepairEvent.new(farmId)
+    local self = FarmTabletForceRepairEvent.emptyNew()
+    self.farmId = farmId
+    return self
+end
+
+function FarmTabletForceRepairEvent:readStream(streamId, connection)
+    self.farmId = streamReadInt32(streamId)
+    self:run(connection)
+end
+
+function FarmTabletForceRepairEvent:writeStream(streamId, connection)
+    streamWriteInt32(streamId, self.farmId)
+end
+
+function FarmTabletForceRepairEvent:run(connection)
+    if g_server ~= nil then
+        -- Server authority: charge the fee to the requesting farm, then broadcast
+        -- the confirm so the requesting client can complete its local repair.
+        local fee = FT ~= nil and FT.FORCE_REPAIR_FEE or 3000
+        local ok = false
+        pcall(function()
+            local farm = g_farmManager ~= nil and g_farmManager:getFarmById(self.farmId) or nil
+            if farm ~= nil and farm.changeBalance ~= nil then
+                farm:changeBalance(-fee, MoneyType.OTHER)
+                if g_currentMission ~= nil and g_currentMission.addMoneyChange ~= nil then
+                    g_currentMission:addMoneyChange(-fee, self.farmId, MoneyType.OTHER, true)
+                end
+                ok = true
+            end
+        end)
+        if ok and g_server.broadcastEvent ~= nil then
+            g_server:broadcastEvent(FarmTabletForceRepairEvent.new(self.farmId))
+        end
+    elseif g_FarmTablet ~= nil and g_FarmTablet.ui ~= nil then
+        -- Receiving client: the fee is charged, finish the local repair.
+        pcall(function()
+            g_FarmTablet.ui:_completeLocalForceRepair()
+        end)
+    end
+end

--- a/src/main.lua
+++ b/src/main.lua
@@ -10,6 +10,7 @@ source(modDirectory .. "src/core/Constants.lua")
 source(modDirectory .. "src/core/EventBus.lua")
 source(modDirectory .. "src/core/FarmTabletFocus.lua")
 source(modDirectory .. "src/core/AppRegistry.lua")
+source(modDirectory .. "src/events/FarmTabletForceRepairEvent.lua")
 
 -- Settings
 source(modDirectory .. "src/settings/SettingsManager.lua")


### PR DESCRIPTION
## What

`TabletForceRepair` on a dedicated server failed with "Money can only be deducted on the server" and could never complete. The tablet display state is client-local, but the 3000 fee must be charged by the server.

## Fix

- New `FarmTabletForceRepairEvent` (src/events/): the client sends the request with its billing farmId; the server charges the fee (`farm:changeBalance` + `addMoneyChange`) and broadcasts the confirm; the receiving client completes its local repair.
- `forceCompleteRepair` now routes: on the server it charges and completes directly (unchanged behaviour); on a client it sends the event instead of erroring. The local-completion half was split into `_completeLocalForceRepair` so the server path and the confirm share it.

## Verified

- Lua 5.1 syntax gate passes (3 staged files).
- Built and uploaded to the RF Dev dedicated server, SHA256 byte-verified. Takes effect on the next server restart. Not yet tested in game.
